### PR TITLE
one-way live sub only

### DIFF
--- a/lib/Lib.Buffer.fsti
+++ b/lib/Lib.Buffer.fsti
@@ -132,7 +132,7 @@ let gsub (#t:buftype) (#a:Type0) (#len:size_t) (b:lbuffer_t t a len)
 val live_sub: #t:buftype -> #a:Type0 -> #len:size_t -> b:lbuffer_t t a len
   -> start:size_t -> n:size_t{v start + v n <= v len} -> h:mem
   -> Lemma
-    (ensures live h b <==> live h (gsub b start n))
+    (ensures live h b ==> live h (gsub b start n))
     [SMTPat (live h (gsub b start n))]
 
 val modifies_sub: #t:buftype -> #a:Type0 -> #len:size_t -> b:lbuffer_t t a len


### PR DESCRIPTION
With @aseemr  and @nikswamy , we intend to remove the precondition on `LowStar.Monotonic.Buffer.mgsub`. As a consequence, `live_sub` has to be weakened: one can only prove the liveness of a subbuffer from the liveness of its enclosing buffer, not the converse. (More precisely, see https://github.com/FStarLang/FStar/pull/1667#issuecomment-468800761 for the proposed change in F*)

It seems that I can already successfully weaken `live_gsub` in HACL* accordingly, per this pull request: with the current F* master, I have HACL* green CI; and with FStarLang/FStar@310b90cd3fd4bddc12a95ab31679e4572935c674, I have a local successful `everest make test verify`.

Do you foresee any problem in no longer being able to derive the liveness of a buffer from the liveness of one of its subbuffers?

Thanks,