### PR TITLE
Simplify defs and lemmas about memory locations

### DIFF
--- a/providers/evercrypt/EverCrypt.AEAD.fsti
+++ b/providers/evercrypt/EverCrypt.AEAD.fsti
@@ -66,15 +66,14 @@ let footprint (#a:alg) (m: HS.mem) (s: state a) =
 // smallest location that is not exposed to be a `loc_union`.)
 
 let loc_includes_union_l_footprint_s
-  (m: HS.mem)
   (l1 l2: B.loc) (#a: alg) (s: state_s a)
 : Lemma
   (requires (
-    B.loc_includes l1 (footprint_s m s) \/ B.loc_includes l2 (footprint_s m s)
+    B.loc_includes l1 (footprint_s s) \/ B.loc_includes l2 (footprint_s s)
   ))
-  (ensures (B.loc_includes (B.loc_union l1 l2) (footprint_s m s)))
-  [SMTPat (B.loc_includes (B.loc_union l1 l2) (footprint_s m s))]
-= B.loc_includes_union_l l1 l2 (footprint_s m s)
+  (ensures (B.loc_includes (B.loc_union l1 l2) (footprint_s s)))
+  [SMTPat (B.loc_includes (B.loc_union l1 l2) (footprint_s s))]
+= B.loc_includes_union_l l1 l2 (footprint_s s)
 
 val invariant_s: (#a:alg) -> HS.mem -> state_s a -> Type0
 let invariant (#a:alg) (m: HS.mem) (s: state a) =

--- a/providers/evercrypt/EverCrypt.AEAD.fsti
+++ b/providers/evercrypt/EverCrypt.AEAD.fsti
@@ -55,7 +55,26 @@ val footprint_s: #a:alg -> state_s a -> GTot B.loc
 let footprint (#a:alg) (m: HS.mem) (s: state a) =
   B.(loc_union (loc_addr_of_buffer s) (footprint_s (B.deref m s)))
 
-unfold let loc_includes_union_l_footprint_s = EverCrypt.Hash.loc_includes_union_l_footprint_s
+// TR: the following pattern is necessary because, if we generically
+// add such a pattern directly on `loc_includes_union_l`, then
+// verification will blowup whenever both sides of `loc_includes` are
+// `loc_union`s. We would like to break all unions on the
+// right-hand-side of `loc_includes` first, using
+// `loc_includes_union_r`.  Here the pattern is on `footprint_s`,
+// because we already expose the fact that `footprint` is a
+// `loc_union`. (In other words, the pattern should be on every
+// smallest location that is not exposed to be a `loc_union`.)
+
+let loc_includes_union_l_footprint_s
+  (m: HS.mem)
+  (l1 l2: B.loc) (#a: alg) (s: state_s a)
+: Lemma
+  (requires (
+    B.loc_includes l1 (footprint_s m s) \/ B.loc_includes l2 (footprint_s m s)
+  ))
+  (ensures (B.loc_includes (B.loc_union l1 l2) (footprint_s m s)))
+  [SMTPat (B.loc_includes (B.loc_union l1 l2) (footprint_s m s))]
+= B.loc_includes_union_l l1 l2 (footprint_s m s)
 
 val invariant_s: (#a:alg) -> HS.mem -> state_s a -> Type0
 let invariant (#a:alg) (m: HS.mem) (s: state a) =

--- a/providers/evercrypt/EverCrypt.AEAD.fsti
+++ b/providers/evercrypt/EverCrypt.AEAD.fsti
@@ -56,10 +56,6 @@ let footprint (#a:alg) (m: HS.mem) (s: state a) =
   B.(loc_union (loc_addr_of_buffer s) (footprint_s (B.deref m s)))
 
 unfold let loc_includes_union_l_footprint_s = EverCrypt.Hash.loc_includes_union_l_footprint_s
-unfold let loc_in = EverCrypt.Hash.loc_in
-unfold let loc_unused_in = EverCrypt.Hash.loc_unused_in
-unfold let fresh_loc = EverCrypt.Hash.fresh_loc
-unfold let fresh_is_disjoint = EverCrypt.Hash.fresh_is_disjoint
 
 val invariant_s: (#a:alg) -> HS.mem -> state_s a -> Type0
 let invariant (#a:alg) (m: HS.mem) (s: state a) =
@@ -73,7 +69,7 @@ val invariant_loc_in_footprint
   (m: HS.mem)
 : Lemma
   (requires (invariant m s))
-  (ensures (loc_in (footprint m s) m))
+  (ensures (B.loc_in (footprint m s) m))
   [SMTPat (invariant m s)]
 
 val frame_invariant: #a:alg -> l:B.loc -> s:state a -> h0:HS.mem -> h1:HS.mem -> Lemma
@@ -124,7 +120,7 @@ let create_in_st (a: alg) =
 
           // Memory stuff
           B.(modifies (loc_buffer dst) h0 h1) /\
-          fresh_loc (footprint h1 s) h0 h1 /\
+          B.fresh_loc (footprint h1 s) h0 h1 /\
           B.(loc_includes (loc_region_only true r) (footprint h1 s)) /\
           freeable h1 s /\
 

--- a/providers/evercrypt/EverCrypt.Hash.Incremental.fsti
+++ b/providers/evercrypt/EverCrypt.Hash.Incremental.fsti
@@ -76,10 +76,6 @@ let footprint (#a:alg) (m: HS.mem) (s: state a) =
   B.(loc_union (loc_addr_of_buffer s) (footprint_s m (B.deref m s)))
 
 unfold let loc_includes_union_l_footprint_s = EverCrypt.Hash.loc_includes_union_l_footprint_s
-unfold let loc_in = EverCrypt.Hash.loc_in
-unfold let loc_unused_in = EverCrypt.Hash.loc_unused_in
-unfold let fresh_loc = EverCrypt.Hash.fresh_loc
-unfold let fresh_is_disjoint = EverCrypt.Hash.fresh_is_disjoint
 
 val invariant_s: (#a:alg) -> HS.mem -> state_s a -> Type0
 let invariant (#a:alg) (m: HS.mem) (s: state a) =
@@ -93,7 +89,7 @@ val invariant_loc_in_footprint
   (m: HS.mem)
 : Lemma
   (requires (invariant m s))
-  (ensures (loc_in (footprint m s) m))
+  (ensures (B.loc_in (footprint m s) m))
   [SMTPat (invariant m s)]
 
 
@@ -213,7 +209,7 @@ val create_in (a: Hash.alg) (r: HS.rid): ST (state a)
     invariant h1 s /\
     hashed h1 s == S.empty /\
     B.(modifies loc_none h0 h1) /\
-    fresh_loc (footprint h1 s) h0 h1 /\
+    B.fresh_loc (footprint h1 s) h0 h1 /\
     B.(loc_includes (loc_region_only true r) (footprint h1 s)) /\
     freeable h1 s))
 

--- a/providers/evercrypt/EverCrypt.Hash.fsti
+++ b/providers/evercrypt/EverCrypt.Hash.fsti
@@ -124,18 +124,8 @@ val alg_of_state: a:e_alg -> (
   (fun h0 -> invariant s h0)
   (fun h0 a' h1 -> h0 == h1 /\ a' == a))
 
-// Waiting for these to land in LowStar.Modifies
-let loc_in (l: M.loc) (h: HS.mem) =
-  M.(loc_not_unused_in h `loc_includes` l)
-
-let loc_unused_in (l: M.loc) (h: HS.mem) =
-  M.(loc_unused_in h `loc_includes` l)
-
-let fresh_loc (l: M.loc) (h0 h1: HS.mem) =
-  loc_unused_in l h0 /\ loc_in l h1
-
 val fresh_is_disjoint: l1:M.loc -> l2:M.loc -> h0:HS.mem -> h1:HS.mem -> Lemma
-  (requires (fresh_loc l1 h0 h1 /\ l2 `loc_in` h0))
+  (requires (B.fresh_loc l1 h0 h1 /\ l2 `B.loc_in` h0))
   (ensures (M.loc_disjoint l1 l2))
 
 // TR: this lemma is necessary to prove that the footprint is disjoint
@@ -147,7 +137,7 @@ val invariant_loc_in_footprint
   (m: HS.mem)
 : Lemma
   (requires (invariant s m))
-  (ensures (loc_in (footprint s m) m))
+  (ensures (B.loc_in (footprint s m) m))
   [SMTPat (invariant s m)]
 
 // TR: frame_invariant, just like all lemmas eliminating `modifies`
@@ -193,7 +183,7 @@ val alloca: a:alg -> StackInline (state a)
   (ensures (fun h0 s h1 ->
     invariant s h1 /\
     M.(modifies loc_none h0 h1) /\
-    fresh_loc (footprint s h1) h0 h1 /\
+    B.fresh_loc (footprint s h1) h0 h1 /\
     M.(loc_includes (loc_region_only true (HS.get_tip h1)) (footprint s h1))))
 
 (** @type: true
@@ -204,7 +194,7 @@ val create_in: a:alg -> r:HS.rid -> ST (state a)
   (ensures (fun h0 s h1 ->
     invariant s h1 /\
     M.(modifies loc_none h0 h1) /\
-    fresh_loc (footprint s h1) h0 h1 /\
+    B.fresh_loc (footprint s h1) h0 h1 /\
     M.(loc_includes (loc_region_only true r) (footprint s h1)) /\
     freeable h1 s))
 
@@ -215,7 +205,7 @@ val create: a:alg -> ST (state a)
   (ensures fun h0 s h1 ->
     invariant s h1 /\
     M.(modifies loc_none h0 h1) /\
-    fresh_loc (footprint s h1) h0 h1 /\
+    B.fresh_loc (footprint s h1) h0 h1 /\
     freeable h1 s)
 
 (** @type: true

--- a/providers/evercrypt/fst/EverCrypt.Hash.Incremental.fst
+++ b/providers/evercrypt/fst/EverCrypt.Hash.Incremental.fst
@@ -124,26 +124,26 @@ let create_in a r =
 
   let buf = B.malloc r 0uy (Hacl.Hash.Definitions.block_len a) in
   (**) let h1 = ST.get () in
-  (**) assert (Hash.fresh_loc (B.loc_buffer buf) h0 h1);
+  (**) assert (B.fresh_loc (B.loc_buffer buf) h0 h1);
 
   let hash_state = Hash.create_in a r in
   (**) let h2 = ST.get () in
-  (**) assert (Hash.fresh_loc (Hash.footprint hash_state h2) h0 h2);
+  (**) assert (B.fresh_loc (Hash.footprint hash_state h2) h0 h2);
 
   let s = State hash_state buf 0UL (G.hide S.empty) in
-  (**) assert (Hash.fresh_loc (footprint_s h2 s) h0 h2);
+  (**) assert (B.fresh_loc (footprint_s h2 s) h0 h2);
 
   let p = B.malloc r s 1ul in
   (**) let h3 = ST.get () in
   (**) Hash.frame_invariant B.loc_none hash_state h2 h3;
   (**) Hash.frame_invariant_implies_footprint_preservation B.loc_none hash_state h2 h3;
-  (**) assert (Hash.fresh_loc (footprint_s h3 s) h0 h3);
-  (**) assert (Hash.fresh_loc (B.loc_addr_of_buffer p) h0 h3);
+  (**) assert (B.fresh_loc (footprint_s h3 s) h0 h3);
+  (**) assert (B.fresh_loc (B.loc_addr_of_buffer p) h0 h3);
 
   Hash.init #(G.hide a) hash_state;
   (**) let h4 = ST.get () in
-  (**) assert (Hash.fresh_loc (Hash.footprint hash_state h4) h0 h4);
-  (**) assert (Hash.fresh_loc (B.loc_buffer buf) h0 h4);
+  (**) assert (B.fresh_loc (Hash.footprint hash_state h4) h0 h4);
+  (**) assert (B.fresh_loc (B.loc_buffer buf) h0 h4);
   (**) Spec.Hash.Lemmas.update_multi_zero a (Hash.repr hash_state h4);
   (**) split_at_last_empty a;
   (**) B.modifies_only_not_unused_in B.loc_none h0 h4;

--- a/providers/test/Test.fst
+++ b/providers/test/Test.fst
@@ -111,7 +111,7 @@ let aead_iv_length32 (al: Spec.AEAD.alg) : Tot (x: U32.t { U32.v x == Spec.AEAD.
 
 #reset-options "--using_facts_from '* -Test.Vectors'"
 
-#push-options "--z3rlimit 128"
+#push-options "--z3rlimit 256"
 
 let test_aead_st alg key key_len iv iv_len aad aad_len tag tag_len plaintext plaintext_len
   ciphertext ciphertext_len: ST unit


### PR DESCRIPTION
Shortcuts such as `loc_in`, `loc_not_in`, `fresh_loc` are now in F* master (`LowStar.Monotonic.Buffer`)

Instances of `loc_includes_union_l` are still necessary for Z3 to pick the right path.