### PR TITLE
Merkle Tree bundling issue

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -661,7 +661,7 @@ TARGETCONFIG_FLAGS = -add-include '"evercrypt_targetconfig.h"'
 # that a particular feature be enabled. For a distribution to disable the
 # corresponding feature, one of these variables needs to be overridden.
 E_HASH_BUNDLE=-bundle EverCrypt.Hash+EverCrypt.Hash.Incremental=[rename=EverCrypt_Hash]
-MERKLE_BUNDLE=-bundle 'MerkleTree+MerkleTree.Low+MerkleTree.Low.Serialization+MerkleTree.Low.Hashfunctions=[rename=MerkleTree]'
+MERKLE_BUNDLE=-bundle 'MerkleTree+MerkleTree.Low+MerkleTree.Low.Serialization+MerkleTree.Low.Hashfunctions=MerkleTree.Low.Datastructures[rename=MerkleTree]'
 CTR_BUNDLE=-bundle EverCrypt.CTR=EverCrypt.CTR.*
 # Disabled by default, overridden for wasm
 WASMSUPPORT_BUNDLE = -bundle WasmSupport


### PR DESCRIPTION
Adding the Merkle Tree Datastructures module to the right (or left) of the `=` in the Merkle bundle specification makes kremlin produce this:

```
Cannot re-check MerkleTree.Low.create_empty_mt as valid Low* and will not extract it.  If MerkleTree.Low.create_empty_mt is not meant to be extracted, consider marking it as Ghost, noextract, or using a bundle. If it is meant to be extracted, use -dast for further debugging.

Warning 4: in the arguments to LowStar.RVector.alloc_rid__LowStar_Vector_vector_str  uint8_t*_LowStar_Regional_regional uint32_t  uint8_t*, in the definition of hs, in top-level declaration MerkleTree.Low.create_empty_mt, in file MerkleTree: Malformed input:
subtype mismatch, LowStar_Vector_vector_str__ uint8_t* (a.k.a. LowStar_Vector_vector_str__ uint8_t*) vs LowStar_Regional_regional__uint32_t_ uint8_t* -> LowStar_Vector_vector_str__ uint8_t* (a.k.a. LowStar_Regional_regional__uint32_t_ uint8_t* -> LowStar_Vector_vector_str__ uint8_t*)
Warning 4 is fatal, exiting.
Makefile:894: recipe for target 'dist/gcc64-only/Makefile.basic' failed
```

However, the `-dast` of `create_empty_mt` is identical to the one I get without that module in the bundle line. 

It looks like it gets confused by the regional for hash vectors (`hvrg` [here](https://github.com/project-everest/hacl-star/blob/3cc6ce0ce91ce41fddb328aa809df234e6185eff/secure_api/merkle_tree/MerkleTree.Low.fst#L352)):

```
LowStar_Vector_vector_str__ uint8_t* 
vs
LowStar_Regional_regional__uint32_t_ uint8_t* -> LowStar_Vector_vector_str__ uint8_t*
```
