### PR TITLE
Lib.Buffer: Make b1 and b2's types and lengths unrelated in modifies3

### DIFF
--- a/lib/Lib.Buffer.fsti
+++ b/lib/Lib.Buffer.fsti
@@ -104,7 +104,7 @@ let modifies2 (#a0:Type0) (#a1:Type0) (#len0:size_t) (#len1:size_t)
 (** Modification three buffers *)
 let modifies3 (#a0:Type0) (#a1:Type0) (#a2:Type0)
   (#len0:size_t) (#len1:size_t) (#len2:size_t)
-  (b0:lbuffer a0 len0) (b1:lbuffer a1 len1) (b2:lbuffer a1 len1) (h1 h2: HS.mem) =
+  (b0:lbuffer a0 len0) (b1:lbuffer a1 len1) (b2:lbuffer a2 len2) (h1 h2: HS.mem) =
   modifies (loc b0 |+| loc b1 |+| loc b2) h1 h2
 
 (** Ghost reveal a buffer as a sequence *)


### PR DESCRIPTION
In modifies3, argument b2 refers to #a1 and #len1, which are also used for
the type and length of b1. Change to #a2 and #len2 which are declared but
not used, as there's no need for the types and lengths of these two buffers
to be the same.