### PR TITLE
Use failwith in Vale assembly printer to avoid tricky corner cases leading to gcc bugs

### DIFF
--- a/vale/code/test/Vale.Test.TestInline.fst
+++ b/vale/code/test/Vale.Test.TestInline.fst
@@ -82,13 +82,14 @@ let test_inline_mov_mul_inputs () : FStar.All.ML unit =
   let c = Block [
     Ins (make_instr ins_Mov64 (OReg rRax) (OReg rRbx));
     Ins (make_instr ins_Mov64 (OReg rRcx) (OReg rR15));
-    Ins (make_instr ins_Mul64 (OReg rRcx));
+    Ins (make_instr ins_IMul64 (OReg rRax) (OReg rRcx));
     ] in
   print_function "test_inline_mov_mul_inputs" (Some "result") args regs_mod c
 
 // This test generates the correct inline assembly code, but only works with gcc >= 9
 // On prior versions, gcc ignores the register asm("rax") annotation, and does not correctly
 // allocate the output "result" into register rax
+(*
 let test_inline_mov_add_input_dummy_mul () : FStar.All.ML unit =
   let args = [
     ("first_arg", TD_Base TUInt64, rR15);
@@ -101,6 +102,7 @@ let test_inline_mov_add_input_dummy_mul () : FStar.All.ML unit =
     Ins (make_instr ins_Add64 (OReg rRax) (OConst 1));
     ] in
   print_function "test_inline_mov_add_input_dummy_mul" (Some "result") args regs_mod c
+*)
 
 let test_inline_comment_add () : FStar.All.ML unit =
   let args = [

--- a/vale/code/test/Vale.Test.TestInline.fst
+++ b/vale/code/test/Vale.Test.TestInline.fst
@@ -51,33 +51,36 @@ let test_inline_mov_add_input () : FStar.All.ML unit =
 
 let test_inline_mul_inputs () : FStar.All.ML unit =
   let args = [
-    ("first_arg", TD_Base TUInt64, rRax);
+    ("first_arg", TD_Base TUInt64, rRbx);
     ("second_arg", TD_Base TUInt64, rR15);
     ] in
   let regs_mod r = (r = rRax || r = rRdx) in
   let c = Block [
-    Ins (make_instr ins_Mul64 (OReg rR15));
+    Ins (make_instr ins_Mov64 (OReg rRax) (OReg rRbx));
+    Ins (make_instr ins_IMul64 (OReg rRax) (OReg rR15));
     ] in
   print_function "test_inline_mul_inputs" (Some "result") args regs_mod c
 
 let test_inline_mov_mul_rax_100 () : FStar.All.ML unit =
   let args = [
-    ("first_arg", TD_Base TUInt64, rRax);
+    ("first_arg", TD_Base TUInt64, rRbx);
     ] in
   let regs_mod r = (r = rRax || r = rRcx || r = rRdx) in
   let c = Block [
+    Ins (make_instr ins_Mov64 (OReg rRax) (OReg rRbx));
     Ins (make_instr ins_Mov64 (OReg rRcx) (OConst 100));
-    Ins (make_instr ins_Mul64 (OReg rRcx));
+    Ins (make_instr ins_IMul64 (OReg rRax) (OReg rRcx));
     ] in
   print_function "test_inline_mov_mul_rax_100" (Some "result") args regs_mod c
 
 let test_inline_mov_mul_inputs () : FStar.All.ML unit =
   let args = [
-    ("first_arg", TD_Base TUInt64, rRax);
+    ("first_arg", TD_Base TUInt64, rRbx);
     ("second_arg", TD_Base TUInt64, rR15);
     ] in
   let regs_mod r = (r = rRax || r = rRcx || r = rRdx) in
   let c = Block [
+    Ins (make_instr ins_Mov64 (OReg rRax) (OReg rRbx));
     Ins (make_instr ins_Mov64 (OReg rRcx) (OReg rR15));
     Ins (make_instr ins_Mul64 (OReg rRcx));
     ] in
@@ -147,7 +150,8 @@ let test_inline () : FStar.All.ML unit =
   test_inline_mul_inputs ();
   test_inline_mov_mul_rax_100 ();
   test_inline_mov_mul_inputs ();
-  test_inline_mov_add_input_dummy_mul ();
+// This test leads (rightfully) to a failure in the printer due to a gcc bug
+//  test_inline_mov_add_input_dummy_mul ();
   test_inline_comment_add ();
   test_inline_same_line ();
   test_inline_same_line_newline ();

--- a/vale/specs/hardware/Vale.X64.Print_Inline_s.fst
+++ b/vale/specs/hardware/Vale.X64.Print_Inline_s.fst
@@ -342,7 +342,7 @@ let print_inline
 
   let inputs_use_rax = uses_rax args 0 of_arg in
   if reserved_regs rRax && Some? ret_val then
-    FStar.All.failwith "We require the annotation register uint64_t result(rax), but it would be ignored by gcc < 9" 
+    FStar.All.failwith "We require the annotation register uint64_t result(rax), but it would be ignored by gcc < 9"; 
 
   if inputs_use_rax && Some? ret_val then
     FStar.All.failwith "inputs are not allowed to be passed in rax when there is a return argument";

--- a/vale/specs/hardware/Vale.X64.Print_Inline_s.fst
+++ b/vale/specs/hardware/Vale.X64.Print_Inline_s.fst
@@ -213,11 +213,10 @@ let print_explicit_register_arg (n:nat) (a:td) (i:nat{i < n}) (of_arg:reg_nat n 
     true, "  register " ^ ty ^ names i ^ "_r asm(\"" ^ P.print_reg_name (of_arg i) ^ "\") = " ^ names i ^ ";\n"
   else false, ""
 
-
 let rec print_explicit_register_args (n:nat) (args:list td) (i:nat{i + List.length args = n}) (of_arg:reg_nat n -> reg_64) (reserved:reg_64 -> bool) (names:nat -> string) =
   match args with
   | [] -> false, ""
-  | a::q -> 
+  | a::q ->
     let was_explicit, explicit_str = print_explicit_register_arg n a i of_arg reserved names in
     let are_explicit, rest_str = print_explicit_register_args n q (i+1) of_arg reserved names in
     was_explicit || are_explicit, explicit_str ^ rest_str
@@ -319,6 +318,12 @@ and remove_blanks (b:codes) : codes =
     )
   | c :: cs -> c :: remove_blanks cs
 
+// Check if any argument is passed in the rax register
+let rec uses_rax (#n:nat) (args:list td) (i:nat{i + List.length args = n}) (of_arg:reg_nat n -> reg_64) =
+  match args with
+  | [] -> false
+  | a::q -> if of_arg i = rRax then true else uses_rax q (i+1) of_arg
+
 let print_inline
   (name:string)
   (label:int)
@@ -334,6 +339,11 @@ let print_inline
   let comments = print_fn_comments fn_comments in
 
   let reserved_regs = build_reserved_args code (fun _ -> false) in
+
+  let inputs_use_rax = uses_rax args 0 of_arg in
+  if inputs_use_rax && Some? ret_val then
+    FStar.All.failwith "inputs are not allowed to be passed in rax when there is a return argument";
+
 
   // Signature: static inline (void | uint64_t) [name] (arg1, arg2???) {
   let header = "static inline " ^ print_rettype ret_val ^ " " ^ name ^ " (" ^ print_args args 0 arg_names ^ ") \n{\n" in

--- a/vale/specs/hardware/Vale.X64.Print_Inline_s.fst
+++ b/vale/specs/hardware/Vale.X64.Print_Inline_s.fst
@@ -341,6 +341,9 @@ let print_inline
   let reserved_regs = build_reserved_args code (fun _ -> false) in
 
   let inputs_use_rax = uses_rax args 0 of_arg in
+  if reserved_regs rRax && Some? ret_val then
+    FStar.All.failwith "We require the annotation register uint64_t result(rax), but it would be ignored by gcc < 9" 
+
   if inputs_use_rax && Some? ret_val then
     FStar.All.failwith "inputs are not allowed to be passed in rax when there is a return argument";
 


### PR DESCRIPTION
As discussed on Slack, this PR rules out corner cases in Vale inline assembly that would lead to bugs in gcc < 9.
The printer now fails if:
* We try to pass an argument in Rax while also expecting an output argument (leading to a possible register allocation clash as both want to be in Rax to preserve verification guarantees)
* The Rax register is implicitly used (for instance by a Mul instruction), and we have an output. This leads to generating the annotation `register uint64_t result("rax");` which is wrongfully ignored by gcc < 9.
We currently do not encounter any of these cases in our existing Curve inline code.