### PR TITLE
Optimisation: Using Rbx instead of R12 in Curve inline asm

### DIFF
--- a/dist/vale/curve25519-inline.h
+++ b/dist/vale/curve25519-inline.h
@@ -501,15 +501,15 @@ static inline void fsqr (uint64_t *out, uint64_t *f, uint64_t *tmp)
     /////// Compute the raw multiplication: tmp <- f * f ////// 
 
     // Step 1: Compute all partial products
-    "  movq 0(%0), %%rdx;"                                       // f[0]
-    "  mulxq 8(%0), %%r8, %%r14;"      "  xor %%r15, %%r15;"     // f[1]*f[0]
-    "  mulxq 16(%0), %%r9, %%r10;"     "  adcx %%r14, %%r9;"     // f[2]*f[0]
-    "  mulxq 24(%0), %%rax, %%rcx;"    "  adcx %%rax, %%r10;"    // f[3]*f[0]
-    "  movq 24(%0), %%rdx;"                                      // f[3]
-    "  mulxq 8(%0), %%r11, %%rbx;"     "  adcx %%rcx, %%r11;"    // f[1]*f[3]
-    "  mulxq 16(%0), %%rax, %%r13;"    "  adcx %%rax, %%rbx;"    // f[2]*f[3]
-    "  movq 8(%0), %%rdx;"             "  adcx %%r15, %%r13;"    // f1
-    "  mulxq 16(%0), %%rax, %%rcx;"    "  mov $0, %%r14;"        // f[2]*f[1]
+    "  movq 0(%1), %%rdx;"                                       // f[0]
+    "  mulxq 8(%1), %%r8, %%r14;"      "  xor %%r15, %%r15;"     // f[1]*f[0]
+    "  mulxq 16(%1), %%r9, %%r10;"     "  adcx %%r14, %%r9;"     // f[2]*f[0]
+    "  mulxq 24(%1), %%rax, %%rcx;"    "  adcx %%rax, %%r10;"    // f[3]*f[0]
+    "  movq 24(%1), %%rdx;"                                      // f[3]
+    "  mulxq 8(%1), %%r11, %%rbx;"     "  adcx %%rcx, %%r11;"    // f[1]*f[3]
+    "  mulxq 16(%1), %%rax, %%r13;"    "  adcx %%rax, %%rbx;"    // f[2]*f[3]
+    "  movq 8(%1), %%rdx;"             "  adcx %%r15, %%r13;"    // f1
+    "  mulxq 16(%1), %%rax, %%rcx;"    "  mov $0, %%r14;"        // f[2]*f[1]
 
     // Step 2: Compute two parallel carry chains
     "  xor %%r15, %%r15;"
@@ -527,39 +527,39 @@ static inline void fsqr (uint64_t *out, uint64_t *f, uint64_t *tmp)
     "  adcx %%r14, %%r14;"
 
     // Step 3: Compute intermediate squares
-    "  movq 0(%0), %%rdx;"     "  mulx %%rdx, %%rax, %%rcx;"    // f[0]^2
-                               "  movq %%rax, 0(%1);"
-    "  add %%rcx, %%r8;"       "  movq %%r8, 8(%1);"
-    "  movq 8(%0), %%rdx;"     "  mulx %%rdx, %%rax, %%rcx;"    // f[1]^2
-    "  adcx %%rax, %%r9;"      "  movq %%r9, 16(%1);"
-    "  adcx %%rcx, %%r10;"     "  movq %%r10, 24(%1);"
-    "  movq 16(%0), %%rdx;"    "  mulx %%rdx, %%rax, %%rcx;"    // f[2]^2
-    "  adcx %%rax, %%r11;"     "  movq %%r11, 32(%1);"
-    "  adcx %%rcx, %%rbx;"     "  movq %%rbx, 40(%1);"
-    "  movq 24(%0), %%rdx;"    "  mulx %%rdx, %%rax, %%rcx;"    // f[3]^2
-    "  adcx %%rax, %%r13;"     "  movq %%r13, 48(%1);"
-    "  adcx %%rcx, %%r14;"     "  movq %%r14, 56(%1);"
+    "  movq 0(%1), %%rdx;"     "  mulx %%rdx, %%rax, %%rcx;"    // f[0]^2
+                               "  movq %%rax, 0(%2);"
+    "  add %%rcx, %%r8;"       "  movq %%r8, 8(%2);"
+    "  movq 8(%1), %%rdx;"     "  mulx %%rdx, %%rax, %%rcx;"    // f[1]^2
+    "  adcx %%rax, %%r9;"      "  movq %%r9, 16(%2);"
+    "  adcx %%rcx, %%r10;"     "  movq %%r10, 24(%2);"
+    "  movq 16(%1), %%rdx;"    "  mulx %%rdx, %%rax, %%rcx;"    // f[2]^2
+    "  adcx %%rax, %%r11;"     "  movq %%r11, 32(%2);"
+    "  adcx %%rcx, %%rbx;"     "  movq %%rbx, 40(%2);"
+    "  movq 24(%1), %%rdx;"    "  mulx %%rdx, %%rax, %%rcx;"    // f[3]^2
+    "  adcx %%rax, %%r13;"     "  movq %%r13, 48(%2);"
+    "  adcx %%rcx, %%r14;"     "  movq %%r14, 56(%2);"
 
     // Line up pointers
-    "  mov %1, %0;"
     "  mov %2, %1;"
+    "  mov %0, %2;"
 
     /////// Wrap the result back into the field ////// 
 
     // Step 1: Compute dst + carry == tmp_hi * 38 + tmp_lo
     "  mov $38, %%rdx;"
-    "  mulxq 32(%0), %%r8, %%r13;"
+    "  mulxq 32(%1), %%r8, %%r13;"
     "  xor %%rcx, %%rcx;"
-    "  adoxq 0(%0), %%r8;"
-    "  mulxq 40(%0), %%r9, %%rbx;"
+    "  adoxq 0(%1), %%r8;"
+    "  mulxq 40(%1), %%r9, %%rbx;"
     "  adcx %%r13, %%r9;"
-    "  adoxq 8(%0), %%r9;"
-    "  mulxq 48(%0), %%r10, %%r13;"
+    "  adoxq 8(%1), %%r9;"
+    "  mulxq 48(%1), %%r10, %%r13;"
     "  adcx %%rbx, %%r10;"
-    "  adoxq 16(%0), %%r10;"
-    "  mulxq 56(%0), %%r11, %%rax;"
+    "  adoxq 16(%1), %%r10;"
+    "  mulxq 56(%1), %%r11, %%rax;"
     "  adcx %%r13, %%r11;"
-    "  adoxq 24(%0), %%r11;"
+    "  adoxq 24(%1), %%r11;"
     "  adcx %%rcx, %%rax;"
     "  adox %%rcx, %%rax;"
     "  imul %%rdx, %%rax;"
@@ -567,19 +567,19 @@ static inline void fsqr (uint64_t *out, uint64_t *f, uint64_t *tmp)
     // Step 2: Fold the carry back into dst
     "  add %%rax, %%r8;"
     "  adcx %%rcx, %%r9;"
-    "  movq %%r9, 8(%1);"
+    "  movq %%r9, 8(%2);"
     "  adcx %%rcx, %%r10;"
-    "  movq %%r10, 16(%1);"
+    "  movq %%r10, 16(%2);"
     "  adcx %%rcx, %%r11;"
-    "  movq %%r11, 24(%1);"
+    "  movq %%r11, 24(%2);"
 
     // Step 3: Fold the carry bit back in; guaranteed not to carry at this point
     "  mov $0, %%rax;"
     "  cmovc %%rdx, %%rax;"
     "  add %%rax, %%r8;"
-    "  movq %%r8, 0(%1);"
-  : "+&r" (f), "+&r" (tmp)
-  : "r" (out)
+    "  movq %%r8, 0(%2);"
+  : "+&r" (out), "+&r" (f), "+&r" (tmp)
+  : 
   : "%rax", "%rbx", "%rcx", "%rdx", "%r8", "%r9", "%r10", "%r11", "%r13", "%r14", "%r15", "memory", "cc"
   );
 }
@@ -592,15 +592,15 @@ static inline void fsqr2 (uint64_t *out, uint64_t *f, uint64_t *tmp)
 {
   asm volatile(
     // Step 1: Compute all partial products
-    "  movq 0(%0), %%rdx;"                                       // f[0]
-    "  mulxq 8(%0), %%r8, %%r14;"      "  xor %%r15, %%r15;"     // f[1]*f[0]
-    "  mulxq 16(%0), %%r9, %%r10;"     "  adcx %%r14, %%r9;"     // f[2]*f[0]
-    "  mulxq 24(%0), %%rax, %%rcx;"    "  adcx %%rax, %%r10;"    // f[3]*f[0]
-    "  movq 24(%0), %%rdx;"                                      // f[3]
-    "  mulxq 8(%0), %%r11, %%rbx;"     "  adcx %%rcx, %%r11;"    // f[1]*f[3]
-    "  mulxq 16(%0), %%rax, %%r13;"    "  adcx %%rax, %%rbx;"    // f[2]*f[3]
-    "  movq 8(%0), %%rdx;"             "  adcx %%r15, %%r13;"    // f1
-    "  mulxq 16(%0), %%rax, %%rcx;"    "  mov $0, %%r14;"        // f[2]*f[1]
+    "  movq 0(%1), %%rdx;"                                       // f[0]
+    "  mulxq 8(%1), %%r8, %%r14;"      "  xor %%r15, %%r15;"     // f[1]*f[0]
+    "  mulxq 16(%1), %%r9, %%r10;"     "  adcx %%r14, %%r9;"     // f[2]*f[0]
+    "  mulxq 24(%1), %%rax, %%rcx;"    "  adcx %%rax, %%r10;"    // f[3]*f[0]
+    "  movq 24(%1), %%rdx;"                                      // f[3]
+    "  mulxq 8(%1), %%r11, %%rbx;"     "  adcx %%rcx, %%r11;"    // f[1]*f[3]
+    "  mulxq 16(%1), %%rax, %%r13;"    "  adcx %%rax, %%rbx;"    // f[2]*f[3]
+    "  movq 8(%1), %%rdx;"             "  adcx %%r15, %%r13;"    // f1
+    "  mulxq 16(%1), %%rax, %%rcx;"    "  mov $0, %%r14;"        // f[2]*f[1]
 
     // Step 2: Compute two parallel carry chains
     "  xor %%r15, %%r15;"
@@ -618,29 +618,29 @@ static inline void fsqr2 (uint64_t *out, uint64_t *f, uint64_t *tmp)
     "  adcx %%r14, %%r14;"
 
     // Step 3: Compute intermediate squares
-    "  movq 0(%0), %%rdx;"     "  mulx %%rdx, %%rax, %%rcx;"    // f[0]^2
-                               "  movq %%rax, 0(%1);"
-    "  add %%rcx, %%r8;"       "  movq %%r8, 8(%1);"
-    "  movq 8(%0), %%rdx;"     "  mulx %%rdx, %%rax, %%rcx;"    // f[1]^2
-    "  adcx %%rax, %%r9;"      "  movq %%r9, 16(%1);"
-    "  adcx %%rcx, %%r10;"     "  movq %%r10, 24(%1);"
-    "  movq 16(%0), %%rdx;"    "  mulx %%rdx, %%rax, %%rcx;"    // f[2]^2
-    "  adcx %%rax, %%r11;"     "  movq %%r11, 32(%1);"
-    "  adcx %%rcx, %%rbx;"     "  movq %%rbx, 40(%1);"
-    "  movq 24(%0), %%rdx;"    "  mulx %%rdx, %%rax, %%rcx;"    // f[3]^2
-    "  adcx %%rax, %%r13;"     "  movq %%r13, 48(%1);"
-    "  adcx %%rcx, %%r14;"     "  movq %%r14, 56(%1);"
+    "  movq 0(%1), %%rdx;"     "  mulx %%rdx, %%rax, %%rcx;"    // f[0]^2
+                               "  movq %%rax, 0(%2);"
+    "  add %%rcx, %%r8;"       "  movq %%r8, 8(%2);"
+    "  movq 8(%1), %%rdx;"     "  mulx %%rdx, %%rax, %%rcx;"    // f[1]^2
+    "  adcx %%rax, %%r9;"      "  movq %%r9, 16(%2);"
+    "  adcx %%rcx, %%r10;"     "  movq %%r10, 24(%2);"
+    "  movq 16(%1), %%rdx;"    "  mulx %%rdx, %%rax, %%rcx;"    // f[2]^2
+    "  adcx %%rax, %%r11;"     "  movq %%r11, 32(%2);"
+    "  adcx %%rcx, %%rbx;"     "  movq %%rbx, 40(%2);"
+    "  movq 24(%1), %%rdx;"    "  mulx %%rdx, %%rax, %%rcx;"    // f[3]^2
+    "  adcx %%rax, %%r13;"     "  movq %%r13, 48(%2);"
+    "  adcx %%rcx, %%r14;"     "  movq %%r14, 56(%2);"
 
     // Step 1: Compute all partial products
-    "  movq 32(%0), %%rdx;"                                       // f[0]
-    "  mulxq 40(%0), %%r8, %%r14;"      "  xor %%r15, %%r15;"     // f[1]*f[0]
-    "  mulxq 48(%0), %%r9, %%r10;"     "  adcx %%r14, %%r9;"     // f[2]*f[0]
-    "  mulxq 56(%0), %%rax, %%rcx;"    "  adcx %%rax, %%r10;"    // f[3]*f[0]
-    "  movq 56(%0), %%rdx;"                                      // f[3]
-    "  mulxq 40(%0), %%r11, %%rbx;"     "  adcx %%rcx, %%r11;"    // f[1]*f[3]
-    "  mulxq 48(%0), %%rax, %%r13;"    "  adcx %%rax, %%rbx;"    // f[2]*f[3]
-    "  movq 40(%0), %%rdx;"             "  adcx %%r15, %%r13;"    // f1
-    "  mulxq 48(%0), %%rax, %%rcx;"    "  mov $0, %%r14;"        // f[2]*f[1]
+    "  movq 32(%1), %%rdx;"                                       // f[0]
+    "  mulxq 40(%1), %%r8, %%r14;"      "  xor %%r15, %%r15;"     // f[1]*f[0]
+    "  mulxq 48(%1), %%r9, %%r10;"     "  adcx %%r14, %%r9;"     // f[2]*f[0]
+    "  mulxq 56(%1), %%rax, %%rcx;"    "  adcx %%rax, %%r10;"    // f[3]*f[0]
+    "  movq 56(%1), %%rdx;"                                      // f[3]
+    "  mulxq 40(%1), %%r11, %%rbx;"     "  adcx %%rcx, %%r11;"    // f[1]*f[3]
+    "  mulxq 48(%1), %%rax, %%r13;"    "  adcx %%rax, %%rbx;"    // f[2]*f[3]
+    "  movq 40(%1), %%rdx;"             "  adcx %%r15, %%r13;"    // f1
+    "  mulxq 48(%1), %%rax, %%rcx;"    "  mov $0, %%r14;"        // f[2]*f[1]
 
     // Step 2: Compute two parallel carry chains
     "  xor %%r15, %%r15;"
@@ -658,37 +658,37 @@ static inline void fsqr2 (uint64_t *out, uint64_t *f, uint64_t *tmp)
     "  adcx %%r14, %%r14;"
 
     // Step 3: Compute intermediate squares
-    "  movq 32(%0), %%rdx;"     "  mulx %%rdx, %%rax, %%rcx;"    // f[0]^2
-                               "  movq %%rax, 64(%1);"
-    "  add %%rcx, %%r8;"       "  movq %%r8, 72(%1);"
-    "  movq 40(%0), %%rdx;"     "  mulx %%rdx, %%rax, %%rcx;"    // f[1]^2
-    "  adcx %%rax, %%r9;"      "  movq %%r9, 80(%1);"
-    "  adcx %%rcx, %%r10;"     "  movq %%r10, 88(%1);"
-    "  movq 48(%0), %%rdx;"    "  mulx %%rdx, %%rax, %%rcx;"    // f[2]^2
-    "  adcx %%rax, %%r11;"     "  movq %%r11, 96(%1);"
-    "  adcx %%rcx, %%rbx;"     "  movq %%rbx, 104(%1);"
-    "  movq 56(%0), %%rdx;"    "  mulx %%rdx, %%rax, %%rcx;"    // f[3]^2
-    "  adcx %%rax, %%r13;"     "  movq %%r13, 112(%1);"
-    "  adcx %%rcx, %%r14;"     "  movq %%r14, 120(%1);"
+    "  movq 32(%1), %%rdx;"     "  mulx %%rdx, %%rax, %%rcx;"    // f[0]^2
+                               "  movq %%rax, 64(%2);"
+    "  add %%rcx, %%r8;"       "  movq %%r8, 72(%2);"
+    "  movq 40(%1), %%rdx;"     "  mulx %%rdx, %%rax, %%rcx;"    // f[1]^2
+    "  adcx %%rax, %%r9;"      "  movq %%r9, 80(%2);"
+    "  adcx %%rcx, %%r10;"     "  movq %%r10, 88(%2);"
+    "  movq 48(%1), %%rdx;"    "  mulx %%rdx, %%rax, %%rcx;"    // f[2]^2
+    "  adcx %%rax, %%r11;"     "  movq %%r11, 96(%2);"
+    "  adcx %%rcx, %%rbx;"     "  movq %%rbx, 104(%2);"
+    "  movq 56(%1), %%rdx;"    "  mulx %%rdx, %%rax, %%rcx;"    // f[3]^2
+    "  adcx %%rax, %%r13;"     "  movq %%r13, 112(%2);"
+    "  adcx %%rcx, %%r14;"     "  movq %%r14, 120(%2);"
 
     // Line up pointers
-    "  mov %1, %0;"
     "  mov %2, %1;"
+    "  mov %0, %2;"
 
     // Step 1: Compute dst + carry == tmp_hi * 38 + tmp_lo
     "  mov $38, %%rdx;"
-    "  mulxq 32(%0), %%r8, %%r13;"
+    "  mulxq 32(%1), %%r8, %%r13;"
     "  xor %%rcx, %%rcx;"
-    "  adoxq 0(%0), %%r8;"
-    "  mulxq 40(%0), %%r9, %%rbx;"
+    "  adoxq 0(%1), %%r8;"
+    "  mulxq 40(%1), %%r9, %%rbx;"
     "  adcx %%r13, %%r9;"
-    "  adoxq 8(%0), %%r9;"
-    "  mulxq 48(%0), %%r10, %%r13;"
+    "  adoxq 8(%1), %%r9;"
+    "  mulxq 48(%1), %%r10, %%r13;"
     "  adcx %%rbx, %%r10;"
-    "  adoxq 16(%0), %%r10;"
-    "  mulxq 56(%0), %%r11, %%rax;"
+    "  adoxq 16(%1), %%r10;"
+    "  mulxq 56(%1), %%r11, %%rax;"
     "  adcx %%r13, %%r11;"
-    "  adoxq 24(%0), %%r11;"
+    "  adoxq 24(%1), %%r11;"
     "  adcx %%rcx, %%rax;"
     "  adox %%rcx, %%rax;"
     "  imul %%rdx, %%rax;"
@@ -696,32 +696,32 @@ static inline void fsqr2 (uint64_t *out, uint64_t *f, uint64_t *tmp)
     // Step 2: Fold the carry back into dst
     "  add %%rax, %%r8;"
     "  adcx %%rcx, %%r9;"
-    "  movq %%r9, 8(%1);"
+    "  movq %%r9, 8(%2);"
     "  adcx %%rcx, %%r10;"
-    "  movq %%r10, 16(%1);"
+    "  movq %%r10, 16(%2);"
     "  adcx %%rcx, %%r11;"
-    "  movq %%r11, 24(%1);"
+    "  movq %%r11, 24(%2);"
 
     // Step 3: Fold the carry bit back in; guaranteed not to carry at this point
     "  mov $0, %%rax;"
     "  cmovc %%rdx, %%rax;"
     "  add %%rax, %%r8;"
-    "  movq %%r8, 0(%1);"
+    "  movq %%r8, 0(%2);"
 
     // Step 1: Compute dst + carry == tmp_hi * 38 + tmp_lo
     "  mov $38, %%rdx;"
-    "  mulxq 96(%0), %%r8, %%r13;"
+    "  mulxq 96(%1), %%r8, %%r13;"
     "  xor %%rcx, %%rcx;"
-    "  adoxq 64(%0), %%r8;"
-    "  mulxq 104(%0), %%r9, %%rbx;"
+    "  adoxq 64(%1), %%r8;"
+    "  mulxq 104(%1), %%r9, %%rbx;"
     "  adcx %%r13, %%r9;"
-    "  adoxq 72(%0), %%r9;"
-    "  mulxq 112(%0), %%r10, %%r13;"
+    "  adoxq 72(%1), %%r9;"
+    "  mulxq 112(%1), %%r10, %%r13;"
     "  adcx %%rbx, %%r10;"
-    "  adoxq 80(%0), %%r10;"
-    "  mulxq 120(%0), %%r11, %%rax;"
+    "  adoxq 80(%1), %%r10;"
+    "  mulxq 120(%1), %%r11, %%rax;"
     "  adcx %%r13, %%r11;"
-    "  adoxq 88(%0), %%r11;"
+    "  adoxq 88(%1), %%r11;"
     "  adcx %%rcx, %%rax;"
     "  adox %%rcx, %%rax;"
     "  imul %%rdx, %%rax;"
@@ -729,19 +729,19 @@ static inline void fsqr2 (uint64_t *out, uint64_t *f, uint64_t *tmp)
     // Step 2: Fold the carry back into dst
     "  add %%rax, %%r8;"
     "  adcx %%rcx, %%r9;"
-    "  movq %%r9, 40(%1);"
+    "  movq %%r9, 40(%2);"
     "  adcx %%rcx, %%r10;"
-    "  movq %%r10, 48(%1);"
+    "  movq %%r10, 48(%2);"
     "  adcx %%rcx, %%r11;"
-    "  movq %%r11, 56(%1);"
+    "  movq %%r11, 56(%2);"
 
     // Step 3: Fold the carry bit back in; guaranteed not to carry at this point
     "  mov $0, %%rax;"
     "  cmovc %%rdx, %%rax;"
     "  add %%rax, %%r8;"
-    "  movq %%r8, 32(%1);"
-  : "+&r" (f), "+&r" (tmp)
-  : "r" (out)
+    "  movq %%r8, 32(%2);"
+  : "+&r" (out), "+&r" (f), "+&r" (tmp)
+  : 
   : "%rax", "%rbx", "%rcx", "%rdx", "%r8", "%r9", "%r10", "%r11", "%r13", "%r14", "%r15", "memory", "cc"
   );
 }

--- a/dist/vale/curve25519-inline.h
+++ b/dist/vale/curve25519-inline.h
@@ -133,15 +133,15 @@ static inline void fmul (uint64_t *out, uint64_t *f1, uint64_t *f2, uint64_t *tm
     "  movq 0(%1), %%rdx;"
     "  mulxq 0(%2), %%r8, %%r9;"       "  xor %%r10, %%r10;"     "  movq %%r8, 0(%3);"
     "  mulxq 8(%2), %%r10, %%r11;"     "  adox %%r9, %%r10;"     "  movq %%r10, 8(%3);"
-    "  mulxq 16(%2), %%r12, %%r13;"    "  adox %%r11, %%r12;"
+    "  mulxq 16(%2), %%rbx, %%r13;"    "  adox %%r11, %%rbx;"
     "  mulxq 24(%2), %%r14, %%rdx;"    "  adox %%r13, %%r14;"    "  mov $0, %%rax;"
                                        "  adox %%rdx, %%rax;"
 
     // Compute src1[1] * src2
     "  movq 8(%1), %%rdx;"
     "  mulxq 0(%2), %%r8, %%r9;"       "  xor %%r10, %%r10;"     "  adcxq 8(%3), %%r8;"    "  movq %%r8, 8(%3);"
-    "  mulxq 8(%2), %%r10, %%r11;"     "  adox %%r9, %%r10;"     "  adcx %%r12, %%r10;"    "  movq %%r10, 16(%3);"
-    "  mulxq 16(%2), %%r12, %%r13;"    "  adox %%r11, %%r12;"    "  adcx %%r14, %%r12;"    "  mov $0, %%r8;"
+    "  mulxq 8(%2), %%r10, %%r11;"     "  adox %%r9, %%r10;"     "  adcx %%rbx, %%r10;"    "  movq %%r10, 16(%3);"
+    "  mulxq 16(%2), %%rbx, %%r13;"    "  adox %%r11, %%rbx;"    "  adcx %%r14, %%rbx;"    "  mov $0, %%r8;"
     "  mulxq 24(%2), %%r14, %%rdx;"    "  adox %%r13, %%r14;"    "  adcx %%rax, %%r14;"    "  mov $0, %%rax;"
                                        "  adox %%rdx, %%rax;"    "  adcx %%r8, %%rax;"
 
@@ -149,8 +149,8 @@ static inline void fmul (uint64_t *out, uint64_t *f1, uint64_t *f2, uint64_t *tm
     // Compute src1[2] * src2
     "  movq 16(%1), %%rdx;"
     "  mulxq 0(%2), %%r8, %%r9;"       "  xor %%r10, %%r10;"    "  adcxq 16(%3), %%r8;"    "  movq %%r8, 16(%3);"
-    "  mulxq 8(%2), %%r10, %%r11;"     "  adox %%r9, %%r10;"     "  adcx %%r12, %%r10;"    "  movq %%r10, 24(%3);"
-    "  mulxq 16(%2), %%r12, %%r13;"    "  adox %%r11, %%r12;"    "  adcx %%r14, %%r12;"    "  mov $0, %%r8;"
+    "  mulxq 8(%2), %%r10, %%r11;"     "  adox %%r9, %%r10;"     "  adcx %%rbx, %%r10;"    "  movq %%r10, 24(%3);"
+    "  mulxq 16(%2), %%rbx, %%r13;"    "  adox %%r11, %%rbx;"    "  adcx %%r14, %%rbx;"    "  mov $0, %%r8;"
     "  mulxq 24(%2), %%r14, %%rdx;"    "  adox %%r13, %%r14;"    "  adcx %%rax, %%r14;"    "  mov $0, %%rax;"
                                        "  adox %%rdx, %%rax;"    "  adcx %%r8, %%rax;"
 
@@ -158,8 +158,8 @@ static inline void fmul (uint64_t *out, uint64_t *f1, uint64_t *f2, uint64_t *tm
     // Compute src1[3] * src2
     "  movq 24(%1), %%rdx;"
     "  mulxq 0(%2), %%r8, %%r9;"       "  xor %%r10, %%r10;"    "  adcxq 24(%3), %%r8;"    "  movq %%r8, 24(%3);"
-    "  mulxq 8(%2), %%r10, %%r11;"     "  adox %%r9, %%r10;"     "  adcx %%r12, %%r10;"    "  movq %%r10, 32(%3);"
-    "  mulxq 16(%2), %%r12, %%r13;"    "  adox %%r11, %%r12;"    "  adcx %%r14, %%r12;"    "  movq %%r12, 40(%3);"    "  mov $0, %%r8;"
+    "  mulxq 8(%2), %%r10, %%r11;"     "  adox %%r9, %%r10;"     "  adcx %%rbx, %%r10;"    "  movq %%r10, 32(%3);"
+    "  mulxq 16(%2), %%rbx, %%r13;"    "  adox %%r11, %%rbx;"    "  adcx %%r14, %%rbx;"    "  movq %%rbx, 40(%3);"    "  mov $0, %%r8;"
     "  mulxq 24(%2), %%r14, %%rdx;"    "  adox %%r13, %%r14;"    "  adcx %%rax, %%r14;"    "  movq %%r14, 48(%3);"    "  mov $0, %%rax;"
                                        "  adox %%rdx, %%rax;"    "  adcx %%r8, %%rax;"     "  movq %%rax, 56(%3);"
 
@@ -174,11 +174,11 @@ static inline void fmul (uint64_t *out, uint64_t *f1, uint64_t *f2, uint64_t *tm
     "  mulxq 32(%1), %%r8, %%r13;"
     "  xor %2, %2;"
     "  adoxq 0(%1), %%r8;"
-    "  mulxq 40(%1), %%r9, %%r12;"
+    "  mulxq 40(%1), %%r9, %%rbx;"
     "  adcx %%r13, %%r9;"
     "  adoxq 8(%1), %%r9;"
     "  mulxq 48(%1), %%r10, %%r13;"
-    "  adcx %%r12, %%r10;"
+    "  adcx %%rbx, %%r10;"
     "  adoxq 16(%1), %%r10;"
     "  mulxq 56(%1), %%r11, %%rax;"
     "  adcx %%r13, %%r11;"
@@ -203,7 +203,7 @@ static inline void fmul (uint64_t *out, uint64_t *f1, uint64_t *f2, uint64_t *tm
     "  movq %%r8, 0(%3);"
   : "+&r" (out), "+&r" (f1), "+&r" (f2), "+&r" (tmp)
   : 
-  : "%rax", "%rdx", "%r8", "%r9", "%r10", "%r11", "%r12", "%r13", "%r14", "memory", "cc"
+  : "%rax", "%rbx", "%rdx", "%r8", "%r9", "%r10", "%r11", "%r13", "%r14", "memory", "cc"
   );
 }
 
@@ -221,15 +221,15 @@ static inline void fmul2 (uint64_t *out, uint64_t *f1, uint64_t *f2, uint64_t *t
     "  movq 0(%1), %%rdx;"
     "  mulxq 0(%2), %%r8, %%r9;"       "  xor %%r10, %%r10;"     "  movq %%r8, 0(%3);"
     "  mulxq 8(%2), %%r10, %%r11;"     "  adox %%r9, %%r10;"     "  movq %%r10, 8(%3);"
-    "  mulxq 16(%2), %%r12, %%r13;"    "  adox %%r11, %%r12;"
+    "  mulxq 16(%2), %%rbx, %%r13;"    "  adox %%r11, %%rbx;"
     "  mulxq 24(%2), %%r14, %%rdx;"    "  adox %%r13, %%r14;"    "  mov $0, %%rax;"
                                        "  adox %%rdx, %%rax;"
 
     // Compute src1[1] * src2
     "  movq 8(%1), %%rdx;"
     "  mulxq 0(%2), %%r8, %%r9;"       "  xor %%r10, %%r10;"     "  adcxq 8(%3), %%r8;"    "  movq %%r8, 8(%3);"
-    "  mulxq 8(%2), %%r10, %%r11;"     "  adox %%r9, %%r10;"     "  adcx %%r12, %%r10;"    "  movq %%r10, 16(%3);"
-    "  mulxq 16(%2), %%r12, %%r13;"    "  adox %%r11, %%r12;"    "  adcx %%r14, %%r12;"    "  mov $0, %%r8;"
+    "  mulxq 8(%2), %%r10, %%r11;"     "  adox %%r9, %%r10;"     "  adcx %%rbx, %%r10;"    "  movq %%r10, 16(%3);"
+    "  mulxq 16(%2), %%rbx, %%r13;"    "  adox %%r11, %%rbx;"    "  adcx %%r14, %%rbx;"    "  mov $0, %%r8;"
     "  mulxq 24(%2), %%r14, %%rdx;"    "  adox %%r13, %%r14;"    "  adcx %%rax, %%r14;"    "  mov $0, %%rax;"
                                        "  adox %%rdx, %%rax;"    "  adcx %%r8, %%rax;"
 
@@ -237,8 +237,8 @@ static inline void fmul2 (uint64_t *out, uint64_t *f1, uint64_t *f2, uint64_t *t
     // Compute src1[2] * src2
     "  movq 16(%1), %%rdx;"
     "  mulxq 0(%2), %%r8, %%r9;"       "  xor %%r10, %%r10;"    "  adcxq 16(%3), %%r8;"    "  movq %%r8, 16(%3);"
-    "  mulxq 8(%2), %%r10, %%r11;"     "  adox %%r9, %%r10;"     "  adcx %%r12, %%r10;"    "  movq %%r10, 24(%3);"
-    "  mulxq 16(%2), %%r12, %%r13;"    "  adox %%r11, %%r12;"    "  adcx %%r14, %%r12;"    "  mov $0, %%r8;"
+    "  mulxq 8(%2), %%r10, %%r11;"     "  adox %%r9, %%r10;"     "  adcx %%rbx, %%r10;"    "  movq %%r10, 24(%3);"
+    "  mulxq 16(%2), %%rbx, %%r13;"    "  adox %%r11, %%rbx;"    "  adcx %%r14, %%rbx;"    "  mov $0, %%r8;"
     "  mulxq 24(%2), %%r14, %%rdx;"    "  adox %%r13, %%r14;"    "  adcx %%rax, %%r14;"    "  mov $0, %%rax;"
                                        "  adox %%rdx, %%rax;"    "  adcx %%r8, %%rax;"
 
@@ -246,8 +246,8 @@ static inline void fmul2 (uint64_t *out, uint64_t *f1, uint64_t *f2, uint64_t *t
     // Compute src1[3] * src2
     "  movq 24(%1), %%rdx;"
     "  mulxq 0(%2), %%r8, %%r9;"       "  xor %%r10, %%r10;"    "  adcxq 24(%3), %%r8;"    "  movq %%r8, 24(%3);"
-    "  mulxq 8(%2), %%r10, %%r11;"     "  adox %%r9, %%r10;"     "  adcx %%r12, %%r10;"    "  movq %%r10, 32(%3);"
-    "  mulxq 16(%2), %%r12, %%r13;"    "  adox %%r11, %%r12;"    "  adcx %%r14, %%r12;"    "  movq %%r12, 40(%3);"    "  mov $0, %%r8;"
+    "  mulxq 8(%2), %%r10, %%r11;"     "  adox %%r9, %%r10;"     "  adcx %%rbx, %%r10;"    "  movq %%r10, 32(%3);"
+    "  mulxq 16(%2), %%rbx, %%r13;"    "  adox %%r11, %%rbx;"    "  adcx %%r14, %%rbx;"    "  movq %%rbx, 40(%3);"    "  mov $0, %%r8;"
     "  mulxq 24(%2), %%r14, %%rdx;"    "  adox %%r13, %%r14;"    "  adcx %%rax, %%r14;"    "  movq %%r14, 48(%3);"    "  mov $0, %%rax;"
                                        "  adox %%rdx, %%rax;"    "  adcx %%r8, %%rax;"     "  movq %%rax, 56(%3);"
 
@@ -257,15 +257,15 @@ static inline void fmul2 (uint64_t *out, uint64_t *f1, uint64_t *f2, uint64_t *t
     "  movq 32(%1), %%rdx;"
     "  mulxq 32(%2), %%r8, %%r9;"       "  xor %%r10, %%r10;"     "  movq %%r8, 64(%3);"
     "  mulxq 40(%2), %%r10, %%r11;"     "  adox %%r9, %%r10;"     "  movq %%r10, 72(%3);"
-    "  mulxq 48(%2), %%r12, %%r13;"    "  adox %%r11, %%r12;"
+    "  mulxq 48(%2), %%rbx, %%r13;"    "  adox %%r11, %%rbx;"
     "  mulxq 56(%2), %%r14, %%rdx;"    "  adox %%r13, %%r14;"    "  mov $0, %%rax;"
                                        "  adox %%rdx, %%rax;"
 
     // Compute src1[1] * src2
     "  movq 40(%1), %%rdx;"
     "  mulxq 32(%2), %%r8, %%r9;"       "  xor %%r10, %%r10;"     "  adcxq 72(%3), %%r8;"    "  movq %%r8, 72(%3);"
-    "  mulxq 40(%2), %%r10, %%r11;"     "  adox %%r9, %%r10;"     "  adcx %%r12, %%r10;"    "  movq %%r10, 80(%3);"
-    "  mulxq 48(%2), %%r12, %%r13;"    "  adox %%r11, %%r12;"    "  adcx %%r14, %%r12;"    "  mov $0, %%r8;"
+    "  mulxq 40(%2), %%r10, %%r11;"     "  adox %%r9, %%r10;"     "  adcx %%rbx, %%r10;"    "  movq %%r10, 80(%3);"
+    "  mulxq 48(%2), %%rbx, %%r13;"    "  adox %%r11, %%rbx;"    "  adcx %%r14, %%rbx;"    "  mov $0, %%r8;"
     "  mulxq 56(%2), %%r14, %%rdx;"    "  adox %%r13, %%r14;"    "  adcx %%rax, %%r14;"    "  mov $0, %%rax;"
                                        "  adox %%rdx, %%rax;"    "  adcx %%r8, %%rax;"
 
@@ -273,8 +273,8 @@ static inline void fmul2 (uint64_t *out, uint64_t *f1, uint64_t *f2, uint64_t *t
     // Compute src1[2] * src2
     "  movq 48(%1), %%rdx;"
     "  mulxq 32(%2), %%r8, %%r9;"       "  xor %%r10, %%r10;"    "  adcxq 80(%3), %%r8;"    "  movq %%r8, 80(%3);"
-    "  mulxq 40(%2), %%r10, %%r11;"     "  adox %%r9, %%r10;"     "  adcx %%r12, %%r10;"    "  movq %%r10, 88(%3);"
-    "  mulxq 48(%2), %%r12, %%r13;"    "  adox %%r11, %%r12;"    "  adcx %%r14, %%r12;"    "  mov $0, %%r8;"
+    "  mulxq 40(%2), %%r10, %%r11;"     "  adox %%r9, %%r10;"     "  adcx %%rbx, %%r10;"    "  movq %%r10, 88(%3);"
+    "  mulxq 48(%2), %%rbx, %%r13;"    "  adox %%r11, %%rbx;"    "  adcx %%r14, %%rbx;"    "  mov $0, %%r8;"
     "  mulxq 56(%2), %%r14, %%rdx;"    "  adox %%r13, %%r14;"    "  adcx %%rax, %%r14;"    "  mov $0, %%rax;"
                                        "  adox %%rdx, %%rax;"    "  adcx %%r8, %%rax;"
 
@@ -282,8 +282,8 @@ static inline void fmul2 (uint64_t *out, uint64_t *f1, uint64_t *f2, uint64_t *t
     // Compute src1[3] * src2
     "  movq 56(%1), %%rdx;"
     "  mulxq 32(%2), %%r8, %%r9;"       "  xor %%r10, %%r10;"    "  adcxq 88(%3), %%r8;"    "  movq %%r8, 88(%3);"
-    "  mulxq 40(%2), %%r10, %%r11;"     "  adox %%r9, %%r10;"     "  adcx %%r12, %%r10;"    "  movq %%r10, 96(%3);"
-    "  mulxq 48(%2), %%r12, %%r13;"    "  adox %%r11, %%r12;"    "  adcx %%r14, %%r12;"    "  movq %%r12, 104(%3);"    "  mov $0, %%r8;"
+    "  mulxq 40(%2), %%r10, %%r11;"     "  adox %%r9, %%r10;"     "  adcx %%rbx, %%r10;"    "  movq %%r10, 96(%3);"
+    "  mulxq 48(%2), %%rbx, %%r13;"    "  adox %%r11, %%rbx;"    "  adcx %%r14, %%rbx;"    "  movq %%rbx, 104(%3);"    "  mov $0, %%r8;"
     "  mulxq 56(%2), %%r14, %%rdx;"    "  adox %%r13, %%r14;"    "  adcx %%rax, %%r14;"    "  movq %%r14, 112(%3);"    "  mov $0, %%rax;"
                                        "  adox %%rdx, %%rax;"    "  adcx %%r8, %%rax;"     "  movq %%rax, 120(%3);"
 
@@ -298,11 +298,11 @@ static inline void fmul2 (uint64_t *out, uint64_t *f1, uint64_t *f2, uint64_t *t
     "  mulxq 32(%1), %%r8, %%r13;"
     "  xor %2, %2;"
     "  adoxq 0(%1), %%r8;"
-    "  mulxq 40(%1), %%r9, %%r12;"
+    "  mulxq 40(%1), %%r9, %%rbx;"
     "  adcx %%r13, %%r9;"
     "  adoxq 8(%1), %%r9;"
     "  mulxq 48(%1), %%r10, %%r13;"
-    "  adcx %%r12, %%r10;"
+    "  adcx %%rbx, %%r10;"
     "  adoxq 16(%1), %%r10;"
     "  mulxq 56(%1), %%r11, %%rax;"
     "  adcx %%r13, %%r11;"
@@ -331,11 +331,11 @@ static inline void fmul2 (uint64_t *out, uint64_t *f1, uint64_t *f2, uint64_t *t
     "  mulxq 96(%1), %%r8, %%r13;"
     "  xor %2, %2;"
     "  adoxq 64(%1), %%r8;"
-    "  mulxq 104(%1), %%r9, %%r12;"
+    "  mulxq 104(%1), %%r9, %%rbx;"
     "  adcx %%r13, %%r9;"
     "  adoxq 72(%1), %%r9;"
     "  mulxq 112(%1), %%r10, %%r13;"
-    "  adcx %%r12, %%r10;"
+    "  adcx %%rbx, %%r10;"
     "  adoxq 80(%1), %%r10;"
     "  mulxq 120(%1), %%r11, %%rax;"
     "  adcx %%r13, %%r11;"
@@ -360,7 +360,7 @@ static inline void fmul2 (uint64_t *out, uint64_t *f1, uint64_t *f2, uint64_t *t
     "  movq %%r8, 32(%3);"
   : "+&r" (out), "+&r" (f1), "+&r" (f2), "+&r" (tmp)
   : 
-  : "%rax", "%rdx", "%r8", "%r9", "%r10", "%r11", "%r12", "%r13", "%r14", "memory", "cc"
+  : "%rax", "%rbx", "%rdx", "%r8", "%r9", "%r10", "%r11", "%r13", "%r14", "memory", "cc"
   );
 }
 
@@ -373,11 +373,11 @@ static inline void fmul_scalar (uint64_t *out, uint64_t *f1, uint64_t f2)
   asm volatile(
     // Compute the raw multiplication of f1*f2
     "  mulxq 0(%2), %%r8, %%rcx;"      // f1[0]*f2
-    "  mulxq 8(%2), %%r9, %%r12;"      // f1[1]*f2
+    "  mulxq 8(%2), %%r9, %%rbx;"      // f1[1]*f2
     "  add %%rcx, %%r9;"
     "  mov $0, %%rcx;"
     "  mulxq 16(%2), %%r10, %%r13;"    // f1[2]*f2
-    "  adcx %%r12, %%r10;"
+    "  adcx %%rbx, %%r10;"
     "  mulxq 24(%2), %%r11, %%rax;"    // f1[3]*f2
     "  adcx %%r13, %%r11;"
     "  adcx %%rcx, %%rax;"
@@ -404,7 +404,7 @@ static inline void fmul_scalar (uint64_t *out, uint64_t *f1, uint64_t f2)
     "  movq %%r8, 0(%1);"
   : "+&r" (f2_r)
   : "r" (out), "r" (f1)
-  : "%rax", "%rcx", "%r8", "%r9", "%r10", "%r11", "%r12", "%r13", "memory", "cc"
+  : "%rax", "%rbx", "%rcx", "%r8", "%r9", "%r10", "%r11", "%r13", "memory", "cc"
   );
 }
 
@@ -501,15 +501,15 @@ static inline void fsqr (uint64_t *out, uint64_t *f, uint64_t *tmp)
     /////// Compute the raw multiplication: tmp <- f * f ////// 
 
     // Step 1: Compute all partial products
-    "  movq 0(%1), %%rdx;"                                       // f[0]
-    "  mulxq 8(%1), %%r8, %%r14;"      "  xor %%r15, %%r15;"     // f[1]*f[0]
-    "  mulxq 16(%1), %%r9, %%r10;"     "  adcx %%r14, %%r9;"     // f[2]*f[0]
-    "  mulxq 24(%1), %%rax, %%rcx;"    "  adcx %%rax, %%r10;"    // f[3]*f[0]
-    "  movq 24(%1), %%rdx;"                                      // f[3]
-    "  mulxq 8(%1), %%r11, %%r12;"     "  adcx %%rcx, %%r11;"    // f[1]*f[3]
-    "  mulxq 16(%1), %%rax, %%r13;"    "  adcx %%rax, %%r12;"    // f[2]*f[3]
-    "  movq 8(%1), %%rdx;"             "  adcx %%r15, %%r13;"    // f1
-    "  mulxq 16(%1), %%rax, %%rcx;"    "  mov $0, %%r14;"        // f[2]*f[1]
+    "  movq 0(%0), %%rdx;"                                       // f[0]
+    "  mulxq 8(%0), %%r8, %%r14;"      "  xor %%r15, %%r15;"     // f[1]*f[0]
+    "  mulxq 16(%0), %%r9, %%r10;"     "  adcx %%r14, %%r9;"     // f[2]*f[0]
+    "  mulxq 24(%0), %%rax, %%rcx;"    "  adcx %%rax, %%r10;"    // f[3]*f[0]
+    "  movq 24(%0), %%rdx;"                                      // f[3]
+    "  mulxq 8(%0), %%r11, %%rbx;"     "  adcx %%rcx, %%r11;"    // f[1]*f[3]
+    "  mulxq 16(%0), %%rax, %%r13;"    "  adcx %%rax, %%rbx;"    // f[2]*f[3]
+    "  movq 8(%0), %%rdx;"             "  adcx %%r15, %%r13;"    // f1
+    "  mulxq 16(%0), %%rax, %%rcx;"    "  mov $0, %%r14;"        // f[2]*f[1]
 
     // Step 2: Compute two parallel carry chains
     "  xor %%r15, %%r15;"
@@ -517,49 +517,49 @@ static inline void fsqr (uint64_t *out, uint64_t *f, uint64_t *tmp)
     "  adcx %%r8, %%r8;"
     "  adox %%rcx, %%r11;"
     "  adcx %%r9, %%r9;"
-    "  adox %%r15, %%r12;"
+    "  adox %%r15, %%rbx;"
     "  adcx %%r10, %%r10;"
     "  adox %%r15, %%r13;"
     "  adcx %%r11, %%r11;"
     "  adox %%r15, %%r14;"
-    "  adcx %%r12, %%r12;"
+    "  adcx %%rbx, %%rbx;"
     "  adcx %%r13, %%r13;"
     "  adcx %%r14, %%r14;"
 
     // Step 3: Compute intermediate squares
-    "  movq 0(%1), %%rdx;"     "  mulx %%rdx, %%rax, %%rcx;"    // f[0]^2
-                               "  movq %%rax, 0(%2);"
-    "  add %%rcx, %%r8;"       "  movq %%r8, 8(%2);"
-    "  movq 8(%1), %%rdx;"     "  mulx %%rdx, %%rax, %%rcx;"    // f[1]^2
-    "  adcx %%rax, %%r9;"      "  movq %%r9, 16(%2);"
-    "  adcx %%rcx, %%r10;"     "  movq %%r10, 24(%2);"
-    "  movq 16(%1), %%rdx;"    "  mulx %%rdx, %%rax, %%rcx;"    // f[2]^2
-    "  adcx %%rax, %%r11;"     "  movq %%r11, 32(%2);"
-    "  adcx %%rcx, %%r12;"     "  movq %%r12, 40(%2);"
-    "  movq 24(%1), %%rdx;"    "  mulx %%rdx, %%rax, %%rcx;"    // f[3]^2
-    "  adcx %%rax, %%r13;"     "  movq %%r13, 48(%2);"
-    "  adcx %%rcx, %%r14;"     "  movq %%r14, 56(%2);"
+    "  movq 0(%0), %%rdx;"     "  mulx %%rdx, %%rax, %%rcx;"    // f[0]^2
+                               "  movq %%rax, 0(%1);"
+    "  add %%rcx, %%r8;"       "  movq %%r8, 8(%1);"
+    "  movq 8(%0), %%rdx;"     "  mulx %%rdx, %%rax, %%rcx;"    // f[1]^2
+    "  adcx %%rax, %%r9;"      "  movq %%r9, 16(%1);"
+    "  adcx %%rcx, %%r10;"     "  movq %%r10, 24(%1);"
+    "  movq 16(%0), %%rdx;"    "  mulx %%rdx, %%rax, %%rcx;"    // f[2]^2
+    "  adcx %%rax, %%r11;"     "  movq %%r11, 32(%1);"
+    "  adcx %%rcx, %%rbx;"     "  movq %%rbx, 40(%1);"
+    "  movq 24(%0), %%rdx;"    "  mulx %%rdx, %%rax, %%rcx;"    // f[3]^2
+    "  adcx %%rax, %%r13;"     "  movq %%r13, 48(%1);"
+    "  adcx %%rcx, %%r14;"     "  movq %%r14, 56(%1);"
 
     // Line up pointers
+    "  mov %1, %0;"
     "  mov %2, %1;"
-    "  mov %0, %2;"
 
     /////// Wrap the result back into the field ////// 
 
     // Step 1: Compute dst + carry == tmp_hi * 38 + tmp_lo
     "  mov $38, %%rdx;"
-    "  mulxq 32(%1), %%r8, %%r13;"
+    "  mulxq 32(%0), %%r8, %%r13;"
     "  xor %%rcx, %%rcx;"
-    "  adoxq 0(%1), %%r8;"
-    "  mulxq 40(%1), %%r9, %%r12;"
+    "  adoxq 0(%0), %%r8;"
+    "  mulxq 40(%0), %%r9, %%rbx;"
     "  adcx %%r13, %%r9;"
-    "  adoxq 8(%1), %%r9;"
-    "  mulxq 48(%1), %%r10, %%r13;"
-    "  adcx %%r12, %%r10;"
-    "  adoxq 16(%1), %%r10;"
-    "  mulxq 56(%1), %%r11, %%rax;"
+    "  adoxq 8(%0), %%r9;"
+    "  mulxq 48(%0), %%r10, %%r13;"
+    "  adcx %%rbx, %%r10;"
+    "  adoxq 16(%0), %%r10;"
+    "  mulxq 56(%0), %%r11, %%rax;"
     "  adcx %%r13, %%r11;"
-    "  adoxq 24(%1), %%r11;"
+    "  adoxq 24(%0), %%r11;"
     "  adcx %%rcx, %%rax;"
     "  adox %%rcx, %%rax;"
     "  imul %%rdx, %%rax;"
@@ -567,20 +567,20 @@ static inline void fsqr (uint64_t *out, uint64_t *f, uint64_t *tmp)
     // Step 2: Fold the carry back into dst
     "  add %%rax, %%r8;"
     "  adcx %%rcx, %%r9;"
-    "  movq %%r9, 8(%2);"
+    "  movq %%r9, 8(%1);"
     "  adcx %%rcx, %%r10;"
-    "  movq %%r10, 16(%2);"
+    "  movq %%r10, 16(%1);"
     "  adcx %%rcx, %%r11;"
-    "  movq %%r11, 24(%2);"
+    "  movq %%r11, 24(%1);"
 
     // Step 3: Fold the carry bit back in; guaranteed not to carry at this point
     "  mov $0, %%rax;"
     "  cmovc %%rdx, %%rax;"
     "  add %%rax, %%r8;"
-    "  movq %%r8, 0(%2);"
-  : "+&r" (out), "+&r" (f), "+&r" (tmp)
-  : 
-  : "%rax", "%rcx", "%rdx", "%r8", "%r9", "%r10", "%r11", "%r12", "%r13", "%r14", "%r15", "memory", "cc"
+    "  movq %%r8, 0(%1);"
+  : "+&r" (f), "+&r" (tmp)
+  : "r" (out)
+  : "%rax", "%rbx", "%rcx", "%rdx", "%r8", "%r9", "%r10", "%r11", "%r13", "%r14", "%r15", "memory", "cc"
   );
 }
 
@@ -592,15 +592,15 @@ static inline void fsqr2 (uint64_t *out, uint64_t *f, uint64_t *tmp)
 {
   asm volatile(
     // Step 1: Compute all partial products
-    "  movq 0(%1), %%rdx;"                                       // f[0]
-    "  mulxq 8(%1), %%r8, %%r14;"      "  xor %%r15, %%r15;"     // f[1]*f[0]
-    "  mulxq 16(%1), %%r9, %%r10;"     "  adcx %%r14, %%r9;"     // f[2]*f[0]
-    "  mulxq 24(%1), %%rax, %%rcx;"    "  adcx %%rax, %%r10;"    // f[3]*f[0]
-    "  movq 24(%1), %%rdx;"                                      // f[3]
-    "  mulxq 8(%1), %%r11, %%r12;"     "  adcx %%rcx, %%r11;"    // f[1]*f[3]
-    "  mulxq 16(%1), %%rax, %%r13;"    "  adcx %%rax, %%r12;"    // f[2]*f[3]
-    "  movq 8(%1), %%rdx;"             "  adcx %%r15, %%r13;"    // f1
-    "  mulxq 16(%1), %%rax, %%rcx;"    "  mov $0, %%r14;"        // f[2]*f[1]
+    "  movq 0(%0), %%rdx;"                                       // f[0]
+    "  mulxq 8(%0), %%r8, %%r14;"      "  xor %%r15, %%r15;"     // f[1]*f[0]
+    "  mulxq 16(%0), %%r9, %%r10;"     "  adcx %%r14, %%r9;"     // f[2]*f[0]
+    "  mulxq 24(%0), %%rax, %%rcx;"    "  adcx %%rax, %%r10;"    // f[3]*f[0]
+    "  movq 24(%0), %%rdx;"                                      // f[3]
+    "  mulxq 8(%0), %%r11, %%rbx;"     "  adcx %%rcx, %%r11;"    // f[1]*f[3]
+    "  mulxq 16(%0), %%rax, %%r13;"    "  adcx %%rax, %%rbx;"    // f[2]*f[3]
+    "  movq 8(%0), %%rdx;"             "  adcx %%r15, %%r13;"    // f1
+    "  mulxq 16(%0), %%rax, %%rcx;"    "  mov $0, %%r14;"        // f[2]*f[1]
 
     // Step 2: Compute two parallel carry chains
     "  xor %%r15, %%r15;"
@@ -608,39 +608,39 @@ static inline void fsqr2 (uint64_t *out, uint64_t *f, uint64_t *tmp)
     "  adcx %%r8, %%r8;"
     "  adox %%rcx, %%r11;"
     "  adcx %%r9, %%r9;"
-    "  adox %%r15, %%r12;"
+    "  adox %%r15, %%rbx;"
     "  adcx %%r10, %%r10;"
     "  adox %%r15, %%r13;"
     "  adcx %%r11, %%r11;"
     "  adox %%r15, %%r14;"
-    "  adcx %%r12, %%r12;"
+    "  adcx %%rbx, %%rbx;"
     "  adcx %%r13, %%r13;"
     "  adcx %%r14, %%r14;"
 
     // Step 3: Compute intermediate squares
-    "  movq 0(%1), %%rdx;"     "  mulx %%rdx, %%rax, %%rcx;"    // f[0]^2
-                               "  movq %%rax, 0(%2);"
-    "  add %%rcx, %%r8;"       "  movq %%r8, 8(%2);"
-    "  movq 8(%1), %%rdx;"     "  mulx %%rdx, %%rax, %%rcx;"    // f[1]^2
-    "  adcx %%rax, %%r9;"      "  movq %%r9, 16(%2);"
-    "  adcx %%rcx, %%r10;"     "  movq %%r10, 24(%2);"
-    "  movq 16(%1), %%rdx;"    "  mulx %%rdx, %%rax, %%rcx;"    // f[2]^2
-    "  adcx %%rax, %%r11;"     "  movq %%r11, 32(%2);"
-    "  adcx %%rcx, %%r12;"     "  movq %%r12, 40(%2);"
-    "  movq 24(%1), %%rdx;"    "  mulx %%rdx, %%rax, %%rcx;"    // f[3]^2
-    "  adcx %%rax, %%r13;"     "  movq %%r13, 48(%2);"
-    "  adcx %%rcx, %%r14;"     "  movq %%r14, 56(%2);"
+    "  movq 0(%0), %%rdx;"     "  mulx %%rdx, %%rax, %%rcx;"    // f[0]^2
+                               "  movq %%rax, 0(%1);"
+    "  add %%rcx, %%r8;"       "  movq %%r8, 8(%1);"
+    "  movq 8(%0), %%rdx;"     "  mulx %%rdx, %%rax, %%rcx;"    // f[1]^2
+    "  adcx %%rax, %%r9;"      "  movq %%r9, 16(%1);"
+    "  adcx %%rcx, %%r10;"     "  movq %%r10, 24(%1);"
+    "  movq 16(%0), %%rdx;"    "  mulx %%rdx, %%rax, %%rcx;"    // f[2]^2
+    "  adcx %%rax, %%r11;"     "  movq %%r11, 32(%1);"
+    "  adcx %%rcx, %%rbx;"     "  movq %%rbx, 40(%1);"
+    "  movq 24(%0), %%rdx;"    "  mulx %%rdx, %%rax, %%rcx;"    // f[3]^2
+    "  adcx %%rax, %%r13;"     "  movq %%r13, 48(%1);"
+    "  adcx %%rcx, %%r14;"     "  movq %%r14, 56(%1);"
 
     // Step 1: Compute all partial products
-    "  movq 32(%1), %%rdx;"                                       // f[0]
-    "  mulxq 40(%1), %%r8, %%r14;"      "  xor %%r15, %%r15;"     // f[1]*f[0]
-    "  mulxq 48(%1), %%r9, %%r10;"     "  adcx %%r14, %%r9;"     // f[2]*f[0]
-    "  mulxq 56(%1), %%rax, %%rcx;"    "  adcx %%rax, %%r10;"    // f[3]*f[0]
-    "  movq 56(%1), %%rdx;"                                      // f[3]
-    "  mulxq 40(%1), %%r11, %%r12;"     "  adcx %%rcx, %%r11;"    // f[1]*f[3]
-    "  mulxq 48(%1), %%rax, %%r13;"    "  adcx %%rax, %%r12;"    // f[2]*f[3]
-    "  movq 40(%1), %%rdx;"             "  adcx %%r15, %%r13;"    // f1
-    "  mulxq 48(%1), %%rax, %%rcx;"    "  mov $0, %%r14;"        // f[2]*f[1]
+    "  movq 32(%0), %%rdx;"                                       // f[0]
+    "  mulxq 40(%0), %%r8, %%r14;"      "  xor %%r15, %%r15;"     // f[1]*f[0]
+    "  mulxq 48(%0), %%r9, %%r10;"     "  adcx %%r14, %%r9;"     // f[2]*f[0]
+    "  mulxq 56(%0), %%rax, %%rcx;"    "  adcx %%rax, %%r10;"    // f[3]*f[0]
+    "  movq 56(%0), %%rdx;"                                      // f[3]
+    "  mulxq 40(%0), %%r11, %%rbx;"     "  adcx %%rcx, %%r11;"    // f[1]*f[3]
+    "  mulxq 48(%0), %%rax, %%r13;"    "  adcx %%rax, %%rbx;"    // f[2]*f[3]
+    "  movq 40(%0), %%rdx;"             "  adcx %%r15, %%r13;"    // f1
+    "  mulxq 48(%0), %%rax, %%rcx;"    "  mov $0, %%r14;"        // f[2]*f[1]
 
     // Step 2: Compute two parallel carry chains
     "  xor %%r15, %%r15;"
@@ -648,47 +648,47 @@ static inline void fsqr2 (uint64_t *out, uint64_t *f, uint64_t *tmp)
     "  adcx %%r8, %%r8;"
     "  adox %%rcx, %%r11;"
     "  adcx %%r9, %%r9;"
-    "  adox %%r15, %%r12;"
+    "  adox %%r15, %%rbx;"
     "  adcx %%r10, %%r10;"
     "  adox %%r15, %%r13;"
     "  adcx %%r11, %%r11;"
     "  adox %%r15, %%r14;"
-    "  adcx %%r12, %%r12;"
+    "  adcx %%rbx, %%rbx;"
     "  adcx %%r13, %%r13;"
     "  adcx %%r14, %%r14;"
 
     // Step 3: Compute intermediate squares
-    "  movq 32(%1), %%rdx;"     "  mulx %%rdx, %%rax, %%rcx;"    // f[0]^2
-                               "  movq %%rax, 64(%2);"
-    "  add %%rcx, %%r8;"       "  movq %%r8, 72(%2);"
-    "  movq 40(%1), %%rdx;"     "  mulx %%rdx, %%rax, %%rcx;"    // f[1]^2
-    "  adcx %%rax, %%r9;"      "  movq %%r9, 80(%2);"
-    "  adcx %%rcx, %%r10;"     "  movq %%r10, 88(%2);"
-    "  movq 48(%1), %%rdx;"    "  mulx %%rdx, %%rax, %%rcx;"    // f[2]^2
-    "  adcx %%rax, %%r11;"     "  movq %%r11, 96(%2);"
-    "  adcx %%rcx, %%r12;"     "  movq %%r12, 104(%2);"
-    "  movq 56(%1), %%rdx;"    "  mulx %%rdx, %%rax, %%rcx;"    // f[3]^2
-    "  adcx %%rax, %%r13;"     "  movq %%r13, 112(%2);"
-    "  adcx %%rcx, %%r14;"     "  movq %%r14, 120(%2);"
+    "  movq 32(%0), %%rdx;"     "  mulx %%rdx, %%rax, %%rcx;"    // f[0]^2
+                               "  movq %%rax, 64(%1);"
+    "  add %%rcx, %%r8;"       "  movq %%r8, 72(%1);"
+    "  movq 40(%0), %%rdx;"     "  mulx %%rdx, %%rax, %%rcx;"    // f[1]^2
+    "  adcx %%rax, %%r9;"      "  movq %%r9, 80(%1);"
+    "  adcx %%rcx, %%r10;"     "  movq %%r10, 88(%1);"
+    "  movq 48(%0), %%rdx;"    "  mulx %%rdx, %%rax, %%rcx;"    // f[2]^2
+    "  adcx %%rax, %%r11;"     "  movq %%r11, 96(%1);"
+    "  adcx %%rcx, %%rbx;"     "  movq %%rbx, 104(%1);"
+    "  movq 56(%0), %%rdx;"    "  mulx %%rdx, %%rax, %%rcx;"    // f[3]^2
+    "  adcx %%rax, %%r13;"     "  movq %%r13, 112(%1);"
+    "  adcx %%rcx, %%r14;"     "  movq %%r14, 120(%1);"
 
     // Line up pointers
+    "  mov %1, %0;"
     "  mov %2, %1;"
-    "  mov %0, %2;"
 
     // Step 1: Compute dst + carry == tmp_hi * 38 + tmp_lo
     "  mov $38, %%rdx;"
-    "  mulxq 32(%1), %%r8, %%r13;"
+    "  mulxq 32(%0), %%r8, %%r13;"
     "  xor %%rcx, %%rcx;"
-    "  adoxq 0(%1), %%r8;"
-    "  mulxq 40(%1), %%r9, %%r12;"
+    "  adoxq 0(%0), %%r8;"
+    "  mulxq 40(%0), %%r9, %%rbx;"
     "  adcx %%r13, %%r9;"
-    "  adoxq 8(%1), %%r9;"
-    "  mulxq 48(%1), %%r10, %%r13;"
-    "  adcx %%r12, %%r10;"
-    "  adoxq 16(%1), %%r10;"
-    "  mulxq 56(%1), %%r11, %%rax;"
+    "  adoxq 8(%0), %%r9;"
+    "  mulxq 48(%0), %%r10, %%r13;"
+    "  adcx %%rbx, %%r10;"
+    "  adoxq 16(%0), %%r10;"
+    "  mulxq 56(%0), %%r11, %%rax;"
     "  adcx %%r13, %%r11;"
-    "  adoxq 24(%1), %%r11;"
+    "  adoxq 24(%0), %%r11;"
     "  adcx %%rcx, %%rax;"
     "  adox %%rcx, %%rax;"
     "  imul %%rdx, %%rax;"
@@ -696,32 +696,32 @@ static inline void fsqr2 (uint64_t *out, uint64_t *f, uint64_t *tmp)
     // Step 2: Fold the carry back into dst
     "  add %%rax, %%r8;"
     "  adcx %%rcx, %%r9;"
-    "  movq %%r9, 8(%2);"
+    "  movq %%r9, 8(%1);"
     "  adcx %%rcx, %%r10;"
-    "  movq %%r10, 16(%2);"
+    "  movq %%r10, 16(%1);"
     "  adcx %%rcx, %%r11;"
-    "  movq %%r11, 24(%2);"
+    "  movq %%r11, 24(%1);"
 
     // Step 3: Fold the carry bit back in; guaranteed not to carry at this point
     "  mov $0, %%rax;"
     "  cmovc %%rdx, %%rax;"
     "  add %%rax, %%r8;"
-    "  movq %%r8, 0(%2);"
+    "  movq %%r8, 0(%1);"
 
     // Step 1: Compute dst + carry == tmp_hi * 38 + tmp_lo
     "  mov $38, %%rdx;"
-    "  mulxq 96(%1), %%r8, %%r13;"
+    "  mulxq 96(%0), %%r8, %%r13;"
     "  xor %%rcx, %%rcx;"
-    "  adoxq 64(%1), %%r8;"
-    "  mulxq 104(%1), %%r9, %%r12;"
+    "  adoxq 64(%0), %%r8;"
+    "  mulxq 104(%0), %%r9, %%rbx;"
     "  adcx %%r13, %%r9;"
-    "  adoxq 72(%1), %%r9;"
-    "  mulxq 112(%1), %%r10, %%r13;"
-    "  adcx %%r12, %%r10;"
-    "  adoxq 80(%1), %%r10;"
-    "  mulxq 120(%1), %%r11, %%rax;"
+    "  adoxq 72(%0), %%r9;"
+    "  mulxq 112(%0), %%r10, %%r13;"
+    "  adcx %%rbx, %%r10;"
+    "  adoxq 80(%0), %%r10;"
+    "  mulxq 120(%0), %%r11, %%rax;"
     "  adcx %%r13, %%r11;"
-    "  adoxq 88(%1), %%r11;"
+    "  adoxq 88(%0), %%r11;"
     "  adcx %%rcx, %%rax;"
     "  adox %%rcx, %%rax;"
     "  imul %%rdx, %%rax;"
@@ -729,20 +729,20 @@ static inline void fsqr2 (uint64_t *out, uint64_t *f, uint64_t *tmp)
     // Step 2: Fold the carry back into dst
     "  add %%rax, %%r8;"
     "  adcx %%rcx, %%r9;"
-    "  movq %%r9, 40(%2);"
+    "  movq %%r9, 40(%1);"
     "  adcx %%rcx, %%r10;"
-    "  movq %%r10, 48(%2);"
+    "  movq %%r10, 48(%1);"
     "  adcx %%rcx, %%r11;"
-    "  movq %%r11, 56(%2);"
+    "  movq %%r11, 56(%1);"
 
     // Step 3: Fold the carry bit back in; guaranteed not to carry at this point
     "  mov $0, %%rax;"
     "  cmovc %%rdx, %%rax;"
     "  add %%rax, %%r8;"
-    "  movq %%r8, 32(%2);"
-  : "+&r" (out), "+&r" (f), "+&r" (tmp)
-  : 
-  : "%rax", "%rcx", "%rdx", "%r8", "%r9", "%r10", "%r11", "%r12", "%r13", "%r14", "%r15", "memory", "cc"
+    "  movq %%r8, 32(%1);"
+  : "+&r" (f), "+&r" (tmp)
+  : "r" (out)
+  : "%rax", "%rbx", "%rcx", "%rdx", "%r8", "%r9", "%r10", "%r11", "%r13", "%r14", "%r15", "memory", "cc"
   );
 }
 

--- a/vale/code/arch/x64/interop/Vale.Inline.X64.Fmul_inline.fst
+++ b/vale/code/arch/x64/interop/Vale.Inline.X64.Fmul_inline.fst
@@ -72,7 +72,7 @@ let fmul_post : VSig.vale_post fmul_dom =
 
 let fmul_regs_modified: MS.reg_64 -> bool = fun (r:MS.reg_64) ->
   let open MS in
-  if r = rRax || r = rRcx || r = rRdx || r = rRdi || r = rRsi || r = rR8 || r = rR9 || r = rR10 || r = rR11 || r = rR12 || r = rR13 || r = rR14 || r = rR15 then true
+  if r = rRax || r = rRbx || r = rRcx || r = rRdx || r = rRdi || r = rRsi || r = rR8 || r = rR9 || r = rR10 || r = rR11 || r = rR13 || r = rR14 || r = rR15 then true
   else false
 
 let fmul_xmms_modified = fun _ -> false
@@ -356,7 +356,7 @@ let fmul1_post : VSig.vale_post fmul1_dom =
 
 let fmul1_regs_modified: MS.reg_64 -> bool = fun (r:MS.reg_64) ->
   let open MS in
-  if r = rRax || r = rRcx || r = rRdx || r = rR8 || r = rR9 || r = rR10 || r = rR11 || r = rR12 || r = rR13 then true
+  if r = rRax || r = rRbx || r = rRcx || r = rRdx || r = rR8 || r = rR9 || r = rR10 || r = rR11 || r = rR13 then true
   else false
 
 let fmul1_xmms_modified = fun _ -> false

--- a/vale/code/arch/x64/interop/Vale.Inline.X64.Fsqr_inline.fst
+++ b/vale/code/arch/x64/interop/Vale.Inline.X64.Fsqr_inline.fst
@@ -70,7 +70,7 @@ let fsqr_post : VSig.vale_post fsqr_dom =
 
 let fsqr_regs_modified: MS.reg_64 -> bool = fun (r:MS.reg_64) ->
   let open MS in
-  if r = rRax || r = rRbx || r = rRcx || r = rRdx || r = rRdi || r = rRsi || r = rR8 || r = rR9 || r = rR10 || r = rR11 || r = rR12 || r = rR13 || r = rR14 || r = rR15 then true
+  if r = rRax || r = rRbx || r = rRcx || r = rRdx || r = rRdi || r = rRsi || r = rR8 || r = rR9 || r = rR10 || r = rR11 || r = rR13 || r = rR14 || r = rR15 then true
   else false
 
 let fsqr_xmms_modified = fun _ -> false
@@ -113,13 +113,13 @@ let fsqr_lemma = as_t #(VSig.vale_sig fsqr_regs_modified fsqr_xmms_modified fsqr
 let code_Fsqr = FW.va_code_Fsqr ()
 
 let of_reg (r:MS.reg_64) : option (IX64.reg_nat 3) = match r with
-  | 1 -> Some 0 // rbx
+  | 12 -> Some 0 // r12
   | 4 -> Some 1 // rsi
   | 5 -> Some 2 // rdi
   | _ -> None
 
 let of_arg (i:IX64.reg_nat 3) : MS.reg_64 = match i with
-  | 0 -> MS.rRbx
+  | 0 -> MS.rR12
   | 1 -> MS.rRsi
   | 2 -> MS.rRdi
 

--- a/vale/code/arch/x64/interop/Vale.Inline.X64.Fsqr_inline.fst
+++ b/vale/code/arch/x64/interop/Vale.Inline.X64.Fsqr_inline.fst
@@ -70,7 +70,7 @@ let fsqr_post : VSig.vale_post fsqr_dom =
 
 let fsqr_regs_modified: MS.reg_64 -> bool = fun (r:MS.reg_64) ->
   let open MS in
-  if r = rRax || r = rRbx || r = rRcx || r = rRdx || r = rRdi || r = rRsi || r = rR8 || r = rR9 || r = rR10 || r = rR11 || r = rR13 || r = rR14 || r = rR15 then true
+  if r = rRax || r = rRbx || r = rRcx || r = rRdx || r = rRdi || r = rRsi || r = rR8 || r = rR9 || r = rR10 || r = rR11 || r = rR12 || r = rR13 || r = rR14 || r = rR15 then true
   else false
 
 let fsqr_xmms_modified = fun _ -> false

--- a/vale/code/thirdPartyPorts/rfc7748/curve25519/x64/Vale.Curve25519.X64.FastHybrid.vaf
+++ b/vale/code/thirdPartyPorts/rfc7748/curve25519/x64/Vale.Curve25519.X64.FastHybrid.vaf
@@ -71,7 +71,7 @@ procedure Fast_mul1(inline offset:nat, ghost inA_b:buffer64)
         d3 @= r11;
 
         tmp0 @= rcx;
-        tmp1 @= r12;
+        tmp1 @= rbx;
         tmp2 @= r13;
 
         carry @= rax;
@@ -130,13 +130,13 @@ procedure Fast_add_after_mul1(ghost dst_b:buffer64, ghost inB_b:buffer64)
         b2 := buffer64_read(inB_b, 2, heap0);
         b3 := buffer64_read(inB_b, 3, heap0);
 
-        a := pow2_five(r8, r10, r12, r14, rax);
+        a := pow2_five(r8, r10, rbx, r14, rax);
         b := pow2_four(b0, b1, b2, b3);
     reads
         dst_ptr; inB_ptr; r14; memLayout;
 
     modifies
-        rax; r8; r9; r10; r11; r12; r13; r15;
+        rax; r8; r9; r10; r11; rbx; r13; r15;
         heap0; efl;
 
     requires
@@ -171,7 +171,7 @@ procedure Fast_add_after_mul1(ghost dst_b:buffer64, ghost inB_b:buffer64)
     Store64_buffer(heap0, dst_ptr, r11,  8, Secret, dst_b, 1);
 
     Load64_buffer(heap0, r13, inB_ptr, 16, Secret, inB_b, 2);     /* B[2] */
-    Adcx64Wrap(r13, r12);
+    Adcx64Wrap(r13, rbx);
     Store64_buffer(heap0, dst_ptr, r13, 16, Secret, dst_b, 2);
 
     Load64_buffer(heap0, r15, inB_ptr, 24, Secret, inB_b, 3);     /* B[3] */
@@ -196,7 +196,7 @@ procedure Fast_add_after_mul1_regs(ghost inB_b:buffer64)
         carry @= rax;
         tmp0 @= rcx;
         tmp1 @= rdx;
-        tmp2 @= r12;
+        tmp2 @= rbx;
         tmp3 @= r13;
 
         b0 := buffer64_read(inB_b, 0, heap0);
@@ -269,7 +269,7 @@ procedure Fast_mul1_add(inline offset:nat, ghost inA_b:buffer64)
         d3 @= r11;
 
         tmp0 @= r13;
-        tmp1 @= r12;
+        tmp1 @= rbx;
 
         carry @= rax;
         zero  @= rcx;
@@ -499,7 +499,7 @@ procedure Carry_wide(inline offset:nat, ghost dst_b:buffer64, ghost inA_b:buffer
 
     modifies
         rax; rcx; rdx;
-        tmp0; tmp1; tmp2; tmp3; r12; r13;
+        tmp0; tmp1; tmp2; tmp3; rbx; r13;
         heap0; efl;
 
     requires
@@ -552,7 +552,7 @@ procedure Carry_wide_stdcall(inline win:bool, ghost dst_b:buffer64, ghost inA_b:
         inA_in := (if win then rdx else rsi);
     reads memLayout;
     modifies
-        rax; rbx; rcx; rdx; rdi; rsi; r8; r9; r10; r11; r12; r13; r14; r15;
+        rax; rbx; rcx; rdx; rdi; rsi; r8; r9; r10; r11; r13; r14; r15;
         rsp; efl; heap0;
     requires
         adx_enabled && bmi2_enabled;
@@ -585,13 +585,11 @@ procedure Carry_wide_stdcall(inline win:bool, ghost dst_b:buffer64, ghost inA_b:
 
         rbx == old(rbx);
         rsi == old(rsi);
-        r12 == old(r12);
         r13 == old(r13);
         r14 == old(r14);
         rsp == old(rsp);
 {
     // Store callee-save registers
-    Push(r12);
     Push(r13);
 
     // Line up the rest of the arguments
@@ -609,7 +607,6 @@ procedure Carry_wide_stdcall(inline win:bool, ghost dst_b:buffer64, ghost inA_b:
         Pop(rsi);
     }
     Pop(r13);
-    Pop(r12);
 }
 */
 
@@ -866,7 +863,7 @@ procedure Fadd_stdcall(
         inA_in := (if win then rdx else rsi);
         inB_in := (if win then r8 else rdx);
     modifies
-        rax; rbx; rcx; rdx; rsi; rdi; rbp; rsp; r8; r9; r10; r11; r12; r13; r14; r15;
+        rax; rbx; rcx; rdx; rsi; rdi; rbp; rsp; r8; r9; r10; r11; r13; r14; r15;
         efl; heap0; memLayout; stack; stackTaint;
     requires
         rsp == init_rsp(stack);
@@ -911,13 +908,11 @@ procedure Fadd_stdcall(
         win ==>  rdi == old(rdi);
         win ==>  rsi == old(rsi);
         win ==>  rsp == old(rsp);
-        win ==>  r12 == old(r12);
         win ==>  r13 == old(r13);
         win ==>  r14 == old(r14);
         win ==>  r15 == old(r15);
         !win ==>  rbx == old(rbx);
         !win ==>  rbp == old(rbp);
-        !win ==>  r12 == old(r12);
         !win ==>  r13 == old(r13);
         !win ==>  r14 == old(r14);
         !win ==>  r15 == old(r15);
@@ -1025,7 +1020,7 @@ procedure Fsub_stdcall(
         inA_in := (if win then rdx else rsi);
         inB_in := (if win then r8 else rdx);
     modifies
-        rax; rbx; rcx; rdx; rsi; rdi; rbp; rsp; r8; r9; r10; r11; r12; r13; r14; r15;
+        rax; rbx; rcx; rdx; rsi; rdi; rbp; rsp; r8; r9; r10; r11; r13; r14; r15;
         efl; heap0; memLayout; stack; stackTaint;
     requires
         rsp == init_rsp(stack);
@@ -1070,13 +1065,11 @@ procedure Fsub_stdcall(
         win ==>  rdi == old(rdi);
         win ==>  rsi == old(rsi);
         win ==>  rsp == old(rsp);
-        win ==>  r12 == old(r12);
         win ==>  r13 == old(r13);
         win ==>  r14 == old(r14);
         win ==>  r15 == old(r15);
         !win ==>  rbx == old(rbx);
         !win ==>  rbp == old(rbp);
-        !win ==>  r12 == old(r12);
         !win ==>  r13 == old(r13);
         !win ==>  r14 == old(r14);
         !win ==>  r15 == old(r15);
@@ -1131,7 +1124,7 @@ procedure Fmul1(ghost dst_b:buffer64, ghost inA_b:buffer64, ghost inB:nat64)
     modifies
         rax; rcx; b;
         tmp0; tmp1; tmp2; tmp3;
-        r12; r13;
+        rbx; r13;
         heap0; memLayout; efl;
 
     requires
@@ -1184,7 +1177,7 @@ procedure Fmul1_stdcall(
         dst_in := (if win then rcx else rdi);
         inA_in := (if win then rdx else rsi);
     modifies
-        rax; rbx; rcx; rdx; rsi; rdi; rbp; rsp; r8; r9; r10; r11; r12; r13; r14; r15;
+        rax; rbx; rcx; rdx; rsi; rdi; rbp; rsp; r8; r9; r10; r11; r13; r14; r15;
         efl; heap0; memLayout; stack; stackTaint;
     requires
         rsp == init_rsp(stack);
@@ -1225,13 +1218,11 @@ procedure Fmul1_stdcall(
         win ==>  rdi == old(rdi);
         win ==>  rsi == old(rsi);
         win ==>  rsp == old(rsp);
-        win ==>  r12 == old(r12);
         win ==>  r13 == old(r13);
         win ==>  r14 == old(r14);
         win ==>  r15 == old(r15);
         !win ==>  rbx == old(rbx);
         !win ==>  rbp == old(rbp);
-        !win ==>  r12 == old(r12);
         !win ==>  r13 == old(r13);
         !win ==>  r14 == old(r14);
         !win ==>  r15 == old(r15);
@@ -1240,8 +1231,8 @@ procedure Fmul1_stdcall(
 {
     // Store callee-save registers
     Push_Secret(rdi);
-    Push_Secret(r12);
     Push_Secret(r13);
+    Push_Secret(rbx);
 
     // Line up the rest of the arguments
     inline if (win)
@@ -1258,7 +1249,8 @@ procedure Fmul1_stdcall(
     {
         Pop_Secret(rsi);
     }
+
+    Pop_Secret(rbx);
     Pop_Secret(r13);
-    Pop_Secret(r12);
     Pop_Secret(rdi);
 }

--- a/vale/code/thirdPartyPorts/rfc7748/curve25519/x64/Vale.Curve25519.X64.FastMul.vaf
+++ b/vale/code/thirdPartyPorts/rfc7748/curve25519/x64/Vale.Curve25519.X64.FastMul.vaf
@@ -78,7 +78,7 @@ procedure Fast_multiply_a0b(
         dst_ptr; inA_ptr; inB_ptr; memLayout;
 
     modifies
-        rax; rdx; r8; r9; r10; r11; r12; r13; r14;
+        rax; rdx; r8; r9; r10; r11; rbx; r13; r14;
         heap0; efl;
 
     requires
@@ -94,7 +94,7 @@ procedure Fast_multiply_a0b(
     ensures
         let d0 := buffer64_read(dst_b, 0 + offset*2, heap0);
         let d1 := buffer64_read(dst_b, 1 + offset*2, heap0);
-        let a0b := d0 + pow2_64 * d1 + pow2_128 * r12 + pow2_192 * r14 + pow2_256 * rax;
+        let a0b := d0 + pow2_64 * d1 + pow2_128 * rbx + pow2_192 * r14 + pow2_256 * rax;
         a0b == a0 * b;
 
         rax < pow2_64 - 1;
@@ -108,7 +108,7 @@ procedure Fast_multiply_a0b(
 //    "movq   (%1), %%rdx; " /* A[0] */
 //    "mulx   (B),  %%r8,  %%r9; " /* A[0]*B[0] */    "xorl %%r10d, %%r10d ;"                           "movq  %%r8,  (dst) ;"
 //    "mulx  8(B), %%r10, %%r11; " /* A[0]*B[1] */    "adox  %%r9, %%r10 ;"                             "movq %%r10, 8(dst) ;"
-//    "mulx 16(B), %%r12, %%r13; " /* A[0]*B[2] */    "adox %%r11, %%r12 ;"
+//    "mulx 16(B), %%rbx, %%r13; " /* A[0]*B[2] */    "adox %%r11, %%rbx ;"
 //    "mulx 24(B), %%r14, %%rdx; " /* A[0]*B[3] */    "adox %%r13, %%r14 ;"                                                       "movq $0, %%rax ;"
 //    /*******************************************/   "adox %%rdx, %%rax ;"
 
@@ -147,9 +147,9 @@ procedure Fast_multiply_a0b(
     //assert_by_tactic(a0b0b1 == a0 * (b0 + pow2_64 * b1), int_canon);   // FAILS
     Newline();
     NoNewline();    
-    Mulx64(r13, r12, Mem64(heap0, inB_ptr, 16 + offset * 8, inB_b, 2 + offset, Secret));  /* A[0]*B[2] */ 
-    let a0b2_lo := r12; lemma_prod_bounds(r13, r12, a0, b2); 
-    Adox64Wrap(r12, r11);
+    Mulx64(r13, rbx, Mem64(heap0, inB_ptr, 16 + offset * 8, inB_b, 2 + offset, Secret));  /* A[0]*B[2] */ 
+    let a0b2_lo := rbx; lemma_prod_bounds(r13, rbx, a0, b2); 
+    Adox64Wrap(rbx, r11);
 
     let overflow1 := overflow(efl);
     NoNewline();
@@ -165,15 +165,15 @@ procedure Fast_multiply_a0b(
 
     carry := if overflow2 then 1 else 0;
     let carry_new := if overflow(efl) then 1 else 0;
-    //let a0b := d0 + pow2_64 * d1 + pow2_128 * r12 + pow2_192 * r14 + pow2_256 * (rdx + carry);
-    let a0b := d0 + pow2_64 * d1 + pow2_128 * r12 + pow2_192 * r14 + pow2_256 * rax + pow2_320 * carry_new;
+    //let a0b := d0 + pow2_64 * d1 + pow2_128 * rbx + pow2_192 * r14 + pow2_256 * (rdx + carry);
+    let a0b := d0 + pow2_64 * d1 + pow2_128 * rbx + pow2_192 * r14 + pow2_256 * rax + pow2_320 * carry_new;
 
 //    a0b_helper(a0, b0, b1, b2, b3,
 //               d0,      r9,
 //               a0b1_lo, r11,
 //               a0b2_lo, r13,
 //               a0b3_lo, rdx,
-//               d1, r12, r14,
+//               d1, rbx, r14,
 //               overflow0, overflow1, overflow2);
 //    assert a0 * b == a0b;   // PASSES
 
@@ -213,7 +213,7 @@ procedure Fast_multiply_a1b(
         dst_ptr; inA_ptr; inB_ptr; memLayout;
 
     modifies
-        rax; rdx; r8; r9; r10; r11; r12; r13; r14;
+        rax; rdx; r8; r9; r10; r11; rbx; r13; r14;
         heap0; efl;
 
     requires
@@ -230,14 +230,14 @@ procedure Fast_multiply_a1b(
 
         let d0 := buffer64_read(dst_b, 0 + offset*2, heap0);
         let d1 := buffer64_read(dst_b, 1 + offset*2, heap0);
-        let a0b := d0 + pow2_64 * d1 + pow2_128 * r12 + pow2_192 * r14 + pow2_256 * rax;
+        let a0b := d0 + pow2_64 * d1 + pow2_128 * rbx + pow2_192 * r14 + pow2_256 * rax;
         a0b == a0 * b;
 
     ensures
         let d0 := buffer64_read(dst_b, 0 + offset*2, heap0);
         let d1 := buffer64_read(dst_b, 1 + offset*2, heap0);
         let d2 := buffer64_read(dst_b, 2 + offset*2, heap0);
-        pow2_two(a0, a1) * b == pow2_six(d0, d1, d2, r12, r14, rax);
+        pow2_two(a0, a1) * b == pow2_six(d0, d1, d2, rbx, r14, rax);
 
         validSrcAddrs64(heap0, dst_ptr, dst_b, 8 + offset*2, memLayout, Secret);
         modifies_buffer_specific(dst_b, old(heap0), heap0, 0 + offset*2, 8 + offset*2 - 1);
@@ -247,15 +247,15 @@ procedure Fast_multiply_a1b(
 
     let a0b_0 := buffer64_read(dst_b, 0 + offset*2, heap0);
     let a0b_1 := buffer64_read(dst_b, 1 + offset*2, heap0);
-    let a0b_2 := r12;
+    let a0b_2 := rbx;
     let a0b_3 := r14;
     let a0b_4 := rax;
     let a0b := pow2_five(a0b_0, a0b_1, a0b_2, a0b_3, a0b_4);
 //
 //    "movq  8(A), %%rdx; " /* A[1] */
 //    "mulx   (B),  %%r8,  %%r9; " /* A[1]*B[0] */    "xorl %%r10d, %%r10d ;"  "adcx 8(dst),  %%r8 ;"    "movq  %%r8,  8(dst) ;"
-//    "mulx  8(B), %%r10, %%r11; " /* A[1]*B[1] */    "adox  %%r9, %%r10 ;"    "adcx %%r12, %%r10 ;"    "movq %%r10, 16(dst) ;"
-//    "mulx 16(B), %%r12, %%r13; " /* A[1]*B[2] */    "adox %%r11, %%r12 ;"    "adcx %%r14, %%r12 ;"                              "movq $0, %%r8  ;"
+//    "mulx  8(B), %%r10, %%r11; " /* A[1]*B[1] */    "adox  %%r9, %%r10 ;"    "adcx %%rbx, %%r10 ;"    "movq %%r10, 16(dst) ;"
+//    "mulx 16(B), %%rbx, %%r13; " /* A[1]*B[2] */    "adox %%r11, %%rbx ;"    "adcx %%r14, %%rbx ;"                              "movq $0, %%r8  ;"
 //    "mulx 24(B), %%r14, %%rdx; " /* A[1]*B[3] */    "adox %%r13, %%r14 ;"    "adcx %%rax, %%r14 ;"                              "movq $0, %%rax ;"
 //    /*******************************************/   "adox %%rdx, %%rax ;"    "adcx  %%r8, %%rax ;"
 
@@ -275,15 +275,15 @@ procedure Fast_multiply_a1b(
     Space(1);
     Adox64Wrap(r10,  r9);  let a1b_1 := r10;      // At this point, overflow = 0, r9 < 2^64 - 1, and (r10 is <= 1 (so no new overflow), or r11 < 2^64-2)
     Space(1);
-    Adcx64Wrap(r10, r12);
+    Adcx64Wrap(r10, rbx);
     Store64_buffer(heap0, dst_ptr, r10, 16 + offset*16, Secret, dst_b, 2 + offset*2);
 
     NoNewline();
-    Mulx64(r13, r12, Mem64(heap0, inB_ptr, 16 + offset * 8, inB_b, 2 + offset, Secret));  /* A[1]*B[2] */ lemma_prod_bounds(r13, r12, a1, b2);  lemma_overflow(r13, r12, r11, bool_bit(overflow(efl)));
+    Mulx64(r13, rbx, Mem64(heap0, inB_ptr, 16 + offset * 8, inB_b, 2 + offset, Secret));  /* A[1]*B[2] */ lemma_prod_bounds(r13, rbx, a1, b2);  lemma_overflow(r13, rbx, r11, bool_bit(overflow(efl)));
     NoNewline();
-    Adox64Wrap(r12, r11);  let a1b_2 := r12;      // At this point, either r13 < 2^64-2 or (r12 <= 1, and (overflow = 0 or r11 < 2^64 - 2)).  RHS of the first or means no overflow
+    Adox64Wrap(rbx, r11);  let a1b_2 := rbx;      // At this point, either r13 < 2^64-2 or (rbx <= 1, and (overflow = 0 or r11 < 2^64 - 2)).  RHS of the first or means no overflow
     NoNewline();
-    Adcx64Wrap(r12, r14);
+    Adcx64Wrap(rbx, r14);
     Mov64( r8, 0);
 
     NoNewline();
@@ -308,7 +308,7 @@ procedure Fast_multiply_a1b(
     let d2 := buffer64_read(dst_b, 2 + offset*2, heap0);
 
     let a1b := pow2_five(a1b_0, a1b_1, a1b_2, a1b_3, a1b_4);
-    let a0a1b := pow2_seven(d0, d1, d2, r12, r14, rax, carry_bit);
+    let a0a1b := pow2_seven(d0, d1, d2, rbx, r14, rax, carry_bit);
 
     assert_by_tactic(a1 * b == 0 + pow2_four(a1 * b0, a1 * b1, a1 * b2, a1 * b3), int_canon);   // PASSES
     assert a1b == a1 * b;  // PASSES
@@ -318,7 +318,7 @@ procedure Fast_multiply_a1b(
               a0b, a0b_0, a0b_1, a0b_2, a0b_3, a0b_4,
               a1b, a1b_0, a1b_1, a1b_2, a1b_3, a1b_4,
               b, b0, b1, b2, b3,
-              d1, d2, r12, r14, rax,
+              d1, d2, rbx, r14, rax,
               carry_bit);
     assert pow2_two(a0, a1) * b == a0a1b;   // Conclusion from the lemma
 }
@@ -351,7 +351,7 @@ procedure Fast_multiply_a2b(
         dst_ptr; inA_ptr; inB_ptr; memLayout;
 
     modifies
-        rax; rdx; r8; r9; r10; r11; r12; r13; r14;
+        rax; rdx; r8; r9; r10; r11; rbx; r13; r14;
         heap0; efl;
 
     requires
@@ -367,13 +367,13 @@ procedure Fast_multiply_a2b(
         let d0 := buffer64_read(dst_b, 0 + offset*2, heap0);
         let d1 := buffer64_read(dst_b, 1 + offset*2, heap0);
         let d2 := buffer64_read(dst_b, 2 + offset*2, heap0);
-        mul_nats(pow2_two(a0, a1), b) == pow2_six(d0, d1, d2, r12, r14, rax);
+        mul_nats(pow2_two(a0, a1), b) == pow2_six(d0, d1, d2, rbx, r14, rax);
     ensures
         let d0 := buffer64_read(dst_b, 0 + offset*2, heap0);
         let d1 := buffer64_read(dst_b, 1 + offset*2, heap0);
         let d2 := buffer64_read(dst_b, 2 + offset*2, heap0);
         let d3 := buffer64_read(dst_b, 3 + offset*2, heap0);
-        pow2_three(a0, a1, a2) * b == pow2_seven(d0, d1, d2, d3, r12, r14, rax);
+        pow2_three(a0, a1, a2) * b == pow2_seven(d0, d1, d2, d3, rbx, r14, rax);
 
         validSrcAddrs64(heap0, dst_ptr, dst_b, 8 + offset*2, memLayout, Secret);
         modifies_buffer_specific(dst_b, old(heap0), heap0, 0 + offset*2, 8 + offset*2 - 1);
@@ -384,7 +384,7 @@ procedure Fast_multiply_a2b(
     let a0a1b_0 := buffer64_read(dst_b, 0 + offset*2, heap0);
     let a0a1b_1 := buffer64_read(dst_b, 1 + offset*2, heap0);
     let a0a1b_2 := buffer64_read(dst_b, 2 + offset*2, heap0);
-    let a0a1b_3 := r12;
+    let a0a1b_3 := rbx;
     let a0a1b_4 := r14;
     let a0a1b_5 := rax;
     let a0a1b := pow2_six(a0a1b_0, a0a1b_1, a0a1b_2, a0a1b_3, a0a1b_4, a0a1b_5);
@@ -392,8 +392,8 @@ procedure Fast_multiply_a2b(
 //
 //    "movq 16(A), %%rdx; " /* A[2] */
 //    "mulx   (B),  %%r8,  %%r9; " /* A[2]*B[0] */    "xorl %%r10d, %%r10d ;"  "adcx 16(dst), %%r8 ;"    "movq  %%r8, 16(dst) ;"
-//    "mulx  8(B), %%r10, %%r11; " /* A[2]*B[1] */    "adox  %%r9, %%r10 ;"    "adcx %%r12, %%r10 ;"    "movq %%r10, 24(dst) ;"
-//    "mulx 16(B), %%r12, %%r13; " /* A[2]*B[2] */    "adox %%r11, %%r12 ;"    "adcx %%r14, %%r12 ;"                              "movq $0, %%r8  ;"
+//    "mulx  8(B), %%r10, %%r11; " /* A[2]*B[1] */    "adox  %%r9, %%r10 ;"    "adcx %%rbx, %%r10 ;"    "movq %%r10, 24(dst) ;"
+//    "mulx 16(B), %%rbx, %%r13; " /* A[2]*B[2] */    "adox %%r11, %%rbx ;"    "adcx %%r14, %%rbx ;"                              "movq $0, %%r8  ;"
 //    "mulx 24(B), %%r14, %%rdx; " /* A[2]*B[3] */    "adox %%r13, %%r14 ;"    "adcx %%rax, %%r14 ;"                              "movq $0, %%rax ;"
 //    /*******************************************/   "adox %%rdx, %%rax ;"    "adcx  %%r8, %%rax ;"
 
@@ -412,15 +412,15 @@ procedure Fast_multiply_a2b(
     Space(1);
     Adox64Wrap(r10,  r9);  let a2b_1 := r10;
     Space(1);
-    Adcx64Wrap(r10, r12);
+    Adcx64Wrap(r10, rbx);
     Store64_buffer(heap0, dst_ptr, r10, 24 + offset*16, Secret, dst_b, 3 + offset*2);
 
     NoNewline();
-    Mulx64(r13, r12, Mem64(heap0, inB_ptr, 16 + offset * 8, inB_b, 2 + offset, Secret));  /* A[2]*B[2] */ lemma_prod_bounds(r13, r12, a2, b2);  lemma_overflow(r13, r12, r11, bool_bit(overflow(efl)));
+    Mulx64(r13, rbx, Mem64(heap0, inB_ptr, 16 + offset * 8, inB_b, 2 + offset, Secret));  /* A[2]*B[2] */ lemma_prod_bounds(r13, rbx, a2, b2);  lemma_overflow(r13, rbx, r11, bool_bit(overflow(efl)));
     NoNewline();
-    Adox64Wrap(r12, r11);  let a2b_2 := r12;
+    Adox64Wrap(rbx, r11);  let a2b_2 := rbx;
     NoNewline();
-    Adcx64Wrap(r12, r14);
+    Adcx64Wrap(rbx, r14);
     Mov64( r8, 0);
 
     NoNewline();
@@ -448,7 +448,7 @@ procedure Fast_multiply_a2b(
     let d3 := buffer64_read(dst_b, 3 + offset*2, heap0);
 
     let a2b := pow2_five(a2b_0, a2b_1, a2b_2, a2b_3, a2b_4);
-    let a0a1a2b := pow2_seven(d0, d1, d2, d3, r12, r14, rax);
+    let a0a1a2b := pow2_seven(d0, d1, d2, d3, rbx, r14, rax);
 
     assert_by_tactic(a2 * b == 0 + pow2_four(a2 * b0, a2 * b1, a2 * b2, a2 * b3), int_canon);   // PASSES
     //assert a2b == a2 * b;  // PASSES
@@ -457,11 +457,11 @@ procedure Fast_multiply_a2b(
               a0a1b, a0a1b_0, a0a1b_1, a0a1b_2, a0a1b_3, a0a1b_4, a0a1b_5,
               a2b, a2b_0, a2b_1, a2b_2, a2b_3, a2b_4,
               b, b0, b1, b2, b3,
-              d2, d3, r12, r14, rax);
+              d2, d3, rbx, r14, rax);
     //assert pow2_three(a0, a1, a2) * b == a0a1a2b;   // Conclusion from the lemma.  // PASSES
 //    assert d0 == a0a1b_0;       // PASSES
 //    assert d1 == a0a1b_1;       // PASSES
-//    assert pow2_three(a0, a1, a2) * b == pow2_seven(d0, d1, d2, d3, r12, r14, rax);
+//    assert pow2_three(a0, a1, a2) * b == pow2_seven(d0, d1, d2, d3, rbx, r14, rax);
 }
 
 procedure Fast_multiply_a3b(
@@ -492,7 +492,7 @@ procedure Fast_multiply_a3b(
         dst_ptr; inA_ptr; inB_ptr; memLayout;
 
     modifies
-        rax; rdx; r8; r9; r10; r11; r12; r13; r14;
+        rax; rdx; r8; r9; r10; r11; rbx; r13; r14;
         heap0; efl;
 
     requires
@@ -509,7 +509,7 @@ procedure Fast_multiply_a3b(
         let d1 := buffer64_read(dst_b, 1 + offset*2, heap0);
         let d2 := buffer64_read(dst_b, 2 + offset*2, heap0);
         let d3 := buffer64_read(dst_b, 3 + offset*2, heap0);
-        pow2_three(a0, a1, a2) * b == pow2_seven(d0, d1, d2, d3, r12, r14, rax);
+        pow2_three(a0, a1, a2) * b == pow2_seven(d0, d1, d2, d3, rbx, r14, rax);
     ensures
         let d0 := buffer64_read(dst_b, 0 + offset*2, heap0);
         let d1 := buffer64_read(dst_b, 1 + offset*2, heap0);
@@ -531,7 +531,7 @@ procedure Fast_multiply_a3b(
     let a0a1a2b_1 := buffer64_read(dst_b, 1 + offset*2, heap0);
     let a0a1a2b_2 := buffer64_read(dst_b, 2 + offset*2, heap0);
     let a0a1a2b_3 := buffer64_read(dst_b, 3 + offset*2, heap0);
-    let a0a1a2b_4 := r12;
+    let a0a1a2b_4 := rbx;
     let a0a1a2b_5 := r14;
     let a0a1a2b_6 := rax;
     let a0a1a2b := pow2_seven(a0a1a2b_0, a0a1a2b_1, a0a1a2b_2, a0a1a2b_3, a0a1a2b_4, a0a1a2b_5, a0a1a2b_6);
@@ -539,8 +539,8 @@ procedure Fast_multiply_a3b(
 //
 //    "movq 24(A), %%rdx; " /* A[3] */
 //    "mulx   (B),  %%r8,  %%r9; " /* A[3]*B[0] */    "xorl %%r10d, %%r10d ;"  "adcx 24(dst), %%r8 ;"   "movq  %%r8, 24(dst) ;"
-//    "mulx  8(B), %%r10, %%r11; " /* A[3]*B[1] */    "adox  %%r9, %%r10 ;"    "adcx %%r12, %%r10 ;"    "movq %%r10, 32(dst) ;"
-//    "mulx 16(B), %%r12, %%r13; " /* A[3]*B[2] */    "adox %%r11, %%r12 ;"    "adcx %%r14, %%r12 ;"    "movq %%r12, 40(dst) ;"    "movq $0, %%r8  ;"
+//    "mulx  8(B), %%r10, %%r11; " /* A[3]*B[1] */    "adox  %%r9, %%r10 ;"    "adcx %%rbx, %%r10 ;"    "movq %%r10, 32(dst) ;"
+//    "mulx 16(B), %%rbx, %%r13; " /* A[3]*B[2] */    "adox %%r11, %%rbx ;"    "adcx %%r14, %%rbx ;"    "movq %%rbx, 40(dst) ;"    "movq $0, %%r8  ;"
 //    "mulx 24(B), %%r14, %%rdx; " /* A[3]*B[3] */    "adox %%r13, %%r14 ;"    "adcx %%rax, %%r14 ;"    "movq %%r14, 48(dst) ;"    "movq $0, %%rax ;"
 //    /*******************************************/   "adox %%rdx, %%rax ;"    "adcx  %%r8, %%rax ;"    "movq %%rax, 56(dst) ;"
 
@@ -559,17 +559,17 @@ procedure Fast_multiply_a3b(
     Space(1);
     Adox64Wrap(r10,  r9);  let a3b_1 := r10;
     Space(1);
-    Adcx64Wrap(r10, r12);
+    Adcx64Wrap(r10, rbx);
     Store64_buffer(heap0, dst_ptr, r10, 32 + offset*16, Secret, dst_b, 4 + offset*2);
 
     NoNewline(); 
-    Mulx64(r13, r12, Mem64(heap0, inB_ptr, 16 + offset * 8, inB_b, 2 + offset, Secret));  /* A[3]*B[2] */ lemma_prod_bounds(r13, r12, a3, b2);  lemma_overflow(r13, r12, r11, bool_bit(overflow(efl)));
+    Mulx64(r13, rbx, Mem64(heap0, inB_ptr, 16 + offset * 8, inB_b, 2 + offset, Secret));  /* A[3]*B[2] */ lemma_prod_bounds(r13, rbx, a3, b2);  lemma_overflow(r13, rbx, r11, bool_bit(overflow(efl)));
     NoNewline();
-    Adox64Wrap(r12, r11);  let a3b_2 := r12;
+    Adox64Wrap(rbx, r11);  let a3b_2 := rbx;
     NoNewline();
-    Adcx64Wrap(r12, r14);
+    Adcx64Wrap(rbx, r14);
     NoNewline();
-    Store64_buffer(heap0, dst_ptr, r12, 40 + offset * 16, Secret, dst_b, 5 + offset * 2);
+    Store64_buffer(heap0, dst_ptr, rbx, 40 + offset * 16, Secret, dst_b, 5 + offset * 2);
     Mov64( r8, 0);
 
     NoNewline();
@@ -647,7 +647,7 @@ procedure Fast_multiply(
         dst_ptr; inA_ptr; inB_ptr; memLayout;
 
     modifies
-        rax; rdx; r8; r9; r10; r11; r12; r13; r14;
+        rax; rdx; r8; r9; r10; r11; rbx; r13; r14;
         heap0; efl;
 
     requires
@@ -702,7 +702,7 @@ procedure Fast_mul_stdcall(
         inB_in := (if win then r8 else rdx);
     reads memLayout;
     modifies
-        rax; rbx; rcx; rdx; rdi; rsi; r8; r9; r10; r11; r12; r13; r14;
+        rax; rbx; rcx; rdx; rdi; rsi; r8; r9; r10; r11; r13; r14;
         rsp; efl; heap0; stack; stackTaint;
     requires
         rsp == init_rsp(stack);
@@ -748,14 +748,12 @@ procedure Fast_mul_stdcall(
         validSrcAddrs64(heap0, dst_in, dst_b, 8, memLayout, Secret);
 
         rsi == old(rsi);
-        r12 == old(r12);
         r13 == old(r13);
         r14 == old(r14);
         rsp == old(rsp);
 {
     // Store callee-save registers
     Push(rsi);
-    Push(r12);
     Push(r13);
     Push(r14);
 
@@ -775,7 +773,6 @@ procedure Fast_mul_stdcall(
 
     Pop(r14);
     Pop(r13);
-    Pop(r12);
     Pop(rsi);
 }
 
@@ -793,7 +790,7 @@ procedure Fast_mul2_stdcall(
         inB_in := (if win then r8 else rdx);
     reads memLayout;
     modifies
-        rax; rbx; rcx; rdx; rdi; rsi; r8; r9; r10; r11; r12; r13; r14;
+        rax; rbx; rcx; rdx; rdi; rsi; r8; r9; r10; r11; r13; r14;
         rsp; efl; heap0; stack; stackTaint;
     requires
         rsp == init_rsp(stack);
@@ -865,13 +862,11 @@ procedure Fast_mul2_stdcall(
         validSrcAddrs64(heap0, dst_in, dst_b, 16, memLayout, Secret);
 
         rsi == old(rsi);
-        r12 == old(r12);
         r13 == old(r13);
         r14 == old(r14);
         rsp == old(rsp);
 {
     // Store callee-save registers
-    Push(r12);
     Push(r13);
     Push(r14);
 
@@ -897,5 +892,4 @@ procedure Fast_mul2_stdcall(
     }
     Pop(r14);
     Pop(r13);
-    Pop(r12);
 }

--- a/vale/code/thirdPartyPorts/rfc7748/curve25519/x64/Vale.Curve25519.X64.FastSqr.vaf
+++ b/vale/code/thirdPartyPorts/rfc7748/curve25519/x64/Vale.Curve25519.X64.FastSqr.vaf
@@ -68,7 +68,7 @@ procedure Fast_sqr_part1(inline offset:nat, ghost inA_b:buffer64)
         inA_ptr; heap0; memLayout;
 
     modifies
-        rax; rcx; rdx; r8; r9; r10; r11; r12; r13; r14; r15;
+        rax; rcx; rdx; r8; r9; r10; r11; rbx; r13; r14; r15;
         efl;
 
     requires
@@ -78,7 +78,7 @@ procedure Fast_sqr_part1(inline offset:nat, ghost inA_b:buffer64)
         validSrcAddrs64(heap0, inA_ptr, inA_b, 4 + offset, memLayout, Secret);
 
     ensures
-        pow2_six(r8, r9, r10, r11, r12, r13) ==
+        pow2_six(r8, r9, r10, r11, rbx, r13) ==
         pow2_five(mul_nats(a0,a1), mul_nats(a0,a2), mul_nats(a0,a3), mul_nats(a1,a3), mul_nats(a2,a3));
 
         pow2_64 * rcx + rax == a1 * a2;
@@ -92,8 +92,8 @@ procedure Fast_sqr_part1(inline offset:nat, ghost inA_b:buffer64)
 //    "mulx 16(%1),  %%r9, %%r10 ;" /* A[2]*A[0] */  "adcx %%r14,  %%r9 ;"
 //    "mulx 24(%1), %%rax, %%rcx ;" /* A[3]*A[0] */  "adcx %%rax, %%r10 ;"
 //    "movq 24(%1), %%rdx        ;" /* A[3]      */
-//    "mulx  8(%1), %%r11, %%r12 ;" /* A[1]*A[3] */  "adcx %%rcx, %%r11 ;"
-//    "mulx 16(%1), %%rax, %%r13 ;" /* A[2]*A[3] */  "adcx %%rax, %%r12 ;"
+//    "mulx  8(%1), %%r11, %%rbx ;" /* A[1]*A[3] */  "adcx %%rcx, %%r11 ;"
+//    "mulx 16(%1), %%rax, %%r13 ;" /* A[2]*A[3] */  "adcx %%rax, %%rbx ;"
 //    "movq  8(%1), %%rdx        ;" /* A[1]      */  "adcx %%r15, %%r13 ;"
 //    "mulx 16(%1), %%rax, %%rcx ;" /* A[2]*A[1] */  "movq    $0, %%r14 ;"
 //    /*******************************************/  "adcx %%r15, %%r14 ;"
@@ -116,10 +116,10 @@ procedure Fast_sqr_part1(inline offset:nat, ghost inA_b:buffer64)
     Space(34); Comment("f[3]");
 
     NoNewline();
-    Mulx64(r12, r11, Mem64(heap0, inA_ptr, 8 + offset * 8, inA_b, 1 + offset, Secret));  /* A[3]*A[1] */ lemma_prod_bounds(r12, r11, a3, a1); Space(1); Adcx64Wrap(r11, rcx); Comment("f[1]*f[3]");
+    Mulx64(rbx, r11, Mem64(heap0, inA_ptr, 8 + offset * 8, inA_b, 1 + offset, Secret));  /* A[3]*A[1] */ lemma_prod_bounds(rbx, r11, a3, a1); Space(1); Adcx64Wrap(r11, rcx); Comment("f[1]*f[3]");
 
     NoNewline();
-    Mulx64(r13, rax, Mem64(heap0, inA_ptr, 16 + offset * 8, inA_b, 2 + offset, Secret));  /* A[3]*A[2] */ lemma_prod_bounds(r13, rax, a3, a2);  NoNewline(); Adcx64Wrap(r12, rax); Comment("f[2]*f[3]");
+    Mulx64(r13, rax, Mem64(heap0, inA_ptr, 16 + offset * 8, inA_b, 2 + offset, Secret));  /* A[3]*A[2] */ lemma_prod_bounds(r13, rax, a3, a2);  NoNewline(); Adcx64Wrap(rbx, rax); Comment("f[2]*f[3]");
 
     NoNewline();
     Load64_buffer(heap0, rdx, inA_ptr, 8 + offset * 8, Secret, inA_b, 1 + offset);     /* A[1] */
@@ -174,7 +174,7 @@ procedure Fast_sqr_part2()
         rax; rcx;
 
     modifies
-        r8; r9; r10; r11; r12; r13; r14; r15;
+        r8; r9; r10; r11; rbx; r13; r14; r15;
         efl;
 
     requires
@@ -182,22 +182,22 @@ procedure Fast_sqr_part2()
         r14 == 0;
 
     ensures
-        pow2_seven(r8, r9, r10, r11, r12, r13, r14) ==
-        old(pow2_six(2*r8, 2*r9, 2*(r10 + rax), 2*(r11+rcx), 2*r12, 2*r13));
+        pow2_seven(r8, r9, r10, r11, rbx, r13, r14) ==
+        old(pow2_six(2*r8, 2*r9, 2*(r10 + rax), 2*(r11+rcx), 2*rbx, 2*r13));
 
         r14 <= 2;
 {
     xor_lemmas();
-    lemma_fast_sqr_part2(r8, r9, r10, r11, r12, r13, rax, rcx);
+    lemma_fast_sqr_part2(r8, r9, r10, r11, rbx, r13, rax, rcx);
 
     Xor64(r15, r15);
     reveal_flags(efl);
 
     Adox_64(r10, rax);     Adcx_64(r8, r8);
     Adox_64(r11, rcx);     Adcx_64(r9, r9);
-    Adox_64(r12, r15);     Adcx_64(r10, r10);
+    Adox_64(rbx, r15);     Adcx_64(r10, r10);
     Adox_64(r13, r15);     Adcx_64(r11, r11);
-    Adox_64(r14, r15);     Adcx_64(r12, r12);
+    Adox_64(r14, r15);     Adcx_64(rbx, rbx);
     Adcx_64(r13, r13);     Adcx_64(r14, r14);
 }
 
@@ -219,7 +219,7 @@ procedure Fast_sqr_part3(inline offset:nat, ghost dst_b:buffer64, ghost inA_b:bu
         dst_ptr; inA_ptr; memLayout;
 
     modifies
-        rax; rcx; rdx; r8; r9; r10; r11; r12; r13; r14; r15;
+        rax; rcx; rdx; r8; r9; r10; r11; rbx; r13; r14; r15;
         heap0; efl;
 
     requires
@@ -243,7 +243,7 @@ procedure Fast_sqr_part3(inline offset:nat, ghost dst_b:buffer64, ghost inA_b:bu
         let d7 := buffer64_read(dst_b, 7 + offset*2, heap0);
 
         pow2_nine(d0, d1, d2, d3, d4, d5, d6, d7, bool_bit(cf(efl))) ==
-        old(pow2_eight(mul_nats(a0,a0), r8, mul_nats(a1,a1) + r9, r10, mul_nats(a2,a2) + r11, r12, mul_nats(a3,a3) + r13, r14));
+        old(pow2_eight(mul_nats(a0,a0), r8, mul_nats(a1,a1) + r9, r10, mul_nats(a2,a2) + r11, rbx, mul_nats(a3,a3) + r13, r14));
 
         validSrcAddrs64(heap0, dst_ptr, dst_b, 8 + offset*2, memLayout, Secret);
         modifies_buffer_specific(dst_b, old(heap0), heap0, 0 + offset*2, 8 + offset*2 - 1);
@@ -258,7 +258,7 @@ procedure Fast_sqr_part3(inline offset:nat, ghost dst_b:buffer64, ghost inA_b:bu
 //    "adcq %%rcx, %%r10 ;"   "movq %%r10, 24(%0) ;"
 //    "movq 16(%1), %%rdx ;"  "mulx %%rdx, %%rax, %%rcx ;" /* A[2]^2 */
 //    "adcq %%rax, %%r11 ;"   "movq %%r11, 32(%0) ;"
-//    "adcq %%rcx, %%r12 ;"   "movq %%r12, 40(%0) ;"
+//    "adcq %%rcx, %%rbx ;"   "movq %%rbx, 40(%0) ;"
 //    "movq 24(%1), %%rdx ;"  "mulx %%rdx, %%rax, %%rcx ;" /* A[3]^2 */
 //    "adcq %%rax, %%r13 ;"   "movq %%r13, 48(%0) ;"
 //    "adcq %%rcx, %%r14 ;"   "movq %%r14, 56(%0) ;"
@@ -287,7 +287,7 @@ procedure Fast_sqr_part3(inline offset:nat, ghost dst_b:buffer64, ghost inA_b:bu
     Adcx64Wrap(r11, rax);   Space(1);                    Store64_buffer(heap0, dst_ptr, r11, 32 + offset * 16, Secret, dst_b, 4 + offset * 2);
     Newline();
     NoNewline();
-    Adcx64Wrap(r12, rcx);   Space(1);                    Store64_buffer(heap0, dst_ptr, r12, 40 + offset * 16, Secret, dst_b, 5 + offset * 2);
+    Adcx64Wrap(rbx, rcx);   Space(1);                    Store64_buffer(heap0, dst_ptr, rbx, 40 + offset * 16, Secret, dst_b, 5 + offset * 2);
     Newline();
     NoNewline();
     Load64_buffer(heap0, rdx, inA_ptr, 24 + offset * 8, Secret, inA_b, 3 + offset); NoNewline();  Mulx64(rcx, rax, rdx);  /* A[3]^2 */  Comment("f[3]^2");
@@ -301,7 +301,7 @@ procedure Fast_sqr_part3(inline offset:nat, ghost dst_b:buffer64, ghost inA_b:bu
     Newline();
 
     lemma_sqr_part3(a, a0, a1, a2, a3, a0_sqr_hi, a0_sqr_lo, a1_sqr_hi, a1_sqr_lo, a2_sqr_hi, a2_sqr_lo, a3_sqr_hi, a3_sqr_lo,
-                    old(r8), old(r9), old(r10), old(r11), old(r12), old(r13), old(r14),
+                    old(r8), old(r9), old(r10), old(r11), old(rbx), old(r13), old(r14),
                     buffer64_read(dst_b, 0 + offset*2, heap0),
                     buffer64_read(dst_b, 1 + offset*2, heap0),
                     buffer64_read(dst_b, 2 + offset*2, heap0),
@@ -331,7 +331,7 @@ procedure Fast_sqr(inline offset:nat, ghost dst_b:buffer64, ghost inA_b:buffer64
         dst_ptr; inA_ptr; memLayout;
 
     modifies
-        rax; rcx; rdx; r8; r9; r10; r11; r12; r13; r14; r15;
+        rax; rbx; rcx; rdx; r8; r9; r10; r11; r13; r14; r15;
         heap0; efl;
 
     requires
@@ -375,7 +375,7 @@ procedure Fast_sqr(inline offset:nat, ghost dst_b:buffer64, ghost inA_b:buffer64
     let old_r9  := r9;
     let old_r10 := r10;
     let old_r11 := r11;
-    let old_r12 := r12;
+    let old_rbx := rbx;
     let old_r13 := r13;
     let old_rax := rax;
     let old_rcx := rcx;
@@ -388,7 +388,7 @@ procedure Fast_sqr(inline offset:nat, ghost dst_b:buffer64, ghost inA_b:buffer64
     let mid_r9  := r9;
     let mid_r10 := r10;
     let mid_r11 := r11;
-    let mid_r12 := r12;
+    let mid_rbx := rbx;
     let mid_r13 := r13;
     let mid_r14 := r14;
 
@@ -405,8 +405,8 @@ procedure Fast_sqr(inline offset:nat, ghost dst_b:buffer64, ghost inA_b:buffer64
     let d6 := buffer64_read(dst_b, 6 + offset*2, heap0);
     let d7 := buffer64_read(dst_b, 7 + offset*2, heap0);
     lemma_sqr(a, a0, a1, a2, a3,
-              old_r8, old_r9, old_r10, old_r11, old_r12, old_r13, old_rax, old_rcx,
-              mid_r8, mid_r9, mid_r10, mid_r11, mid_r12, mid_r13, mid_r14,
+              old_r8, old_r9, old_r10, old_r11, old_rbx, old_r13, old_rax, old_rcx,
+              mid_r8, mid_r9, mid_r10, mid_r11, mid_rbx, mid_r13, mid_r14,
               d0, d1, d2, d3, d4, d5, d6, d7, bool_bit(cf(efl)));
 }
 
@@ -419,7 +419,7 @@ procedure Fast_sqr_stdcall(inline win:bool, ghost dst_b:buffer64, ghost inA_b:bu
         inA_in := (if win then rdx else rsi);
     reads memLayout;
     modifies
-        rax; rbx; rcx; rdx; rdi; rsi; r8; r9; r10; r11; r12; r13; r14; r15;
+        rax; rbx; rcx; rdx; rdi; rsi; r8; r9; r10; r11; r13; r14; r15;
         rsp; efl; heap0; stack; stackTaint;
     requires
         rsp == init_rsp(stack);
@@ -458,7 +458,6 @@ procedure Fast_sqr_stdcall(inline win:bool, ghost dst_b:buffer64, ghost inA_b:bu
 
         rbx == old(rbx);
         rsi == old(rsi);
-        r12 == old(r12);
         r13 == old(r13);
         r14 == old(r14);
         r15 == old(r15);
@@ -466,8 +465,8 @@ procedure Fast_sqr_stdcall(inline win:bool, ghost dst_b:buffer64, ghost inA_b:bu
 {
     // Store callee-save registers
     Push(r15);
+    Push(rbx);
     Push(rsi);
-    Push(r12);
     Push(r13);
     Push(r14);
 
@@ -482,8 +481,8 @@ procedure Fast_sqr_stdcall(inline win:bool, ghost dst_b:buffer64, ghost inA_b:bu
 
     Pop(r14);
     Pop(r13);
-    Pop(r12);
     Pop(rsi);
+    Pop(rbx);
     Pop(r15);
 }
 
@@ -505,7 +504,7 @@ procedure Fast_sqr_loop(inline offset:nat, ghost dst_b:buffer64, ghost inA_b:buf
         dst_ptr; inA_ptr; memLayout;
 
     modifies
-        rax; rbx; rcx; rdx; r8; r9; r10; r11; r12; r13; r14; r15;
+        rax; rbx; rcx; rdx; r8; r9; r10; r11; rbx; r13; r14; r15;
         heap0; efl;
 
     requires
@@ -560,7 +559,7 @@ procedure Fast_sqr_loop_stdcall(inline win:bool, ghost dst_b:buffer64, ghost inA
         count_in := (if win then  r8 else rdx);
     reads memLayout;
     modifies
-        rax; rbx; rcx; rdx; rdi; rsi; r8; r9; r10; r11; r12; r13; r14; r15;
+        rax; rbx; rcx; rdx; rdi; rsi; r8; r9; r10; r11; r13; r14; r15;
         rsp; efl; heap0; stack; stackTaint;
     requires
         rsp == init_rsp(stack);
@@ -599,7 +598,6 @@ procedure Fast_sqr_loop_stdcall(inline win:bool, ghost dst_b:buffer64, ghost inA
 
         rbx == old(rbx);
         rsi == old(rsi);
-        r12 == old(r12);
         r13 == old(r13);
         r14 == old(r14);
         r15 == old(r15);
@@ -609,7 +607,6 @@ procedure Fast_sqr_loop_stdcall(inline win:bool, ghost dst_b:buffer64, ghost inA
     Push(rbx);
     Push(r15);
     Push(rsi);
-    Push(r12);
     Push(r13);
     Push(r14);
 
@@ -629,7 +626,6 @@ procedure Fast_sqr_loop_stdcall(inline win:bool, ghost dst_b:buffer64, ghost inA
 
     Pop(r14);
     Pop(r13);
-    Pop(r12);
     Pop(rsi);
     Pop(r15);
     Pop(rbx);
@@ -645,7 +641,7 @@ procedure Sqr2_stdcall(inline win:bool, ghost dst_b:buffer64, ghost inA_b:buffer
         inA_in := (if win then rdx else rsi);
     reads memLayout;
     modifies
-        rax; rbx; rcx; rdx; rdi; rsi; r8; r9; r10; r11; r12; r13; r14; r15;
+        rax; rbx; rcx; rdx; rdi; rsi; r8; r9; r10; r11; r13; r14; r15;
         rsp; efl; heap0; stack; stackTaint;
     requires
         rsp == init_rsp(stack);
@@ -684,7 +680,6 @@ procedure Sqr2_stdcall(inline win:bool, ghost dst_b:buffer64, ghost inA_b:buffer
 
         rbx == old(rbx);
         rsi == old(rsi);
-        r12 == old(r12);
         r13 == old(r13);
         r14 == old(r14);
         r15 == old(r15);
@@ -692,9 +687,9 @@ procedure Sqr2_stdcall(inline win:bool, ghost dst_b:buffer64, ghost inA_b:buffer
 {
     // Store callee-save registers
     Push(r15);
-    Push(r12);
     Push(r13);
     Push(r14);
+    Push(rbx);
 
     // Line up the rest of the arguments
     inline if (win)
@@ -712,8 +707,8 @@ procedure Sqr2_stdcall(inline win:bool, ghost dst_b:buffer64, ghost inA_b:buffer
         Pop(rsi);
     }
 
+    Pop(rbx);
     Pop(r14);
     Pop(r13);
-    Pop(r12);
     Pop(r15);
 }

--- a/vale/code/thirdPartyPorts/rfc7748/curve25519/x64/Vale.Curve25519.X64.FastUtil.vaf
+++ b/vale/code/thirdPartyPorts/rfc7748/curve25519/x64/Vale.Curve25519.X64.FastUtil.vaf
@@ -67,7 +67,7 @@ procedure Fast_mul1(ghost dst_b:buffer64, ghost inA_b:buffer64)
         dst_ptr; inA_ptr; b; memLayout;
 
     modifies
-        rax; r8; r9; r10; r11; r12; r13; r14;
+        rax; r8; r9; r10; r11; rbx; r13; r14;
         heap0; efl;
 
     requires
@@ -96,9 +96,9 @@ procedure Fast_mul1(ghost dst_b:buffer64, ghost inA_b:buffer64)
     Mulx64(r11, r10, Mem64(heap0, inA_ptr,  8, inA_b, 1, Secret));  /* A[1]*B */ lemma_prod_bounds(r11, r10, b, a1);
     Add64Wrap(r10, r9);
     Store64_buffer(heap0, dst_ptr, r10,  8, Secret, dst_b, 1);
-    Mulx64(r13, r12, Mem64(heap0, inA_ptr, 16, inA_b, 2, Secret));  /* A[2]*B */ lemma_prod_bounds(r13, r12, b, a2);
-    Adcx64Wrap(r12, r11);
-    Store64_buffer(heap0, dst_ptr, r12, 16, Secret, dst_b, 2);
+    Mulx64(r13, rbx, Mem64(heap0, inA_ptr, 16, inA_b, 2, Secret));  /* A[2]*B */ lemma_prod_bounds(r13, rbx, b, a2);
+    Adcx64Wrap(rbx, r11);
+    Store64_buffer(heap0, dst_ptr, rbx, 16, Secret, dst_b, 2);
     Mulx64(rax, r14, Mem64(heap0, inA_ptr, 24, inA_b, 3, Secret));  /* A[3]*B */ lemma_prod_bounds(rax, r14, b, a3);
     Adcx64Wrap(r14, r13);
     Store64_buffer(heap0, dst_ptr, r14, 24, Secret, dst_b, 3);
@@ -121,7 +121,7 @@ procedure Fast_mul1_stdcall(inline win:bool, ghost dst_b:buffer64, ghost inA_b:b
         inB_in := (if win then r8  else rdx);
     reads memLayout;
     modifies
-        rax; rbx; rcx; rdx; rdi; rsi; r8; r9; r10; r11; r12; r13; r14; r15;
+        rax; rbx; rcx; rdx; rdi; rsi; r8; r9; r10; r11; r13; r14; r15;
         rsp; efl; heap0;
     requires
         adx_enabled && bmi2_enabled;
@@ -154,14 +154,12 @@ procedure Fast_mul1_stdcall(inline win:bool, ghost dst_b:buffer64, ghost inA_b:b
 
         rbx == old(rbx);
         rsi == old(rsi);
-        r12 == old(r12);
         r13 == old(r13);
         r14 == old(r14);
         rsp == old(rsp);
 {
     // Store callee-save registers
     Push(rsi);
-    Push(r12);
     Push(r13);
     Push(r14);
 
@@ -177,7 +175,6 @@ procedure Fast_mul1_stdcall(inline win:bool, ghost dst_b:buffer64, ghost inA_b:b
 
     Pop(r14);
     Pop(r13);
-    Pop(r12);
     Pop(rsi);
 }
 */
@@ -271,7 +268,7 @@ procedure Fast_add1_stdcall(
         dst_in := (if win then rcx else rdi);
         inA_in := (if win then rdx else rsi);
     modifies
-        rax; rbx; rcx; rdx; rsi; rdi; rbp; rsp; r8; r9; r10; r11; r12; r13; r14; r15;
+        rax; rbx; rcx; rdx; rsi; rdi; rbp; rsp; r8; r9; r10; r11; r13; r14; r15;
         efl; heap0; memLayout; stack; stackTaint;
     requires
         rsp == init_rsp(stack);
@@ -311,13 +308,11 @@ procedure Fast_add1_stdcall(
         win ==>  rdi == old(rdi);
         win ==>  rsi == old(rsi);
         win ==>  rsp == old(rsp);
-        win ==>  r12 == old(r12);
         win ==>  r13 == old(r13);
         win ==>  r14 == old(r14);
         win ==>  r15 == old(r15);
         !win ==>  rbx == old(rbx);
         !win ==>  rbp == old(rbp);
-        !win ==>  r12 == old(r12);
         !win ==>  r13 == old(r13);
         !win ==>  r14 == old(r14);
         !win ==>  r15 == old(r15);
@@ -420,7 +415,7 @@ procedure Fast_sub1_stdcall(inline win:bool, ghost dst_b:buffer64, ghost inA_b:b
         inB_in := (if win then r8  else rdx);
     reads memLayout;
     modifies
-        rax; rbx; rcx; rdx; rdi; rsi; r8; r9; r10; r11; r12; r13; r14; r15;
+        rax; rbx; rcx; rdx; rdi; rsi; r8; r9; r10; r11; r13; r14; r15;
         rsp; efl; heap0; stack;
     requires
         rsp == init_rsp(stack);
@@ -454,7 +449,6 @@ procedure Fast_sub1_stdcall(inline win:bool, ghost dst_b:buffer64, ghost inA_b:b
 
         rbx == old(rbx);
         rsi == old(rsi);
-        r12 == old(r12);
         r13 == old(r13);
         r14 == old(r14);
         rsp == old(rsp);
@@ -501,7 +495,7 @@ procedure Fast_add(ghost dst_b:buffer64, ghost inA_b:buffer64, ghost inB_b:buffe
         dst_ptr; inA_ptr; inB_ptr; memLayout;
 
     modifies
-        rax; r8; r9; r10; r11; r12;
+        rax; r8; r9; r10; r11; rbx;
         heap0; efl;
 
     requires
@@ -540,9 +534,9 @@ procedure Fast_add(ghost dst_b:buffer64, ghost inA_b:buffer64, ghost inB_b:buffe
     Adcx64Wrap(r11, Mem64(heap0, inA_ptr, 16, inA_b, 2, Secret));
     Store64_buffer(heap0, dst_ptr, r11, 16, Secret, dst_b, 2);
 
-    Load64_buffer(heap0, r12, inB_ptr, 24, Secret, inB_b, 3);     /* B[3] */
-    Adcx64Wrap(r12, Mem64(heap0, inA_ptr, 24, inA_b, 3, Secret));
-    Store64_buffer(heap0, dst_ptr, r12, 24, Secret, dst_b, 3);
+    Load64_buffer(heap0, rbx, inB_ptr, 24, Secret, inB_b, 3);     /* B[3] */
+    Adcx64Wrap(rbx, Mem64(heap0, inA_ptr, 24, inA_b, 3, Secret));
+    Store64_buffer(heap0, dst_ptr, rbx, 24, Secret, dst_b, 3);
 
     Adcx64Wrap(rax, r8);
 }
@@ -564,7 +558,7 @@ procedure Fast_add_stdcall(
         inB_in := (if win then r8 else rdx);
     reads memLayout;
     modifies
-        rax; rbx; rcx; rdx; rdi; rsi; r8; r9; r10; r11; r12; r13; r14;
+        rax; rbx; rcx; rdx; rdi; rsi; r8; r9; r10; r11; r13; r14;
         rsp; efl; heap0; stack;
     requires
         rsp == init_rsp(stack);
@@ -605,14 +599,12 @@ procedure Fast_add_stdcall(
         validSrcAddrs64(heap0, dst_in, dst_b, 4, memLayout, Secret);
 
         rsi == old(rsi);
-        r12 == old(r12);
         r13 == old(r13);
         r14 == old(r14);
         rsp == old(rsp);
 {
     // Store callee-save registers
     Push(rsi);
-    Push(r12);
 
     // Line up the rest of the arguments
     inline if (win)
@@ -628,7 +620,6 @@ procedure Fast_add_stdcall(
 
     Fast_add(dst_b, inA_b, inB_b);
 
-    Pop(r12);
     Pop(rsi);
 }
 */
@@ -732,7 +723,7 @@ procedure Fast_sub_stdcall(
         inB_in := (if win then r8 else rdx);
     reads memLayout;
     modifies
-        rax; rbx; rcx; rdx; rdi; rsi; r8; r9; r10; r11; r12; r13; r14;
+        rax; rbx; rcx; rdx; rdi; rsi; r8; r9; r10; r11; r13; r14;
         rsp; efl; heap0; stack;
     requires
         rsp == init_rsp(stack);
@@ -773,14 +764,12 @@ procedure Fast_sub_stdcall(
         validSrcAddrs64(heap0, dst_in, dst_b, 4, memLayout, Secret);
 
         rsi == old(rsi);
-        r12 == old(r12);
         r13 == old(r13);
         r14 == old(r14);
         rsp == old(rsp);
 {
     // Store callee-save registers
     Push(rsi);
-    Push(r12);
 
     // Line up the rest of the arguments
     inline if (win)
@@ -796,7 +785,6 @@ procedure Fast_sub_stdcall(
 
     Fast_sub(dst_b, inA_b, inB_b);
 
-    Pop(r12);
     Pop(rsi);
 }
 */

--- a/vale/code/thirdPartyPorts/rfc7748/curve25519/x64/Vale.Curve25519.X64.FastWide.vaf
+++ b/vale/code/thirdPartyPorts/rfc7748/curve25519/x64/Vale.Curve25519.X64.FastWide.vaf
@@ -70,7 +70,7 @@ procedure Fmul(
         dst_in := r15;
         inB_in := rcx;
     modifies
-        rax; rcx; rdx; rdi; rsi; r8; r9; r10; r11; r12; r13; r14; r15;
+        rax; rbx; rcx; rdx; rdi; rsi; r8; r9; r10; r11; r13; r14; r15;
         efl; heap0; memLayout;
     requires
         adx_enabled && bmi2_enabled;
@@ -149,7 +149,7 @@ procedure Fmul_stdcall(
         dst_in := (if win then r8  else rdx);
         inB_in := (if win then r9  else rcx);
     modifies
-        rax; rbx; rcx; rdx; rsi; rdi; rbp; rsp; r8; r9; r10; r11; r12; r13; r14; r15;
+        rax; rbx; rcx; rdx; rsi; rdi; rbp; rsp; r8; r9; r10; r11; r13; r14; r15;
         efl; heap0; memLayout; stack; stackTaint;
     requires
         rsp == init_rsp(stack);
@@ -199,23 +199,21 @@ procedure Fmul_stdcall(
         win ==>  rdi == old(rdi);
         win ==>  rsi == old(rsi);
         win ==>  rsp == old(rsp);
-        win ==>  r12 == old(r12);
         win ==>  r13 == old(r13);
         win ==>  r14 == old(r14);
         win ==>  r15 == old(r15);
         !win ==>  rbx == old(rbx);
         !win ==>  rbp == old(rbp);
-        !win ==>  r12 == old(r12);
         !win ==>  r13 == old(r13);
         !win ==>  r14 == old(r14);
         !win ==>  r15 == old(r15);
 
         rsp == old(rsp);
 {
-    Push_Secret(r12);
     Push_Secret(r13);
     Push_Secret(r14);
     Push_Secret(r15);
+    Push_Secret(rbx);
 
     // Line up the rest of the arguments
     inline if (win)
@@ -242,10 +240,10 @@ procedure Fmul_stdcall(
         Pop_Secret(rsi);
     }
 
+    Pop_Secret(rbx);
     Pop_Secret(r15);
     Pop_Secret(r14);
     Pop_Secret(r13);
-    Pop_Secret(r12);
 }
 
 procedure Fmul2(
@@ -263,7 +261,7 @@ procedure Fmul2(
         dst_in := r15;
         inB_in := rcx;
     modifies
-        rax; rcx; rdx; rdi; rsi; r8; r9; r10; r11; r12; r13; r14; r15;
+        rax; rbx; rcx; rdx; rdi; rsi; r8; r9; r10; r11; r13; r14; r15;
         efl; heap0; memLayout;
     requires
         adx_enabled && bmi2_enabled;
@@ -367,7 +365,7 @@ procedure Fmul2_stdcall(
         dst_in := (if win then r8  else rdx);
         inB_in := (if win then r9  else rcx);
     modifies
-        rax; rbx; rcx; rdx; rsi; rdi; rbp; rsp; r8; r9; r10; r11; r12; r13; r14; r15;
+        rax; rbx; rcx; rdx; rsi; rdi; rbp; rsp; r8; r9; r10; r11; r13; r14; r15;
         efl; heap0; memLayout; stack; stackTaint;
     requires
         rsp == init_rsp(stack);
@@ -439,23 +437,21 @@ procedure Fmul2_stdcall(
         win ==>  rdi == old(rdi);
         win ==>  rsi == old(rsi);
         win ==>  rsp == old(rsp);
-        win ==>  r12 == old(r12);
         win ==>  r13 == old(r13);
         win ==>  r14 == old(r14);
         win ==>  r15 == old(r15);
         !win ==>  rbx == old(rbx);
         !win ==>  rbp == old(rbp);
-        !win ==>  r12 == old(r12);
         !win ==>  r13 == old(r13);
         !win ==>  r14 == old(r14);
         !win ==>  r15 == old(r15);
 
         rsp == old(rsp);
 {
-    Push_Secret(r12);
     Push_Secret(r13);
     Push_Secret(r14);
     Push_Secret(r15);
+    Push_Secret(rbx);
 
     // Line up the rest of the arguments
     inline if (win)
@@ -482,10 +478,10 @@ procedure Fmul2_stdcall(
         Pop_Secret(rsi);
     }
 
+    Pop_Secret(rbx);
     Pop_Secret(r15);
     Pop_Secret(r14);
     Pop_Secret(r13);
-    Pop_Secret(r12);
 }
 
 procedure Fsqr(ghost tmp_b:buffer64, ghost inA_b:buffer64, ghost dst_b:buffer64)
@@ -493,10 +489,10 @@ procedure Fsqr(ghost tmp_b:buffer64, ghost inA_b:buffer64, ghost dst_b:buffer64)
     {:quick}
     {:exportSpecs}
     lets
-        tmp_ptr @= rdi; inA_ptr @= rsi; dst_ptr @= rbx;
+        tmp_ptr @= rdi; inA_ptr @= rsi; dst_ptr @= r12;
         tmp_in := rdi;
         inA_in := rsi;
-        dst_in := rbx;
+        dst_in := r12;
     modifies
         rax; rbx; rcx; rdx; rdi; rsi; r8; r9; r10; r11; r12; r13; r14; r15;
         efl; heap0; memLayout;
@@ -531,6 +527,8 @@ procedure Fsqr(ghost tmp_b:buffer64, ghost inA_b:buffer64, ghost dst_b:buffer64)
         //   Framing
         //////////////////////////////////////
 
+        old(r12) == r12;
+
         modifies_buffer_2(dst_b, tmp_b, old(mem), mem);
 
 {
@@ -545,7 +543,7 @@ procedure Fsqr(ghost tmp_b:buffer64, ghost inA_b:buffer64, ghost dst_b:buffer64)
     Newline();
     Comment("Line up pointers");
     Mov64(inA_ptr, tmp_ptr);
-    Mov64(rdi, rbx);
+    Mov64(rdi, r12);
 
     LargeComment("Wrap the result back into the field");
     Carry_wide(0, dst_b, tmp_b);
@@ -563,7 +561,7 @@ procedure Fsqr_stdcall(
     {:quick}
     {:exportSpecs}
     lets
-        tmp_ptr @= rdi; inA_ptr @= rsi; dst_ptr @= rbx;
+        tmp_ptr @= rdi; inA_ptr @= rsi; dst_ptr @= r12;
         tmp_in := (if win then rcx else rdi);
         inA_in := (if win then rdx else rsi);
         dst_in := (if win then r8  else rdx);
@@ -624,9 +622,9 @@ procedure Fsqr_stdcall(
         rsp == old(rsp);
 {
     Push_Secret(r15);
-    Push_Secret(r12);
     Push_Secret(r13);
     Push_Secret(r14);
+    Push_Secret(r12);
     Push_Secret(rbx);
 
     // Line up the rest of the arguments
@@ -654,9 +652,9 @@ procedure Fsqr_stdcall(
     }
 
     Pop_Secret(rbx);
+    Pop_Secret(r12);
     Pop_Secret(r14);
     Pop_Secret(r13);
-    Pop_Secret(r12);
     Pop_Secret(r15);
 }
 
@@ -665,10 +663,10 @@ procedure Fsqr2(ghost tmp_b:buffer64, ghost inA_b:buffer64, ghost dst_b:buffer64
     {:quick}
     {:exportSpecs}
     lets
-        tmp_ptr @= rdi; inA_ptr @= rsi; dst_ptr @= rbx;
+        tmp_ptr @= rdi; inA_ptr @= rsi; dst_ptr @= r12;
         tmp_in := rdi;
         inA_in := rsi;
-        dst_in := rbx;
+        dst_in := r12;
     modifies
         rax; rbx; rcx; rdx; rdi; rsi; r8; r9; r10; r11; r12; r13; r14; r15;
         efl; heap0; memLayout;
@@ -714,6 +712,8 @@ procedure Fsqr2(ghost tmp_b:buffer64, ghost inA_b:buffer64, ghost dst_b:buffer64
         //   Framing
         //////////////////////////////////////
 
+        old(r12) == r12;
+
         modifies_buffer_2(dst_b, tmp_b, old(mem), mem);
 {
     CreateHeaplets(list(
@@ -727,7 +727,7 @@ procedure Fsqr2(ghost tmp_b:buffer64, ghost inA_b:buffer64, ghost dst_b:buffer64
     Newline();
     Comment("Line up pointers");
     Mov64(inA_ptr, tmp_ptr);
-    Mov64(rdi, rbx);
+    Mov64(rdi, r12);
     Newline();
     Carry_wide(0, dst_b, tmp_b);
     Newline();
@@ -746,7 +746,7 @@ procedure Fsqr2_stdcall(
     {:quick}
     {:exportSpecs}
     lets
-        tmp_ptr @= rdi; inA_ptr @= rsi; dst_ptr @= rbx;
+        tmp_ptr @= rdi; inA_ptr @= rsi; dst_ptr @= r12;
         tmp_in := (if win then rcx else rdi);
         inA_in := (if win then rdx else rsi);
         dst_in := (if win then r8  else rdx);
@@ -818,9 +818,9 @@ procedure Fsqr2_stdcall(
         rsp == old(rsp);
 {
     Push_Secret(r15);
-    Push_Secret(r12);
     Push_Secret(r13);
     Push_Secret(r14);
+    Push_Secret(r12);
     Push_Secret(rbx);
 
     // Line up the rest of the arguments
@@ -848,9 +848,9 @@ procedure Fsqr2_stdcall(
     }
 
     Pop_Secret(rbx);
+    Pop_Secret(r12);
     Pop_Secret(r14);
     Pop_Secret(r13);
-    Pop_Secret(r12);
     Pop_Secret(r15);
 }
 
@@ -871,7 +871,7 @@ procedure Fsqr_loop_stdcall(
         count_in := (if win then r9  else rcx);
     reads memLayout;
     modifies
-        rax; rbx; rcx; rdx; rdi; rsi; r8; r9; r10; r11; r12; r13; r14; r15;
+        rax; rbx; rcx; rdx; rdi; rsi; r8; r9; r10; r11; r13; r14; r15;
         rbp; rsp; efl; heap0; stack;
     requires
         rsp == init_rsp(stack);
@@ -911,7 +911,6 @@ procedure Fsqr_loop_stdcall(
         validSrcAddrs64(mem, dst_in, dst_b, 4, memLayout, Secret);
 
         win ==> rsi == old(rsi);
-        r12 == old(r12);
         r13 == old(r13);
         r14 == old(r14);
         r15 == old(r15);
@@ -922,7 +921,6 @@ procedure Fsqr_loop_stdcall(
     Push(rbp);
     Push(rbx);
     Push(r15);
-    Push(r12);
     Push(r13);
     Push(r14);
 
@@ -995,7 +993,6 @@ procedure Fsqr_loop_stdcall(
 
     Pop(r14);
     Pop(r13);
-    Pop(r12);
     Pop(r15);
     Pop(rbx);
     Pop(rbp);


### PR DESCRIPTION
This PR optimises the Curve code with inline assembly by using R12 instead of Rbx in Vale, following changes in Wireguard:
https://git.zx2c4.com/wireguard-linux-compat/commit/?id=118398c1c6540d44a070266cf3a39c5077775c8e

I included one generated .h file to compare the diff to master with the diff to Wireguard.