### PR TITLE
Work around FStarLang/FStar#1651

### DIFF
--- a/Makefile.common
+++ b/Makefile.common
@@ -40,7 +40,11 @@ OUTPUT_DIR ?= obj
 
 FSTAR_INCLUDES = $(addprefix --include ,$(INCLUDES))
 
+ifeq ($(OTHERFLAGS),$(subst --admit_smt_queries true,,$(OTHERFLAGS)))
 FSTAR_HINTS ?= --use_hints --use_hint_hashes --record_hints
+else
+FSTAR_HINTS ?= --use_hints --use_hint_hashes
+endif
 
 # --trivial_pre_for_unannotated_effectful_fns false
 #   to not enforce trivial preconditions


### PR DESCRIPTION
If you are running with `OTHERFLAGS="--admit_smt_queries true"`, F* will still record empty hints, a known issue. This attempts to work around it to limit the amount of frustration related to hint churn, the need to reset and checkout hints when pulling, etc.