### PR TITLE
Align convention for constants towards size_<name>

### DIFF
--- a/specs/Spec.AES.fst
+++ b/specs/Spec.AES.fst
@@ -216,8 +216,9 @@ let (^~.) x y = logand #U8 (lognot #U8 (x ^. y)) (u8 1)
   let output = s7 ^. (s6 <<. u32 1) ^. (s5 <<. u32 2) ^. (s4 <<. u32 3) ^. (s3 <<. u32 4) ^. (s2 <<. u32 5) ^. (s1 <<. u32 6) ^. (s0 <<. u32 7) in
   output *)
 
-
-type block = lseq uint8 16
+inline_for_extraction
+let size_block:size_nat = 16
+type block = lseq uint8 size_block
 
 let subBytes (state:block) : block =
   map sbox state
@@ -318,7 +319,10 @@ let block_cipher (key:lseq uint8 (11 * 16)) (input:block) =
   let state = addRoundKey kn state in
   state
 
-type word = lseq uint8 4
+inline_for_extraction
+let size_word: size_nat = 4
+type word = lseq uint8 size_word
+
 let rotate_word (w:word) : word =
   createL [w.[1];w.[2];w.[3];w.[0]]
 
@@ -381,7 +385,7 @@ let aes128_encrypt_block (k:block) (m:block) : block =
 
 noeq type aes_state = {
   key_ex: lseq uint8 (11 `op_Multiply` 16);
-  block:  lseq uint8 16;
+  block:  lseq uint8 size_block;
   ctr:    size_nat;
 }
 

--- a/specs/Spec.AESGCM.fst
+++ b/specs/Spec.AESGCM.fst
@@ -10,11 +10,12 @@ module AES = Spec.AES
 module GF = Spec.GF128
 
 (* Constants *)
-let keylen: size_nat =   16
-let blocksize: size_nat = 16
+let size_key: size_nat = 16
+let size_nonce_ietf: size_nat = 12
+let size_block: size_nat = 16
 
 (* Types *)
-type key = lbytes keylen
+type key = lbytes size_key
 
 
 
@@ -26,8 +27,8 @@ val ghash_:
   Tot GF.tag
 
 let ghash_ gmul_in_len gmul_in tag_k k =
-  let b0: GF.tag = AES.aes128_encrypt_block k (create blocksize (u8 0)) in
-  let h:lbytes blocksize = GF.gmac gmul_in_len gmul_in b0 tag_k in
+  let b0: GF.tag = AES.aes128_encrypt_block k (create size_block (u8 0)) in
+  let h:lbytes size_block = GF.gmac gmul_in_len gmul_in b0 tag_k in
   h
 
 
@@ -42,16 +43,16 @@ val ghash:
 
 let ghash text_len text aad_len aad tag_k k =
   (* gmul input: A || 0^v || C || 0^u || ceil(len(A))_64 || ceil(len(C))_64 *)
-  let aad_padding = (blocksize - (aad_len % blocksize)) % blocksize in
-  let text_padding = (blocksize - (text_len % blocksize)) % blocksize in
-  let gmul_input_len: size_nat = aad_len + aad_padding + text_len + text_padding + blocksize in
+  let aad_padding = (size_block - (aad_len % size_block)) % size_block in
+  let text_padding = (size_block - (text_len % size_block)) % size_block in
+  let gmul_input_len: size_nat = aad_len + aad_padding + text_len + text_padding + size_block in
   let gmul_input = create gmul_input_len (u8 0) in
   let gmul_input = update_slice gmul_input 0 aad_len aad  in
   let gmul_input = update_slice gmul_input (aad_len + aad_padding) (aad_len + aad_padding + text_len) text  in
   let aad_len_bytes = nat_to_bytes_be 8 (aad_len * 8) in
   let gmul_input = update_slice gmul_input (aad_len + aad_padding + text_len + text_padding) (aad_len + aad_padding + text_len + text_padding + 8) aad_len_bytes  in
   let text_len_bytes = nat_to_bytes_be 8 (text_len * 8) in
-  let gmul_input = update_slice gmul_input (aad_len + aad_padding + text_len + text_padding + 8) (aad_len + aad_padding + text_len + text_padding + blocksize) text_len_bytes  in
+  let gmul_input = update_slice gmul_input (aad_len + aad_padding + text_len + text_padding + 8) (aad_len + aad_padding + text_len + text_padding + size_block) text_len_bytes  in
   ghash_ gmul_input_len gmul_input tag_k k
 
 
@@ -66,7 +67,7 @@ val gcm:
   Tot Spec.GF128.tag
 
 let gcm k n_len n m_len m aad_len aad =
-  let tag_key = AES.aes128_encrypt_bytes k n_len n 1 blocksize (create blocksize (u8 0)) in
+  let tag_key = AES.aes128_encrypt_bytes k n_len n 1 size_block (create size_block (u8 0)) in
   let mac = ghash m_len m aad_len aad tag_key k in
   mac
 
@@ -75,30 +76,30 @@ val aead_encrypt:
     k:key
   -> n_len:size_nat
   -> n:lbytes n_len
-  -> len:size_nat{len + blocksize <= max_size_t}
+  -> len:size_nat{len + size_block <= max_size_t}
   -> m:lbytes len
-  -> aad_len:size_nat{(len + aad_len) / blocksize <= max_size_t}
+  -> aad_len:size_nat{(len + aad_len) / size_block <= max_size_t}
   -> aad:lbytes aad_len ->
-  Tot (lbytes (len + blocksize))
+  Tot (lbytes (len + size_block))
 
 let aead_encrypt k n_len n len m aad_len aad =
-  let iv_len = if n_len = 12 then 12 else blocksize in
+  let iv_len = if n_len = 12 then 12 else size_block in
   let iv: lbytes iv_len = if n_len = 12 then n else (
     (* gmul input: IV || 0^(s+64) || ceil(len(IV))_64 *)
-    let n_padding:size_nat = (blocksize - (n_len % blocksize)) % blocksize in
+    let n_padding:size_nat = (size_block - (n_len % size_block)) % size_block in
     let n_padding = n_padding + 8 in
     let gmul_input_len = n_len + n_padding + 8 in
     let gmul_input = create gmul_input_len (u8 0) in
     let gmul_input = update_slice gmul_input 0 n_len n  in
     let n_len_bytes = nat_to_bytes_be 8 (n_len * 8) in
     let gmul_input = update_slice gmul_input (n_len + n_padding) (n_len + n_padding + 8) n_len_bytes  in
-    ghash_ gmul_input_len gmul_input (create blocksize (u8 0)) k
+    ghash_ gmul_input_len gmul_input (create size_block (u8 0)) k
   ) in
   let c = AES.aes128_encrypt_bytes k iv_len iv 2 len m in
   let mac = gcm k iv_len iv len c aad_len aad in
-  let result = create (len + blocksize) (u8 0) in
+  let result = create (len + size_block) (u8 0) in
   let result = update_slice result 0 len c in
-  let result = update_slice result len (len + blocksize) mac in
+  let result = update_slice result len (len + size_block) mac in
   result
 
 
@@ -106,29 +107,29 @@ val aead_decrypt:
     k:key
   -> n_len:size_nat
   -> n:lbytes n_len
-  -> clen:size_nat{blocksize <= clen}
+  -> clen:size_nat{size_block <= clen}
   -> c:lbytes clen
-  -> aad_len:size_nat{(clen - blocksize + aad_len) / blocksize <= max_size_t}
+  -> aad_len:size_nat{(clen - size_block + aad_len) / size_block <= max_size_t}
   -> aad:lbytes aad_len ->
-  Tot (lbytes (clen - blocksize))
+  Tot (lbytes (clen - size_block))
 
 let aead_decrypt k n_len n clen c aad_len aad =
-  let iv_len = if n_len = 12 then 12 else blocksize in
+  let iv_len = if n_len = 12 then 12 else size_block in
   let iv: lbytes iv_len = if n_len = 12 then n else (
-    let n_padding:size_nat = (blocksize - (n_len % blocksize)) % blocksize in
+    let n_padding:size_nat = (size_block - (n_len % size_block)) % size_block in
     let n_padding = n_padding + 8 in
     let gmul_input_len = n_len + n_padding + 8 in
     let gmul_input = create gmul_input_len (u8 0) in
     let gmul_input = update_slice gmul_input 0 n_len n  in
     let n_len_bytes = nat_to_bytes_be 8 (n_len * 8) in
     let gmul_input = update_slice gmul_input (n_len + n_padding) (n_len + n_padding + 8) n_len_bytes  in
-    ghash_ gmul_input_len gmul_input (create blocksize (u8 0)) k
+    ghash_ gmul_input_len gmul_input (create size_block (u8 0)) k
   ) in
-  let encrypted_plaintext = sub c 0 (clen - blocksize) in
-  let associated_mac = sub c (clen - blocksize) blocksize in
-  let computed_mac = gcm k iv_len iv (clen - blocksize) encrypted_plaintext aad_len aad in
+  let encrypted_plaintext = sub c 0 (clen - size_block) in
+  let associated_mac = sub c (clen - size_block) size_block in
+  let computed_mac = gcm k iv_len iv (clen - size_block) encrypted_plaintext aad_len aad in
   let result = for_all2 (fun a b -> uint_to_nat #U8 a = uint_to_nat #U8 b) computed_mac associated_mac in
-  let zeros = create (clen - blocksize) (u8 0) in
+  let zeros = create (clen - size_block) (u8 0) in
   if result then
-    AES.aes128_encrypt_bytes k iv_len iv 2 (clen - blocksize) encrypted_plaintext
+    AES.aes128_encrypt_bytes k iv_len iv 2 (clen - size_block) encrypted_plaintext
   else zeros

--- a/specs/Spec.Chacha20Poly1305.fst
+++ b/specs/Spec.Chacha20Poly1305.fst
@@ -12,7 +12,7 @@ module Poly = Spec.Poly1305
 #set-options "--max_fuel 0 --z3rlimit 30"
 
 inline_for_extraction
-let size_key : size_nat =   32 (* in bytes *)
+let size_key : size_nat = 32 (* in bytes *)
 
 inline_for_extraction
 let size_nonce : size_nat = 12 (* in bytes *)
@@ -20,21 +20,21 @@ let size_nonce : size_nat = 12 (* in bytes *)
 type key = lbytes size_key
 type nonce = lbytes size_nonce
 
-let poly1305_padded (len:size_nat) (text:lbytes len) (tmp:lbytes Poly.blocksize) (st:Poly1305.state) : Poly1305.state =
-  let n = len / Poly.blocksize in
-  let r = len % Poly.blocksize in
-  let blocks = sub text 0 (n * Poly.blocksize) in
-  let rem = sub text (n * Poly.blocksize) r in
+let poly1305_padded (len:size_nat) (text:lbytes len) (tmp:lbytes Poly.size_block) (st:Poly1305.state) : Poly1305.state =
+  let n = len / Poly.size_block in
+  let r = len % Poly.size_block in
+  let blocks = sub text 0 (n * Poly.size_block) in
+  let rem = sub text (n * Poly.size_block) r in
   let st = Poly.update_blocks n blocks st in
   let tmp = update_sub tmp 0 r rem in
-  let st = Poly1305.update1 Poly1305.blocksize tmp st in
+  let st = Poly1305.update1 Poly1305.size_block tmp st in
   st
 
-let poly1305_do (k:Poly.key) (len:size_nat{len + Poly.blocksize <= max_size_t}) (m:lbytes len)
+let poly1305_do (k:Poly.key) (len:size_nat{len + Poly.size_block <= max_size_t}) (m:lbytes len)
         (aad_len:size_nat{(len + aad_len) / Spec.Chacha20.blocklen <= max_size_t}) (aad:lbytes aad_len)
 : Tot Poly.tag =
   let st = Poly.poly1305_init k in
-  let block = create Poly.blocksize (u8 0) in
+  let block = create Poly.size_block (u8 0) in
   let st = poly1305_padded aad_len aad block st in
   let st = poly1305_padded len m block st in
   let aad_len8 = uint_to_bytes_le #U64 (u64 aad_len) in
@@ -45,20 +45,20 @@ let poly1305_do (k:Poly.key) (len:size_nat{len + Poly.blocksize <= max_size_t}) 
   Poly.finish st
 
 
-val aead_encrypt: k:key -> n:nonce -> len:size_nat{len + Poly.blocksize <= max_size_t} -> m:lbytes len -> aad_len:size_nat{(len + aad_len) / Spec.Chacha20.blocklen <= max_size_t} -> aad:lbytes aad_len -> Tot (lbytes (len + Poly.blocksize))
+val aead_encrypt: k:key -> n:nonce -> len:size_nat{len + Poly.size_block <= max_size_t} -> m:lbytes len -> aad_len:size_nat{(len + aad_len) / Spec.Chacha20.blocklen <= max_size_t} -> aad:lbytes aad_len -> Tot (lbytes (len + Poly.size_block))
 
 let aead_encrypt k n len m len_aad aad =
   let key0 = Spec.Chacha20.chacha20_key_block0 k n in
   let poly_k = sub key0 0 32 in
-  let res = create (len + Poly.blocksize) (u8 0) in
+  let res = create (len + Poly.size_block) (u8 0) in
   let cipher = Spec.Chacha20.chacha20_encrypt_bytes k n 1 len m in
   let mac = poly1305_do poly_k len cipher len_aad aad in
   let res = update_sub res 0 len cipher in
-  let res = update_sub res len Poly.blocksize mac in
+  let res = update_sub res len Poly.size_block mac in
   res
 
 
-val aead_decrypt: k:key -> n:nonce -> len:size_nat{len + Poly.blocksize <= max_size_t} -> c:lbytes len -> tag:lbytes Poly.blocksize -> aad_len:size_nat{(len + aad_len) / Spec.Chacha20.blocklen <= max_size_t} -> aad:lbytes aad_len -> Tot (option (lbytes len))
+val aead_decrypt: k:key -> n:nonce -> len:size_nat{len + Poly.size_block <= max_size_t} -> c:lbytes len -> tag:lbytes Poly.size_block -> aad_len:size_nat{(len + aad_len) / Spec.Chacha20.blocklen <= max_size_t} -> aad:lbytes aad_len -> Tot (option (lbytes len))
 let aead_decrypt k n len c tag len_aad aad =
   let key0 = Spec.Chacha20.chacha20_key_block0 k n in
   let poly_k = sub key0 0 32 in

--- a/specs/Spec.Chacha20Poly1305.fst
+++ b/specs/Spec.Chacha20Poly1305.fst
@@ -11,11 +11,14 @@ module Poly = Spec.Poly1305
 (* RFC7539: https://tools.ietf.org/html/rfc7539#section-2.8 *)
 #set-options "--max_fuel 0 --z3rlimit 30"
 
-let keylen : size_nat =   32 (* in bytes *)
-let noncelen : size_nat = 12 (* in bytes *)
+inline_for_extraction
+let size_key : size_nat =   32 (* in bytes *)
 
-type key = lbytes keylen
-type nonce = lbytes noncelen
+inline_for_extraction
+let size_nonce : size_nat = 12 (* in bytes *)
+
+type key = lbytes size_key
+type nonce = lbytes size_nonce
 
 let poly1305_padded (len:size_nat) (text:lbytes len) (tmp:lbytes Poly.blocksize) (st:Poly1305.state) : Poly1305.state =
   let n = len / Poly.blocksize in

--- a/specs/Spec.Chacha20_vec.fst
+++ b/specs/Spec.Chacha20_vec.fst
@@ -10,13 +10,13 @@ open Lib.RawIntTypes
 
 #reset-options "--max_fuel 0 --z3rlimit 100"
 
-let keylen = 32 (* in bytes *)
-let blocklen = 64  (* in bytes *)
-let noncelen = 12 (* in bytes *)
+let size_key = 32 (* in bytes *)
+let size_block = 64  (* in bytes *)
+let size_nonce = 12 (* in bytes *)
 
-type key = lbytes keylen
-type block = lbytes blocklen
-type nonce = lbytes noncelen
+type key = lbytes size_key
+type block = lbytes size_block
+type nonce = lbytes size_nonce
 type counter = size_nat
 
 // using @ as a functional substitute for ;
@@ -138,7 +138,7 @@ let chacha20_block (k:key) (n:nonce) (c:counter): Tot block =
     chacha20_key_block st
 
 let chacha20_cipher =
-  Spec.CTR.Cipher state keylen noncelen max_size_t blocklen chacha20_init chacha20_set_counter chacha20_key_block
+  Spec.CTR.Cipher state size_key size_nonce max_size_t size_block chacha20_init chacha20_set_counter chacha20_key_block
 
 let chacha20_encrypt_bytes key nonce counter len m =
   Spec.CTR.counter_mode chacha20_cipher key nonce counter len m

--- a/specs/Spec.Curve25519.fst
+++ b/specs/Spec.Curve25519.fst
@@ -25,8 +25,12 @@ let rec ( ** ) (e:elem) (n:pos) : Tot elem (decreases n) =
     else e *. ((e *. e) ** ((n-1)/2))
 
 (* Type aliases *)
-type scalar = lbytes 32
-type serialized_point = lbytes 32
+inline_for_extraction
+let size_key: size_nat = 32
+
+type scalar = lbytes size_key
+type serialized_point = lbytes size_key
+
 noeq type proj_point = | Proj: x:elem -> z:elem -> proj_point
 
 let decodeScalar25519 (k:scalar) =
@@ -35,7 +39,7 @@ let decodeScalar25519 (k:scalar) =
   let k :scalar = k.[31] <- ((k.[31] &. u8 127) |. u8 64) in k
 
 let decodePoint (u:serialized_point) =
-  to_elem (nat_from_bytes_le u % pow2 255) 
+  to_elem (nat_from_bytes_le u % pow2 255)
 
 let add_and_double qx nq nqp1 =
   let x_1 = qx in

--- a/specs/Spec.Curve448.fst
+++ b/specs/Spec.Curve448.fst
@@ -34,8 +34,11 @@ let rec ( ** ) (e:elem) (n:pos) : Tot elem (decreases n) =
     else e `fmul` ((e `fmul` e) ** ((n-1)/2))
 
 (* Type aliases *)
-type scalar = lbytes 56
-type serialized_point = lbytes 56
+inline_for_extraction
+let size_key: size_nat = 56
+
+type scalar = lbytes size_key
+type serialized_point = lbytes size_key
 type proj_point = | Proj: x:elem -> z:elem -> proj_point
 
 let decodeScalar448 (k:scalar) =

--- a/specs/Spec.ECIES.fst
+++ b/specs/Spec.ECIES.fst
@@ -11,16 +11,16 @@ assume val crypto_random: len:size_nat -> Tot (lbytes len)
 
 (** Definition of a ECKEM IV *)
 inline_for_extraction
-let vsize_eckem_iv: size_nat = 12
-type eckem_iv_s = lbytes vsize_eckem_iv
+let size_eckem_iv: size_nat = 12
+type eckem_iv_s = lbytes size_eckem_iv
 
 (** Definition of a ECKEM counter *)
 type eckem_counter_t = uint32
 
 (** Definition of a ECKEM keys *)
-inline_for_extraction let vsize_eckem_key_asymmetric: size_nat = 32
-type eckem_key_public_s = lbytes vsize_eckem_key_asymmetric
-type eckem_key_private_s = lbytes vsize_eckem_key_asymmetric
+inline_for_extraction let size_eckem_key_asymmetric: size_nat = 32
+type eckem_key_public_s = lbytes size_eckem_key_asymmetric
+type eckem_key_private_s = lbytes size_eckem_key_asymmetric
 
 
 (** Definition of a ECKEM keypair *)
@@ -40,7 +40,7 @@ val eckem_generate: unit -> Tot eckem_keypair_r
 let eckem_generate () =
   let basepoint_zeros = create 32 (u8 0) in
   let basepoint = upd basepoint_zeros 31 (u8 0x09) in
-  let kpriv = crypto_random vsize_eckem_key_asymmetric in
+  let kpriv = crypto_random size_eckem_key_asymmetric in
   let kpub = eckem_secret_to_public kpriv in
   kpub, Some kpriv
 
@@ -55,17 +55,17 @@ val encrypt:
   Tot (lbytes olen)
 
 let encrypt #olen receiver sender len input =
-  let kdf_iv = crypto_random vsize_eckem_iv in
+  let kdf_iv = crypto_random size_eckem_iv in
   let ek: lbytes 32 = Spec.Curve25519.scalarmult receiver sender in
   let safe = for_all (fun a -> uint_to_nat #U8 a = 0) ek in
-  let stream = Spec.HKDF.hkdf_extract Spec.Hash.SHA2_256 vsize_eckem_iv kdf_iv 32 ek in
+  let stream = Spec.HKDF.hkdf_extract Spec.Hash.SHA2_256 size_eckem_iv kdf_iv 32 ek in
   let key = sub stream 0 Spec.AESGCM.keylen in
   let iv = sub stream Spec.AESGCM.keylen 12 in
   let c = Spec.AESGCM.aead_encrypt key 12 iv len input 0 empty in
-  let zeros = create (len + vsize_eckem_iv) (u8 0) in
-  let out = create (len + vsize_eckem_iv) (u8 0) in
-  let out = update_sub out 0 vsize_eckem_iv iv in
-  let out = update_sub out vsize_eckem_iv len c in
+  let zeros = create (len + size_eckem_iv) (u8 0) in
+  let out = create (len + size_eckem_iv) (u8 0) in
+  let out = update_sub out 0 size_eckem_iv iv in
+  let out = update_sub out size_eckem_iv len c in
   if safe then out else zeros
 
 
@@ -79,15 +79,15 @@ val decrypt:
   Tot (lbytes olen)
 
 let decrypt #olen sender receiver len input =
-  let kdf_iv = sub input 0 vsize_eckem_iv in
+  let kdf_iv = sub input 0 size_eckem_iv in
   let ek: lbytes 32 = Spec.Curve25519.scalarmult sender receiver in
   let safe = for_all (fun a -> uint_to_nat #U8 a = 0) ek in
-  let stream = Spec.HKDF.hkdf_extract Spec.Hash.SHA2_256 vsize_eckem_iv kdf_iv 32 ek in
+  let stream = Spec.HKDF.hkdf_extract Spec.Hash.SHA2_256 size_eckem_iv kdf_iv 32 ek in
   let key = sub stream 0 Spec.AESGCM.keylen in
   let iv = sub stream Spec.AESGCM.keylen 12 in
-  let ciphertext = sub input vsize_eckem_iv (len - vsize_eckem_iv) in
+  let ciphertext = sub input size_eckem_iv (len - size_eckem_iv) in
   let out = Spec.AESGCM.aead_decrypt key 12 iv len ciphertext 0 empty in
-  let zeros = create (len + vsize_eckem_iv) (u8 0) in
+  let zeros = create (len + size_eckem_iv) (u8 0) in
   if safe then out else zeros
 
 
@@ -109,14 +109,14 @@ val encrypt_explicit_iv:
 let encrypt_explicit_iv #olen kdf_iv receiver sender len input =
   let ek: lbytes 32 = Spec.Curve25519.scalarmult receiver sender in
   let safe = for_all (fun a -> uint_to_nat #U8 a = 0) ek in
-  let stream = Spec.HKDF.hkdf_extract Spec.Hash.SHA2_256 vsize_eckem_iv kdf_iv 32 ek in
+  let stream = Spec.HKDF.hkdf_extract Spec.Hash.SHA2_256 size_eckem_iv kdf_iv 32 ek in
   let key = sub stream 0 Spec.AESGCM.keylen in
   let iv = sub stream Spec.AESGCM.keylen 12 in
   let c = Spec.AESGCM.aead_encrypt key 12 iv len input 0 empty in
-  let zeros = create (len + vsize_eckem_iv) (u8 0) in
-  let out = create (len + vsize_eckem_iv) (u8 0) in
-  let out = update_sub out 0 vsize_eckem_iv iv in
-  let out = update_sub out vsize_eckem_iv len c in
+  let zeros = create (len + size_eckem_iv) (u8 0) in
+  let out = create (len + size_eckem_iv) (u8 0) in
+  let out = update_sub out 0 size_eckem_iv iv in
+  let out = update_sub out size_eckem_iv len c in
   if safe then out else zeros
 
 
@@ -131,15 +131,15 @@ val decrypt_explicit_iv:
   Tot (lbytes olen)
 
 let decrypt_explicit_iv #olen iv sender receiver len input =
-  let kdf_iv = sub input 0 vsize_eckem_iv in
+  let kdf_iv = sub input 0 size_eckem_iv in
   let ek: lbytes 32 = Spec.Curve25519.scalarmult sender receiver in
   let safe = for_all (fun a -> uint_to_nat #U8 a = 0) ek in
-  let stream = Spec.HKDF.hkdf_extract Spec.Hash.SHA2_256 vsize_eckem_iv kdf_iv 32 ek in
+  let stream = Spec.HKDF.hkdf_extract Spec.Hash.SHA2_256 size_eckem_iv kdf_iv 32 ek in
   let key = sub stream 0 Spec.AESGCM.keylen in
   let iv = sub stream Spec.AESGCM.keylen 12 in
-  let encrypted_plaintext = sub input vsize_eckem_iv (len - vsize_eckem_iv) in
+  let encrypted_plaintext = sub input size_eckem_iv (len - size_eckem_iv) in
   let out = Spec.AESGCM.aead_decrypt key 12 iv len input 0 empty in
-  let zeros = create (len + vsize_eckem_iv) (u8 0) in
+  let zeros = create (len + size_eckem_iv) (u8 0) in
   if safe then out else zeros
 
 

--- a/specs/Spec.GF128.fst
+++ b/specs/Spec.GF128.fst
@@ -13,48 +13,51 @@ let elem = felem gf128
 let zero = zero #gf128
 
 (* GCM types and specs *)
-let blocksize : size_nat = 16
-let keysize   : size_nat = 16
-type block = lbytes blocksize
-type tag   = lbytes blocksize
-type key   = lbytes keysize
+inline_for_extraction
+let size_block : size_nat = 16
+inline_for_extraction
+let size_key   : size_nat = 16
 
-let encode (len:size_nat{len <= blocksize}) (w:lbytes len) : Tot elem =
-  let b = create blocksize (u8 0) in
+type block = lbytes size_block
+type tag   = lbytes size_block
+type key   = lbytes size_key
+
+let encode (len:size_nat{len <= size_block}) (w:lbytes len) : Tot elem =
+  let b = create size_block (u8 0) in
   let b = update_slice b 0 len w  in
   to_felem (nat_from_bytes_be b)
 
-let decode (e:elem) : Tot block = nat_to_bytes_be blocksize (from_felem e)
+let decode (e:elem) : Tot block = nat_to_bytes_be size_block (from_felem e)
 
-let update (r:elem ) (len:size_nat{len <= blocksize}) (w:lbytes len) (acc:elem) : Tot elem =
+let update (r:elem ) (len:size_nat{len <= size_block}) (w:lbytes len) (acc:elem) : Tot elem =
     (encode len w `fadd` acc) `fmul` r
 
 val poly: len:size_nat -> text:lbytes len -> r:elem ->  Tot (a:elem)  (decreases len)
 let poly len text r =
-  let blocks = len / blocksize in
-  let rem = len % blocksize in
+  let blocks = len / size_block in
+  let rem = len % size_block in
   let init  : elem = zero in
   let acc   : elem =
     repeati blocks
       (fun i acc  ->
-	let b = slice text (i * blocksize) ((i+1)*blocksize) in
-	update r blocksize b acc)
+	let b = slice text (i * size_block) ((i+1)*size_block) in
+	update r size_block b acc)
       init in
   let acc = if rem = 0 then acc else
     update r rem (slice text (len-rem) len) acc in
   acc
-let finish (a:elem) (s:tag) : Tot tag = decode (a `fadd` (encode blocksize s))
+let finish (a:elem) (s:tag) : Tot tag = decode (a `fadd` (encode size_block s))
 
-let gmul (len:size_nat) (text:lbytes len) (h:lbytes blocksize) : Tot tag  =
-    let r = encode blocksize h in
+let gmul (len:size_nat) (text:lbytes len) (h:lbytes size_block) : Tot tag  =
+    let r = encode size_block h in
     decode (poly len text r)
 
 val gmac:
   len:size_nat ->
   text:lbytes len ->
-  h:lbytes blocksize ->
+  h:lbytes size_block ->
   k:key ->
   Tot tag
 let gmac len text h k =
-  let r = encode blocksize h in
+  let r = encode size_block h in
   finish (poly len text r) k

--- a/specs/Spec.Gimli.fst
+++ b/specs/Spec.Gimli.fst
@@ -6,7 +6,7 @@ open Lib.Sequence
 open Lib.ByteSequence
 open Lib.RawIntTypes
 
-
+inline_for_extraction
 let size_state : size_nat = 12
 let rate : size_nat = 16
 

--- a/specs/Spec.HSalsa20.fst
+++ b/specs/Spec.HSalsa20.fst
@@ -11,13 +11,18 @@ open Spec.Lib
 
 module Salsa20 = Spec.Salsa20
 
-let keylen = 32 (* in bytes *)
-let blocklen = 64  (* in bytes *)
-let noncelen = 16  (* in bytes *)
+inline_for_extraction
+let size_key = 32 (* in bytes *)
 
-type key = lbytes keylen
-type nonce = lbytes noncelen
-type block = lbytes blocklen
+inline_for_extraction
+let size_block = 64  (* in bytes *)
+
+inline_for_extraction
+let size_nonce = 16  (* in bytes *)
+
+type key = lbytes size_key
+type nonce = lbytes size_nonce
+type block = lbytes size_block
 
 type state = Salsa20.state
 
@@ -33,7 +38,7 @@ let setup (k:key) (n:nonce): state =
 	  (index ns 2)       (index ns 3)      Salsa20.constant2 (index ks 4)
           (index ks 5)       (index ks 6)      (index ks 7)      Salsa20.constant3
 
-let hsalsa20 (k:key) (n:nonce) : Tot key = 
+let hsalsa20 (k:key) (n:nonce) : Tot key =
   let st = setup k n in
   let st' = Spec.Salsa20.rounds st in
   let hs = create_8 st'.[0] st'.[5] st'.[10] st'.[15] st'.[6] st'.[7] st'.[8] st'.[9] in

--- a/specs/Spec.Keccak.fst
+++ b/specs/Spec.Keccak.fst
@@ -6,6 +6,14 @@ open Lib.Sequence
 open Lib.ByteSequence
 open FStar.Mul
 
+
+inline_for_extraction
+let size_state: size_nat = 25
+
+type state = lseq uint64 size_state
+type index = n:size_nat{n < 5}
+
+
 let lfsr86540 (lfsr:uint8) : tuple2 uint8 bool =
   let lfsr1 : uint8 = logand #U8 lfsr (u8 1) in
   let result : bool = u8_to_UInt8 lfsr1 <> 0uy in
@@ -15,13 +23,11 @@ let lfsr86540 (lfsr:uint8) : tuple2 uint8 bool =
   else
     lfsr', result
 
-type state = lseq uint64 25
-type index = n:size_nat{n < 5}
 
-let readLane (s:state) (x:index) (y:index) : uint64 = 
+let readLane (s:state) (x:index) (y:index) : uint64 =
   s.[x + 5 * y]
 
-let writeLane (s:state ) (x:index) (y:index) (v:uint64) : state = 
+let writeLane (s:state ) (x:index) (y:index) (v:uint64) : state =
   s.[x + 5 * y] <- v
 
 #set-options "--max_fuel 0 --z3rlimit 100"
@@ -57,7 +63,7 @@ let state_permute1 (s:state) (lfsr:uint8) : tuple2 state uint8 =
     repeati 5 (fun y s ->
       repeati 5 (fun x s ->
         writeLane s x y ((readLane temp x y) ^. (logand #U64 (lognot (readLane temp ((x+1)%5) y)) (readLane temp ((x+2)%5) y)))) s) s_pi_rho in
-							
+
   let (s_iota,lfsr) =
     repeati 7 (fun j (s,lfsr) ->
       Math.Lemmas.pow2_le_compat 6 j;

--- a/specs/Spec.Poly1305.fst
+++ b/specs/Spec.Poly1305.fst
@@ -17,11 +17,11 @@ let zero : elem = to_elem 0
 
 
 (* Poly1305 parameters *)
-let blocksize : size_nat = 16
-let keysize   : size_nat = 32
-type block = lbytes blocksize
-type tag   = lbytes blocksize
-type key   = lbytes keysize
+let size_block : size_nat = 16
+let size_key   : size_nat = 32
+type block = lbytes size_block
+type tag   = lbytes size_block
+type key   = lbytes size_key
 
 
 noeq type state = {
@@ -34,24 +34,24 @@ let set_acc (st:state) (acc:elem) =
   {st with acc = acc}
 
 (* Poly1305 specification *)
-let update1 (len:size_nat{len <= blocksize}) (b:lbytes len) (st:state) : state =
+let update1 (len:size_nat{len <= size_block}) (b:lbytes len) (st:state) : state =
   Math.Lemmas.pow2_le_compat 128 (8 * len);
   assert (pow2 (8 * len) <= pow2 128);
   let n = to_elem (pow2 (8 * len)) +. to_elem (nat_from_bytes_le b) in
   let acc = (n +. st.acc) *. st.r in
   set_acc st acc
 
-let update_blocks (n:size_nat{n * blocksize <= max_size_t}) (text:lbytes (n * blocksize)) (st:state) : state =
-  reduce_blocks blocksize n (fun i -> update1 16) text st
+let update_blocks (n:size_nat{n * size_block <= max_size_t}) (text:lbytes (n * size_block)) (st:state) : state =
+  reduce_blocks size_block n (fun i -> update1 16) text st
 
 let poly (len:size_nat) (text:lbytes len) (st:state) : state =
-  let n = len / blocksize in
-  let rem = len % blocksize in
-  let blocks = slice text 0 (n * blocksize) in
+  let n = len / size_block in
+  let rem = len % size_block in
+  let blocks = slice text 0 (n * size_block) in
   let st = update_blocks n blocks st in
   if rem = 0 then st
   else
-    let last = slice text (n * blocksize) len in
+    let last = slice text (n * size_block) len in
     update1 rem last st
 
 let finish (st:state) : tag =

--- a/specs/Spec.Salsa20.fst
+++ b/specs/Spec.Salsa20.fst
@@ -10,13 +10,13 @@ open Lib.RawIntTypes
 #set-options "--max_fuel 0 --z3rlimit 100"
 
 (* Constants *)
-let keylen = 32 (* in bytes *)
-let blocklen = 64  (* in bytes *)
-let noncelen = 8   (* in bytes *)
+let size_key = 32 (* in bytes *)
+let size_block = 64  (* in bytes *)
+let size_nonce = 8   (* in bytes *)
 
-type key = lbytes keylen
-type block = lbytes blocklen
-type nonce = lbytes noncelen
+type key = lbytes size_key
+type block = lbytes size_block
+type nonce = lbytes size_nonce
 type counter = size_nat
 
 type state = m:intseq U32 16
@@ -92,7 +92,7 @@ let salsa20_key_block (st:state) : Tot block =
   uints_to_bytes_le st'
 
 let salsa20_cipher =
-  Spec.CTR.Cipher state keylen max_size_t blocklen salsa20_init salsa20_set_counter salsa20_key_block
+  Spec.CTR.Cipher state size_key max_size_t size_block salsa20_init salsa20_set_counter salsa20_key_block
 
 let salsa20_encrypt_bytes key nonce counter m =
   Spec.CTR.counter_mode salsa20_cipher key nonce counter m

--- a/specs/tests/Spec.Poly1305.Test.fst
+++ b/specs/tests/Spec.Poly1305.Test.fst
@@ -32,9 +32,9 @@ let test () =
   assert_norm(List.Tot.length k        = 32);
   assert_norm(List.Tot.length expected = 16);
   let msg      : lseq uint8 34  = createL #uint8 msg in
-  let k        : lseq uint8 keysize  = createL #uint8 k   in
-  let expected : lseq uint8 blocksize = createL #uint8 expected in
-  let mac      : lseq uint8 blocksize = poly1305 34 msg k in
+  let k        : lseq uint8 size_key  = createL #uint8 k   in
+  let expected : lseq uint8 size_block = createL #uint8 expected in
+  let mac      : lseq uint8 size_block = poly1305 34 msg k in
   let result : bool = for_all2 (fun a b -> uint_to_nat #U8 a = uint_to_nat #U8 b) mac expected in
   IO.print_string   "Expected MAC:";
   List.iter (fun a -> IO.print_string (UInt8.to_string (u8_to_UInt8 a))) (as_list expected);


### PR DESCRIPTION
Moving away from `blocklen`, `blocksize` or `<random names>` towards `size_<name>`...
Any objections ? @polubelova @karthikbhargavan (CC: @s-zanella)
This is likely to break extraction of the code, but we need to do a pass on it anyway...