### PR TITLE
Fix HACL code following issue #1940 on F*

### DIFF
--- a/code/curve25519/Hacl.Impl.Curve25519.Field64.Vale.fst
+++ b/code/curve25519/Hacl.Impl.Curve25519.Field64.Vale.fst
@@ -144,6 +144,7 @@ let fmul out f1 f2 tmp =
   ) else
     Vale.Wrapper.X64.Fmul.fmul_e (sub tmp 0ul 8ul) f1 out f2
 
+#push-options "--z3rlimit 500"
 [@ CInline]
 let fmul2 out f1 f2 tmp =
   let h0 = ST.get() in
@@ -153,6 +154,7 @@ let fmul2 out f1 f2 tmp =
     Vale.Inline.X64.Fmul_inline.fmul2 out f1 f2 tmp
   else
     Vale.Wrapper.X64.Fmul.fmul2_e tmp f1 out f2
+#pop-options
 
 [@ CInline]
 let fmul_scalar out f1 f2 =

--- a/code/curve25519/Hacl.Impl.Curve25519.Fields.Core.fsti
+++ b/code/curve25519/Hacl.Impl.Curve25519.Fields.Core.fsti
@@ -252,17 +252,17 @@ let fmul2_t (s:field_spec) (p: Type0) =
   -> tmp:felem_wide2 s
   -> Stack unit
     (requires fun h ->
-      p /\
+     p /\
       live h out /\ live h f1 /\ live h f2 /\ live h tmp /\
-      (disjoint out f1 \/ out == f1) /\
-      (disjoint out f2 \/ out == f2) /\
-      (disjoint out tmp \/ out == tmp) /\
+      (disjoint out f1) /\
+      (disjoint out f2) /\
+      (disjoint out tmp) /\
       (disjoint f1 f2 \/ f1 == f2) /\
       disjoint f1 tmp /\
       disjoint f2 tmp /\
       fmul2_pre h f1 f2)
     (ensures  fun h0 _ h1 ->
-      modifies (loc out |+| loc tmp) h0 h1 /\ fmul2_fsqr2_post h1 out /\
+     modifies (loc out |+| loc tmp) h0 h1 /\ fmul2_fsqr2_post h1 out /\
      (let out0 = gsub out 0ul (nlimb s) in
       let out1 = gsub out (nlimb s) (nlimb s) in
       let f10 = gsub f1 0ul (nlimb s) in
@@ -350,7 +350,7 @@ let fsqr2_t (s:field_spec) (p: Type0) =
       p /\
       live h out /\ live h f /\ live h tmp /\
       (disjoint out f \/ out == f) /\
-      (disjoint out tmp \/ out == tmp) /\
+      (disjoint out tmp) /\
       disjoint tmp f /\
       fsqr2_pre h f)
     (ensures  fun h0 _ h1 ->

--- a/code/curve25519/Hacl.Impl.Curve25519.Fields.Core.fsti
+++ b/code/curve25519/Hacl.Impl.Curve25519.Fields.Core.fsti
@@ -254,8 +254,8 @@ let fmul2_t (s:field_spec) (p: Type0) =
     (requires fun h ->
      p /\
       live h out /\ live h f1 /\ live h f2 /\ live h tmp /\
-      (disjoint out f1) /\
-      (disjoint out f2) /\
+      (disjoint out f1 \/ out == f1) /\
+      (disjoint out f2 \/ out == f2) /\
       (disjoint out tmp) /\
       (disjoint f1 f2 \/ f1 == f2) /\
       disjoint f1 tmp /\

--- a/code/curve25519/Hacl.Impl.Curve25519.Finv.fst
+++ b/code/curve25519/Hacl.Impl.Curve25519.Finv.fst
@@ -35,7 +35,7 @@ val fsqr_s:
     (requires fun h ->
       live h out /\ live h f1 /\ live h tmp /\
       (disjoint out f1 \/ out == f1) /\
-      (disjoint out tmp \/ out == tmp) /\
+      (disjoint out tmp) /\
       disjoint tmp f1 /\
       fsquare_times_inv h f1)
     (ensures  fun h0 _ h1 ->
@@ -64,7 +64,7 @@ val fmul_s:
       live h out /\ live h f1 /\ live h f2 /\ live h tmp /\
       (disjoint out f1 \/ out == f1) /\
       (disjoint out f2 \/ out == f2) /\
-      (disjoint out tmp \/ out == tmp) /\
+      (disjoint out tmp) /\
       (disjoint f1 f2 \/ f1 == f2) /\
       disjoint f1 tmp /\
       disjoint f2 tmp /\
@@ -182,7 +182,7 @@ val finv:
     (requires fun h0 ->
       live h0 o /\ live h0 i /\ live h0 tmp /\
       disjoint o i /\ disjoint i tmp /\
-      (disjoint o tmp \/ o == tmp) /\
+      (disjoint o tmp) /\
       fsquare_times_inv h0 i)
     (ensures  fun h0 _ h1 ->
       modifies (loc o |+| loc tmp) h0 h1 /\


### PR DESCRIPTION
Small fixes were required following F* issue 1940, removing preconditions that should have been equivalent to False, but not detected.