### PR TITLE
Use Vale binary release rather than Vale sources

### DIFF
--- a/.docker/build/build.sh
+++ b/.docker/build/build.sh
@@ -29,7 +29,7 @@ function export_home() {
 function vale_test() {
   echo Running Vale Test &&
   fetch_kremlin &&
-        fetch_and_make_vale &&
+        fetch_vale &&
         env VALE_SCONS_PARALLEL_OPT="-j $threads" make -j $threads vale.build -k
 }
 
@@ -37,7 +37,7 @@ function hacl_test() {
     fetch_and_make_kremlin &&
         fetch_and_make_mlcrypto &&
         fetch_mitls &&
-        fetch_and_make_vale &&
+        fetch_vale &&
         export_home OPENSSL "$(pwd)/mlcrypto/openssl" &&
         env VALE_SCONS_PARALLEL_OPT="-j $threads" make -j $threads ci -k
 }
@@ -113,20 +113,15 @@ function fetch_vale() {
     # NOTE: the name of the directory where Vale is downloaded MUST NOT be vale, because the latter already exists
     # so let's call it valebin
     if [ ! -d valebin ]; then
-        git clone https://github.com/project-everest/vale valebin
+        mkdir valebin
     fi
-    cd valebin
-    git fetch origin
-    local ref=$(if [ -f ../.vale_version ]; then cat ../.vale_version | tr -d '\r\n'; else echo origin/master; fi)
-    echo Switching to Vale $ref
-    git reset --hard $ref
-    cd ..
+    vale_version=$(<vale/.vale_version)
+    wget "https://github.com/project-everest/vale/releases/download/v${vale_version}/vale-release-${vale_version}.zip" -O valebin/vale-release.zip
+    rm -rf "valebin/vale-release-${vale_version}"
+    unzip -o valebin/vale-release.zip -d valebin
+    rm -rf "valebin/bin"
+    mv "valebin/vale-release-${vale_version}/bin" valebin/
     export_home VALE "$(pwd)/valebin"
-}
-
-function fetch_and_make_vale() {
-    fetch_vale
-    pushd valebin && ./run_scons.sh -j $threads && popd
 }
 
 function refresh_hacl_hints() {

--- a/.docker/build/build.sh
+++ b/.docker/build/build.sh
@@ -122,6 +122,7 @@ function fetch_vale() {
     unzip -o valebin/vale-release.zip -d valebin
     rm -rf "valebin/bin"
     mv "valebin/vale-release-${vale_version}/bin" valebin/
+    chmod +x valebin/bin/*.exe
     export_home VALE "$(pwd)/valebin"
 }
 

--- a/.docker/build/build.sh
+++ b/.docker/build/build.sh
@@ -116,6 +116,7 @@ function fetch_vale() {
         mkdir valebin
     fi
     vale_version=$(<vale/.vale_version)
+    vale_version=${vale_version%$'\r'}  # remove Windows carriage return, if it exists
     wget "https://github.com/project-everest/vale/releases/download/v${vale_version}/vale-release-${vale_version}.zip" -O valebin/vale-release.zip
     rm -rf "valebin/vale-release-${vale_version}"
     unzip -o valebin/vale-release.zip -d valebin


### PR DESCRIPTION
This changes the `build.sh` script to fetch the Vale tool binary release rather than trying to build the Vale tool from source code.  This eliminates dependencies on the Vale source code as well as on nuget/fslex/fsyacc.

This corresponds to a recent Everest pull request: https://github.com/project-everest/everest/pull/60
