### PR TITLE
lib: PrintSequence: remove dec_pad printing functions

### DIFF
--- a/lib/Lib.PrintSequence.fst
+++ b/lib/Lib.PrintSequence.fst
@@ -18,9 +18,6 @@ let print_nat8_hex_pad x =
 let print_nat8_dec x =
   IO.print_uint8_dec (u8_to_UInt8 (u8 x))
 
-let print_nat8_dec_pad x =
-  IO.print_uint8_dec_pad (u8_to_UInt8 (u8 x))
-
 
 let print_nat32_hex x =
   IO.print_uint32 (u32_to_UInt32 (u32 x))
@@ -30,9 +27,6 @@ let print_nat32_hex_pad x =
 
 let print_nat32_dec x =
   IO.print_uint32_dec (u32_to_UInt32 (u32 x))
-
-let print_nat32_dec_pad x =
-  IO.print_uint32_dec_pad (u32_to_UInt32 (u32 x))
 
 
 let print_nat64_hex x =
@@ -44,9 +38,6 @@ let print_nat64_hex_pad x =
 let print_nat64_dec x =
   IO.print_uint64_dec (u64_to_UInt64 (u64 x))
 
-let print_nat64_dec_pad x =
-  IO.print_uint64_dec_pad (u64_to_UInt64 (u64 x))
-
 
 let print_uint8_hex x =
   IO.print_uint8 (u8_to_UInt8 x)
@@ -56,9 +47,6 @@ let print_uint8_hex_pad x =
 
 let print_uint8_dec x =
   IO.print_uint8_dec (u8_to_UInt8 x)
-
-let print_uint8_dec_pad x =
-  IO.print_uint8_dec_pad (u8_to_UInt8 x)
 
 
 let print_uint32_hex x =
@@ -70,9 +58,6 @@ let print_uint32_hex_pad x =
 let print_uint32_dec x =
   IO.print_uint32_dec (u32_to_UInt32 x)
 
-let print_uint32_dec_pad x =
-  IO.print_uint32_dec_pad (u32_to_UInt32 x)
-
 
 let print_uint64_hex x =
   IO.print_uint64 (u64_to_UInt64 x)
@@ -82,9 +67,6 @@ let print_uint64_hex_pad x =
 
 let print_uint64_dec x =
   IO.print_uint64_dec (u64_to_UInt64 x)
-
-let print_uint64_dec_pad x =
-  IO.print_uint64_dec_pad (u64_to_UInt64 x)
 
 
 let print_label_nat64 flag s x =

--- a/lib/Lib.PrintSequence.fsti
+++ b/lib/Lib.PrintSequence.fsti
@@ -12,33 +12,27 @@ open Lib.LoopCombinators
 val print_nat8_hex: x:nat{x <= maxint U8} -> FStar.All.ML unit
 val print_nat8_hex_pad: x:nat{x <= maxint U8} -> FStar.All.ML unit
 val print_nat8_dec: x:nat{x <= maxint U8} -> FStar.All.ML unit
-val print_nat8_dec_pad: x:nat{x <= maxint U8} -> FStar.All.ML unit
 
 val print_nat32_hex: x:nat{x <= maxint U32} -> FStar.All.ML unit
 val print_nat32_hex_pad: x:nat{x <= maxint U32} -> FStar.All.ML unit
 val print_nat32_dec: x:nat{x <= maxint U32} -> FStar.All.ML unit
-val print_nat32_dec_pad: x:nat{x <= maxint U32} -> FStar.All.ML unit
 
 val print_nat64_hex: x:nat{x <= maxint U64} -> FStar.All.ML unit
 val print_nat64_hex_pad: x:nat{x <= maxint U64} -> FStar.All.ML unit
 val print_nat64_dec: x:nat{x <= maxint U64} -> FStar.All.ML unit
-val print_nat64_dec_pad: x:nat{x <= maxint U64} -> FStar.All.ML unit
 
 
 val print_uint8_hex: uint8 -> FStar.All.ML unit
 val print_uint8_hex_pad: uint8 -> FStar.All.ML unit
 val print_uint8_dec: uint8 -> FStar.All.ML unit
-val print_uint8_dec_pad: uint8 -> FStar.All.ML unit
 
 val print_uint32_hex: uint32 -> FStar.All.ML unit
 val print_uint32_hex_pad: uint32 -> FStar.All.ML unit
 val print_uint32_dec: uint32 -> FStar.All.ML unit
-val print_uint32_dec_pad: uint32 -> FStar.All.ML unit
 
 val print_uint64_hex: uint64 -> FStar.All.ML unit
 val print_uint64_hex_pad: uint64 -> FStar.All.ML unit
 val print_uint64_dec: uint64 -> FStar.All.ML unit
-val print_uint64_dec_pad: uint64 -> FStar.All.ML unit
 
 
 val print_label_nat64: display:bool -> string -> x:nat{x <= maxint U64} -> FStar.All.ML unit


### PR DESCRIPTION
These will no longer be exported by F*, and were not behaving well in any case (they were not fixed-width). They do not seem to be used anywhere besides defining these wrappers.