### PR TITLE
Fix specs Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,8 +46,6 @@ include Makefile.common
 # Catching setup errors #
 #########################
 
-# This was needed once because of the shortest stem rule. I don't think it's
-# needed anymore, but better be safe.
 ifeq (3.81,$(MAKE_VERSION))
   $(error You seem to be using the OSX antiquated Make version. Hint: brew \
     install make, then invoke gmake instead of make)

--- a/Makefile.local
+++ b/Makefile.local
@@ -1,6 +1,11 @@
 # A shared set of local definitions for local Makefiles. See curve25519/Makefile
 # for comments.
 
+ifeq (3.81,$(MAKE_VERSION))
+  $(error You seem to be using the OSX antiquated Make version. Hint: brew \
+    install make, then invoke gmake instead of make)
+endif
+
 HACL_HOME ?= .
 
 OUTPUT_DIR=$(HACL_HOME)/obj

--- a/specs/Makefile
+++ b/specs/Makefile
@@ -11,14 +11,16 @@ FSTAR_ROOTS += $(wildcard tests/*.fst) $(wildcard alternative/*.fst) $(wildcard 
 .PHONY: all-tests
 all-tests: $(subst .,_,$(patsubst %.fst,test-ml-%,$(notdir $(wildcard tests/*.fst))))
 
-.PRECIOUS: specs/tests/%_AutoTest.ml
-specs/tests/%_AutoTest.ml:
+.PRECIOUS: tests/%_AutoTest.ml
+tests/%_AutoTest.ml:
 	echo "if not ($*.test ()) then (print_endline \"$* failed\"; exit 1)" > $@
 
-.PRECIOUS: specs/tests/%.exe
-specs/tests/%.exe: $(ALL_CMX_FILES) specs/tests/%_AutoTest.ml
+%.exe:
+
+.PRECIOUS: tests/%.exe
+tests/%.exe: $(ALL_CMX_FILES) tests/%_AutoTest.ml
 	$(OCAMLOPT) $^ -o $@
 
 .PHONY: test-ml-%
-test-ml-%: specs/tests/%.exe
+test-ml-%: tests/%.exe
 	$<


### PR DESCRIPTION
Santiago, Karthik recently reported that the specs local Makefile no longer works. I tried to patch it up, but I thought I'd run the changes by you since you touched it recently.

Some relative paths seemed to need a fix, and somehow that shortest stem rule didn't seem to kick in for the .exe rule.

We should also enforce that this local Makefile uses a recent GNU make.