### PR TITLE
Anticipate fixing FStarLang/FStar#1905

### DIFF
--- a/Makefile.common
+++ b/Makefile.common
@@ -40,7 +40,11 @@ OUTPUT_DIR ?= obj
 
 FSTAR_INCLUDES = $(addprefix --include ,$(INCLUDES))
 
+ifeq ($(OTHERFLAGS),$(subst --admit_smt_queries true,,$(OTHERFLAGS)))
 FSTAR_HINTS ?= --use_hints --use_hint_hashes --record_hints
+else
+FSTAR_HINTS ?= --use_hints --use_hint_hashes
+endif
 
 # --trivial_pre_for_unannotated_effectful_fns false
 #   to not enforce trivial preconditions

--- a/code/curve25519/Hacl.Spec.Curve25519.Finv.fst
+++ b/code/curve25519/Hacl.Spec.Curve25519.Finv.fst
@@ -12,7 +12,7 @@ let one:elem =
   assert_norm (1 < prime);
   1
 
-val pow: a:elem -> b:nat -> res:elem
+val pow: a:elem -> b:nat -> elem
 let rec pow a b =
   if b = 0 then 1
   else fmul a (pow a (b - 1))

--- a/code/hash/Hacl.Hash.Core.SHA1.fst
+++ b/code/hash/Hacl.Hash.Core.SHA1.fst
@@ -52,7 +52,7 @@ let legacy_init s =
   )
 
 inline_for_extraction
-let w_t = (b: B.lbuffer (word SHA1) 80)
+let w_t = B.lbuffer (word SHA1) 80
 
 inline_for_extraction
 let block_t = (block: B.buffer uint8 { B.length block == block_length SHA1 } )

--- a/code/poly1305/Hacl.Poly1305.Field32xN.Lemmas1.fst
+++ b/code/poly1305/Hacl.Poly1305.Field32xN.Lemmas1.fst
@@ -904,7 +904,7 @@ let carry_reduce_lemma_i #w l cin i =
   FStar.Math.Lemmas.pow2_minus 32 26
 
 
-#push-options "--z3rlimit 200"
+#push-options "--z3rlimit 400"
 val carry_reduce_felem5_fits_lemma_i0:
     #w:lanes
   -> f:felem5 w{acc_inv_t f}

--- a/code/poly1305/Hacl.Poly1305.Field32xN.Lemmas1.fst
+++ b/code/poly1305/Hacl.Poly1305.Field32xN.Lemmas1.fst
@@ -56,7 +56,7 @@ let vec_smul_mod_five #w f =
 
 
 noextract
-val carry_wide_felem5_compact: #w:lanes -> inp:felem_wide5 w -> out:felem5 w
+val carry_wide_felem5_compact: #w:lanes -> inp:felem_wide5 w -> felem5 w
 let carry_wide_felem5_compact #w (x0, x1, x2, x3, x4) =
   // m_i <= 4096, x_i <= m_i * max26 * max26
   // felem_wide_fits5 (x0, x1, x2, x3, x4) (m0, m1, m2, m3, m4)

--- a/code/poly1305/Hacl.Spec.Poly1305.Field32xN.fst
+++ b/code/poly1305/Hacl.Spec.Poly1305.Field32xN.fst
@@ -199,7 +199,7 @@ inline_for_extraction noextract
 val precomp_r5:
     #w:lanes
   -> r:felem5 w
-  -> r5:felem5 w
+  -> felem5 w
 let precomp_r5 #w (r0, r1, r2, r3, r4) =
   [@inline_let]
   let r50 = vec_smul_mod r0 (u64 5) in
@@ -218,7 +218,7 @@ val fadd5:
     #w:lanes
   -> f1:felem5 w
   -> f2:felem5 w
-  -> out:felem5 w
+  -> felem5 w
 let fadd5 #w (f10, f11, f12, f13, f14) (f20, f21, f22, f23, f24) =
   [@inline_let]
   let o0 = f10 +| f20 in
@@ -237,7 +237,7 @@ val smul_felem5:
     #w:lanes
   -> u1:uint64xN w
   -> f2:felem5 w
-  -> out:felem_wide5 w
+  -> felem_wide5 w
 let smul_felem5 #w u1 (f20, f21, f22, f23, f24) =
   [@inline_let]
   let o0 = vec_mul_mod f20 u1 in
@@ -257,7 +257,7 @@ val smul_add_felem5:
   -> u1:uint64xN w
   -> f2:felem5 w
   -> acc1:felem_wide5 w
-  -> acc2:felem_wide5 w
+  -> felem_wide5 w
 let smul_add_felem5 #w u1 (f20, f21, f22, f23, f24) (o0, o1, o2, o3, o4) =
   [@inline_let]
   let o0 = vec_add_mod o0 (vec_mul_mod f20 u1) in
@@ -277,7 +277,7 @@ val mul_felem5:
   -> f1:felem5 w
   -> r:felem5 w
   -> r5:felem5 w
-  -> out:felem_wide5 w
+  -> felem_wide5 w
 let mul_felem5 #w (f10,f11,f12,f13,f14) (r0,r1,r2,r3,r4) (r50,r51,r52,r53,r54) =
   let (a0,a1,a2,a3,a4) = smul_felem5 #w f10 (r0,r1,r2,r3,r4) in
   let (a0,a1,a2,a3,a4) = smul_add_felem5 #w f11 (r54,r0,r1,r2,r3) (a0,a1,a2,a3,a4) in
@@ -301,7 +301,7 @@ inline_for_extraction noextract
 val carry_full_felem5:
     #w:lanes
   -> inp:felem5 w
-  -> out:felem5 w
+  -> felem5 w
 let carry_full_felem5 #w (f0, f1, f2, f3, f4) =
   let tmp0,c0 = carry26 f0 (zero w) in
   let tmp1,c1 = carry26 f1 c0 in
@@ -317,7 +317,7 @@ inline_for_extraction noextract
 val subtract_p5:
     #w:lanes
   -> f:felem5 w
-  -> out:felem5 w
+  -> felem5 w
 let subtract_p5 #w (f0, f1, f2, f3, f4) =
   let mh = vec_load (u64 0x3ffffff) w in
   let ml = vec_load (u64 0x3fffffb) w in
@@ -339,7 +339,7 @@ inline_for_extraction noextract
 val reduce_felem5:
     #w:lanes
   -> f:felem5 w
-  -> out:felem5 w
+  -> felem5 w
 let reduce_felem5 #w (f0, f1, f2, f3, f4) =
   let (f0, f1, f2, f3, f4) = carry_full_felem5 (f0, f1, f2, f3, f4) in
   let (f0, f1, f2, f3, f4) = carry_full_felem5 (f0, f1, f2, f3, f4) in
@@ -350,7 +350,7 @@ val load_felem5:
     #w:lanes
   -> lo:uint64xN w
   -> hi:uint64xN w
-  -> f:felem5 w
+  -> felem5 w
 let load_felem5 #w lo hi =
   let f0 = vec_and lo (mask26 w) in
   let f1 = vec_and (vec_shift_right lo 26ul) (mask26 w) in
@@ -361,7 +361,7 @@ let load_felem5 #w lo hi =
 
 
 inline_for_extraction noextract
-val load_felem5_4: lo:uint64xN 4 -> hi:uint64xN 4 -> f:felem5 4
+val load_felem5_4: lo:uint64xN 4 -> hi:uint64xN 4 -> felem5 4
 let load_felem5_4 lo hi =
   let mask26 = mask26 4 in
   let m0 = vec_interleave_low_n 2 lo hi in
@@ -385,7 +385,7 @@ inline_for_extraction noextract
 val load_acc5_2:
     f:felem5 2
   -> e:felem5 2
-  -> out:felem5 2
+  -> felem5 2
 let load_acc5_2 (f0, f1, f2, f3, f4) (e0, e1, e2, e3, e4) =
   let f0 = vec_set f0 1ul (u64 0) in
   let f1 = vec_set f1 1ul (u64 0) in
@@ -399,7 +399,7 @@ inline_for_extraction noextract
 val load_acc5_4:
     f:felem5 4
   -> e:felem5 4
-  -> out:felem5 4
+  -> felem5 4
 let load_acc5_4 (f0, f1, f2, f3, f4) (e0, e1, e2, e3, e4) =
   let (r0, r1, r2, r3, r4) = (zero 4, zero 4, zero 4, zero 4, zero 4) in
   let r0 = vec_set r0 0ul (vec_get f0 0ul) in
@@ -433,7 +433,7 @@ inline_for_extraction noextract
 val carry_wide_felem5:
     #w:lanes
   -> inp:felem_wide5 w
-  -> out:felem5 w
+  -> felem5 w
 let carry_wide_felem5 #w (x0, x1, x2, x3, x4) =
   let mask26 = mask26 w in
   let z0 = vec_shift_right x0 26ul in
@@ -476,7 +476,7 @@ val fmul_r5:
   -> f1:felem5 w
   -> r:felem5 w
   -> r5:felem5 w
-  -> out:felem5 w
+  -> felem5 w
 let fmul_r5 #w (f10, f11, f12, f13, f14) (r0, r1, r2, r3, r4) (r50, r51, r52, r53, r54) =
   let (t0, t1, t2, t3, t4) = mul_felem5 (f10, f11, f12, f13, f14) (r0, r1, r2, r3, r4) (r50, r51, r52, r53, r54) in
   carry_wide_felem5 (t0, t1, t2, t3, t4)
@@ -488,7 +488,7 @@ val fadd_mul_r5:
   -> f1:felem5 w
   -> r:felem5 w
   -> r5:felem5 w
-  -> out:felem5 w
+  -> felem5 w
 let fadd_mul_r5 #w (a0, a1, a2, a3, a4) (f10, f11, f12, f13, f14) (r0, r1, r2, r3, r4) (r50, r51, r52, r53, r54) =
   let (a0, a1, a2, a3, a4) = fadd5 (a0, a1, a2, a3, a4) (f10, f11, f12, f13, f14) in
   let (t0, t1, t2, t3, t4) = mul_felem5 (a0, a1, a2, a3, a4) (r0, r1, r2, r3, r4) (r50, r51, r52, r53, r54) in
@@ -500,7 +500,7 @@ val fmul_rn5:
   -> f1:felem5 w
   -> rn:felem5 w
   -> rn5:felem5 w
-  -> out:felem5 w
+  -> felem5 w
 let fmul_rn5 #w (f10, f11, f12, f13, f14) (rn0, rn1, rn2, rn3, rn4) (rn50, rn51, rn52, rn53, rn54) =
   let (t0, t1, t2, t3, t4) = mul_felem5 (f10, f11, f12, f13, f14) (rn0, rn1, rn2, rn3, rn4) (rn50, rn51, rn52, rn53, rn54) in
   carry_wide_felem5 (t0, t1, t2, t3, t4)
@@ -510,7 +510,7 @@ val fmul_r2_normalize5:
     acc:felem5 2
   -> r:felem5 2
   -> r2:felem5 2
-  -> out:felem5 2
+  -> felem5 2
 let fmul_r2_normalize5 (a0, a1, a2, a3, a4) (r0, r1, r2, r3, r4) (r20, r21, r22, r23, r24) =
   let r20 = vec_interleave_low r20 r0 in
   let r21 = vec_interleave_low r21 r1 in
@@ -534,7 +534,7 @@ val fmul_r4_normalize5:
   -> r:felem5 4
   -> r_5:felem5 4
   -> r4:felem5 4
-  -> out:felem5 4
+  -> felem5 4
 let fmul_r4_normalize5 (a0, a1, a2, a3, a4) (r10, r11, r12, r13, r14) (r150, r151, r152, r153, r154) (r40, r41, r42, r43, r44) =
   let (r20, r21, r22, r23, r24) = fmul_r5 (r10, r11, r12, r13, r14) (r10, r11, r12, r13, r14) (r150, r151, r152, r153, r154) in
   let (r30, r31, r32, r33, r34) = fmul_r5 (r20, r21, r22, r23, r24) (r10, r11, r12, r13, r14) (r150, r151, r152, r153, r154) in
@@ -588,7 +588,7 @@ val set_bit5:
     #w:lanes
   -> f:lseq (uint64xN w) 5
   -> i:size_nat{i <= 128}
-  -> out:lseq (uint64xN w) 5
+  -> lseq (uint64xN w) 5
 let set_bit5 #w f i =
   let b = u64 1 <<. size (i % 26) in
   let mask = vec_load b w in

--- a/hints/EverCrypt.Hash.Incremental.fst.hints
+++ b/hints/EverCrypt.Hash.Incremental.fst.hints
@@ -1,5 +1,5 @@
 [
-  "\u0004žçAŽ\u0000×rËé\u0013g.øÐË",
+  "Ÿ<œ\u001aN?1>¦÷0“GˆJ¥",
   [
     [
       "EverCrypt.Hash.Incremental.bytes_any_hash_fits",
@@ -29,7 +29,7 @@
         "refinement_interpretation_Tm_refine_1431b33da4c1d2104e0028c47aa83434"
       ],
       0,
-      "6075ccdfabb2a6d2578afac3791ef421"
+      "e84cfc99656674e75fcc530c8e670f27"
     ],
     [
       "EverCrypt.Hash.Incremental.any_hash_t_fits",
@@ -59,7 +59,7 @@
         "refinement_interpretation_Tm_refine_bbb9361d0a9731d5c29a69af24da18c7"
       ],
       0,
-      "50588d56401ad27c01ed296192da0704"
+      "5ce38bbfd123c2495014990fb196b320"
     ],
     [
       "EverCrypt.Hash.Incremental.uu___8",
@@ -68,7 +68,7 @@
       0,
       [ "@query" ],
       0,
-      "bb2a7b62e6bf05cb27dc0c768af40c56"
+      "de86604fe64ea2bd1ba7f267200eb55e"
     ],
     [
       "EverCrypt.Hash.Incremental.loc_includes_union_l_footprint_s",
@@ -77,7 +77,7 @@
       0,
       [ "@query" ],
       0,
-      "ba83dd4a31c1ea57c1e0d4d8b75c6a9b"
+      "d11a4193e9f8598b5afff83806be2731"
     ],
     [
       "EverCrypt.Hash.Incremental.split_at_last",
@@ -87,17 +87,15 @@
       [
         "@MaxIFuel_assumption", "@query",
         "constructor_distinct_FStar.Integers.W16",
-        "constructor_distinct_FStar.Integers.W31",
         "constructor_distinct_FStar.Integers.W32",
-        "constructor_distinct_FStar.Integers.W63",
+        "constructor_distinct_FStar.Integers.W64",
         "constructor_distinct_FStar.Integers.W8",
         "constructor_distinct_Lib.IntTypes.U1",
         "constructor_distinct_Lib.IntTypes.U128",
         "constructor_distinct_Lib.IntTypes.U64",
         "equality_tok_FStar.Integers.W16@tok",
-        "equality_tok_FStar.Integers.W31@tok",
         "equality_tok_FStar.Integers.W32@tok",
-        "equality_tok_FStar.Integers.W63@tok",
+        "equality_tok_FStar.Integers.W64@tok",
         "equality_tok_FStar.Integers.W8@tok",
         "equation_FStar.Pervasives.inversion",
         "equation_FStar.Seq.Properties.split", "equation_Lib.IntTypes.uint8",
@@ -134,7 +132,7 @@
         "typing_FStar.Seq.Base.append", "typing_FStar.Seq.Base.length"
       ],
       0,
-      "a3e2787de8ae6f17bfea989e3017c143"
+      "256d99156edb4a3872eb538dc5577467"
     ],
     [
       "EverCrypt.Hash.Incremental.invariant_s",
@@ -168,7 +166,7 @@
         "typing_LowStar.Buffer.trivial_preorder"
       ],
       0,
-      "de41d98113f2545e12835567a1441fbc"
+      "8837280bb505135e085c401fb3f48db6"
     ],
     [
       "EverCrypt.Hash.Incremental.invariant",
@@ -183,7 +181,7 @@
         "refinement_interpretation_Tm_refine_573cfed777dae20cc82e8fef9622857e"
       ],
       0,
-      "f6266df169a24206004544a7c92a4eb7"
+      "cb8a8da0816bae45453df6109082e8fe"
     ],
     [
       "EverCrypt.Hash.Incremental.invariant_loc_in_footprint",
@@ -228,7 +226,7 @@
         "typing_LowStar.Monotonic.Buffer.loc_not_unused_in"
       ],
       0,
-      "04513972ddf89174ef2790cbc7c9c020"
+      "314446e797742a456464cd7294fd83a5"
     ],
     [
       "EverCrypt.Hash.Incremental.hash_fits",
@@ -252,7 +250,7 @@
         "projection_inverse_BoxInt_proj_0"
       ],
       0,
-      "19b1efa7e496df230f0798e224fa6c57"
+      "3defeff27b062b2085e0f7d412580b43"
     ],
     [
       "EverCrypt.Hash.Incremental.alg_of_state",
@@ -270,7 +268,7 @@
         "typing_FStar.Ghost.reveal"
       ],
       0,
-      "ae0244ccb055b265e1e870669367c94c"
+      "093b9153650e88e1e1e60a2096b7969f"
     ],
     [
       "EverCrypt.Hash.Incremental.frame_invariant",
@@ -324,7 +322,7 @@
         "typing_LowStar.Monotonic.Buffer.loc_buffer"
       ],
       0,
-      "821a223edfebf170df102ad312727ee5"
+      "707dbb37b096a085946e770387427100"
     ],
     [
       "EverCrypt.Hash.Incremental.frame_hashed",
@@ -367,7 +365,7 @@
         "typing_LowStar.Monotonic.Buffer.loc_buffer"
       ],
       0,
-      "0ed0a21f6c017408faf95577cc01c4f2"
+      "0900a5d35e6cf482cfc36398b19534dc"
     ],
     [
       "EverCrypt.Hash.Incremental.frame_freeable",
@@ -423,7 +421,7 @@
         "typing_LowStar.Monotonic.Buffer.loc_buffer"
       ],
       0,
-      "26d3e7fe9d825195b064c48818b4466b"
+      "75f9b6596480691e5ccc1140bb25d56a"
     ],
     [
       "EverCrypt.Hash.Incremental.split_at_last_empty",
@@ -474,7 +472,41 @@
         "typing_FStar.Seq.Base.slice"
       ],
       0,
-      "0defe712c222521083f0eb6171b2274b"
+      "5f2d44b70c470688a9ec101965e33512"
+    ],
+    [
+      "EverCrypt.Hash.Incremental.block_len_nonzero",
+      1,
+      0,
+      0,
+      [
+        "@MaxIFuel_assumption", "@query",
+        "constructor_distinct_FStar.Integers.W16",
+        "constructor_distinct_FStar.Integers.W32",
+        "constructor_distinct_FStar.Integers.W8",
+        "constructor_distinct_Lib.IntTypes.PUB",
+        "constructor_distinct_Lib.IntTypes.U32",
+        "equality_tok_FStar.Integers.W16@tok",
+        "equality_tok_FStar.Integers.W32@tok",
+        "equality_tok_FStar.Integers.W8@tok",
+        "equality_tok_Lib.IntTypes.PUB@tok",
+        "equality_tok_Lib.IntTypes.U32@tok",
+        "equation_FStar.Pervasives.inversion",
+        "equation_Hacl.Hash.Definitions.block_len",
+        "equation_Lib.IntTypes.pub_int_v", "equation_Lib.IntTypes.v",
+        "equation_Spec.Hash.Definitions.block_length",
+        "equation_Spec.Hash.Definitions.block_word_length",
+        "equation_Spec.Hash.Definitions.word_length",
+        "fuel_guarded_inversion_Spec.Hash.Definitions.hash_alg",
+        "inversion-interp", "primitive_Prims.op_Multiply",
+        "projection_inverse_BoxInt_proj_0",
+        "projection_inverse_FStar.Integers.Signed__0",
+        "projection_inverse_FStar.Integers.Unsigned__0",
+        "refinement_interpretation_Tm_refine_91c352d831715ed604553457a8078865",
+        "typing_Hacl.Hash.Definitions.block_len"
+      ],
+      0,
+      "e9d88e12c8bcbae52b90ce4bedf3e103"
     ],
     [
       "EverCrypt.Hash.Incremental.create_in",
@@ -663,7 +695,7 @@
         "typing_Spec.Hash.Definitions.word", "typing_tok_Lib.IntTypes.U8@tok"
       ],
       0,
-      "8ca127b0ec7a2dcc3851e7e3d750f30c"
+      "a450cf4e6453f087816f2ce02d374bd1"
     ],
     [
       "EverCrypt.Hash.Incremental.init",
@@ -675,16 +707,12 @@
         "@fuel_correspondence_Prims.pow2.fuel_instrumented",
         "@fuel_correspondence_Spec.Agile.Hash.update_multi.fuel_instrumented",
         "@query", "Prims_pretyping_ae567c2fb75be05905677af440075565",
-        "b2t_def", "bool_typing", "constructor_distinct_FStar.Integers.W16",
-        "constructor_distinct_FStar.Integers.W31",
-        "constructor_distinct_FStar.Integers.W32",
+        "b2t_def", "bool_typing", "constructor_distinct_FStar.Integers.W64",
         "constructor_distinct_FStar.Integers.W8",
         "constructor_distinct_Lib.IntTypes.U1",
         "constructor_distinct_Lib.IntTypes.U128",
         "constructor_distinct_Lib.IntTypes.U64",
-        "equality_tok_FStar.Integers.W16@tok",
-        "equality_tok_FStar.Integers.W31@tok",
-        "equality_tok_FStar.Integers.W32@tok",
+        "equality_tok_FStar.Integers.W64@tok",
         "equality_tok_FStar.Integers.W8@tok",
         "equation_EverCrypt.Hash.Incremental.bytes",
         "equation_EverCrypt.Hash.Incremental.footprint",
@@ -807,7 +835,7 @@
         "typing_Spec.Hash.Definitions.word"
       ],
       0,
-      "122a69b20e7a166cd92b1608d41f3474"
+      "6f4963ea266b842ea9a26a440bdeeda2"
     ],
     [
       "EverCrypt.Hash.Incremental.update_pre",
@@ -816,7 +844,7 @@
       0,
       [ "@query" ],
       0,
-      "472b632e2df6ce77fbbf642971db7713"
+      "fcc7dcaa11c30de359cde198a6af2456"
     ],
     [
       "EverCrypt.Hash.Incremental.rest",
@@ -880,7 +908,7 @@
         "typing_tok_Lib.IntTypes.U32@tok"
       ],
       0,
-      "b71162411c9d0b98e51091a82c53f5fb"
+      "b8ef432a0ffedb579a145f03603ee15b"
     ],
     [
       "EverCrypt.Hash.Incremental.add_len",
@@ -904,7 +932,7 @@
         "typing_FStar.UInt64.v"
       ],
       0,
-      "35c876f0de09afbd75a847d212092385"
+      "13e53ba5c300d218a2a93e91e465a6a4"
     ],
     [
       "EverCrypt.Hash.Incremental.split_at_last_small",
@@ -960,7 +988,7 @@
         "typing_FStar.Seq.Base.slice"
       ],
       0,
-      "4259bd7babe04350bab2da2cc9c3d25a"
+      "02b42e25a57e4a1b1532cb742b25bee5"
     ],
     [
       "EverCrypt.Hash.Incremental.add_len_small",
@@ -1022,7 +1050,7 @@
         "typing_Spec.Hash.Definitions.word_length"
       ],
       0,
-      "e172bbf5015c8d57732808db1327431e"
+      "654feb391e1a5795812131975c402af9"
     ],
     [
       "EverCrypt.Hash.Incremental.update_small",
@@ -1203,7 +1231,7 @@
         "typing_LowStar.Monotonic.Buffer.loc_buffer"
       ],
       0,
-      "a767144c3cf3ad6a27918f15ca6de7a3"
+      "5308ab927e60013973146364841880b1"
     ],
     [
       "EverCrypt.Hash.Incremental.split_at_last_blocks",
@@ -1268,7 +1296,7 @@
         "typing_FStar.Seq.Base.length"
       ],
       0,
-      "5ea17ce42d1e6481117371f56e7f8dc4"
+      "04284f0dae2b5b9c829997139393a203"
     ],
     [
       "EverCrypt.Hash.Incremental.update_empty_buf",
@@ -1277,7 +1305,7 @@
       0,
       [ "@query", "assumption_FStar.UInt32.t__uu___haseq" ],
       0,
-      "36317b148a1d55c6d8ab74023dca5293"
+      "b6ada70757b419a890c124a68fa22cd7"
     ],
     [
       "EverCrypt.Hash.Incremental.update_empty_buf",
@@ -1456,7 +1484,7 @@
         "typing_Spec.Hash.Definitions.word"
       ],
       0,
-      "8b43c811254dfc55bfa95faa2987ec10"
+      "ca5c76819b8f39ff34c0826cccd0de51"
     ],
     [
       "EverCrypt.Hash.Incremental.update_round",
@@ -1495,7 +1523,7 @@
         "typing_LowStar.Monotonic.Buffer.as_seq"
       ],
       0,
-      "65bba9f146943ab4ed02a49500063ceb"
+      "bb55d40aa5a3d709c98434a8b3cf9b35"
     ],
     [
       "EverCrypt.Hash.Incremental.split_at_last_block",
@@ -1516,7 +1544,6 @@
         "function_token_typing_Lib.IntTypes.uint8", "int_inversion",
         "int_typing", "inversion-interp",
         "lemma_FStar.Seq.Base.lemma_eq_elim",
-        "lemma_FStar.Seq.Base.lemma_eq_intro",
         "lemma_FStar.Seq.Base.lemma_eq_refl",
         "lemma_FStar.Seq.Base.lemma_len_append",
         "lemma_FStar.Seq.Base.lemma_len_slice",
@@ -1534,13 +1561,12 @@
         "refinement_interpretation_Tm_refine_b361ba8089a6e963921008d537e799a1",
         "refinement_interpretation_Tm_refine_b913a3f691ca99086652e0a655e72f17",
         "refinement_interpretation_Tm_refine_cb501e9a53386de989708c119282e769",
-        "refinement_interpretation_Tm_refine_d83f8da8ef6c1cb9f71d1465c1bb1c55",
         "typing_EverCrypt.Hash.Incremental.split_at_last",
         "typing_FStar.Seq.Base.append", "typing_FStar.Seq.Base.empty",
         "typing_FStar.Seq.Base.length", "typing_FStar.Seq.Base.slice"
       ],
       0,
-      "929b21d921d3f65c4610b72ebe5e404f"
+      "5a9e29ff3c8d0be1ce8c3e053f0616f5"
     ],
     [
       "EverCrypt.Hash.Incremental.update_round",
@@ -1727,7 +1753,7 @@
         "typing_Spec.Hash.Definitions.word_length"
       ],
       0,
-      "ee8eb40cab196f40ad6c0443b834fa60"
+      "0232941ee555236c16c8d6ff265d4906"
     ],
     [
       "EverCrypt.Hash.Incremental.update",
@@ -1859,7 +1885,7 @@
         "unit_typing"
       ],
       0,
-      "fde40f5eb482f673d6c5de6db4c07f20"
+      "416461d291ca480abc542e84cf4fb168"
     ],
     [
       "EverCrypt.Hash.Incremental.finish_st",
@@ -1872,7 +1898,7 @@
         "refinement_interpretation_Tm_refine_b9688d2cc74c3f47e54760f7117117a9"
       ],
       0,
-      "57636b4e5960e40b55690b4aa1bfa9f5"
+      "a33f62ac32c3be076216eacef006f855"
     ],
     [
       "EverCrypt.Hash.Incremental.total_len_leq_max_input_length",
@@ -1883,9 +1909,8 @@
         "@MaxIFuel_assumption",
         "@fuel_correspondence_Prims.pow2.fuel_instrumented", "@query",
         "b2t_def", "constructor_distinct_FStar.Integers.W16",
-        "constructor_distinct_FStar.Integers.W31",
         "constructor_distinct_FStar.Integers.W32",
-        "constructor_distinct_FStar.Integers.W63",
+        "constructor_distinct_FStar.Integers.W64",
         "constructor_distinct_FStar.Integers.W8",
         "constructor_distinct_Lib.IntTypes.U1",
         "constructor_distinct_Lib.IntTypes.U128",
@@ -1900,9 +1925,8 @@
         "disc_equation_Spec.Hash.Definitions.SHA2_384",
         "disc_equation_Spec.Hash.Definitions.SHA2_512",
         "equality_tok_FStar.Integers.W16@tok",
-        "equality_tok_FStar.Integers.W31@tok",
         "equality_tok_FStar.Integers.W32@tok",
-        "equality_tok_FStar.Integers.W63@tok",
+        "equality_tok_FStar.Integers.W64@tok",
         "equality_tok_FStar.Integers.W8@tok",
         "equation_FStar.Pervasives.inversion", "equation_FStar.UInt.fits",
         "equation_FStar.UInt.size", "equation_FStar.UInt.uint_t",
@@ -1919,7 +1943,7 @@
         "typing_FStar.UInt64.v"
       ],
       0,
-      "21ef256707f75e08e2217bac10953977"
+      "4912de5862309e7b9c177d23ee1ce990"
     ],
     [
       "EverCrypt.Hash.Incremental.mk_finish",
@@ -1933,9 +1957,8 @@
         "assumption_FStar.Monotonic.HyperHeap.Mod_set_def", "b2t_def",
         "bool_inversion", "bool_typing",
         "constructor_distinct_FStar.Integers.W16",
-        "constructor_distinct_FStar.Integers.W31",
         "constructor_distinct_FStar.Integers.W32",
-        "constructor_distinct_FStar.Integers.W63",
+        "constructor_distinct_FStar.Integers.W64",
         "constructor_distinct_FStar.Integers.W8",
         "constructor_distinct_Lib.IntTypes.PUB",
         "constructor_distinct_Lib.IntTypes.U1",
@@ -1944,9 +1967,8 @@
         "constructor_distinct_Lib.IntTypes.U64",
         "constructor_distinct_Lib.IntTypes.U8",
         "equality_tok_FStar.Integers.W16@tok",
-        "equality_tok_FStar.Integers.W31@tok",
         "equality_tok_FStar.Integers.W32@tok",
-        "equality_tok_FStar.Integers.W63@tok",
+        "equality_tok_FStar.Integers.W64@tok",
         "equality_tok_FStar.Integers.W8@tok",
         "equality_tok_Lib.IntTypes.PUB@tok",
         "equality_tok_Lib.IntTypes.U32@tok",
@@ -1967,6 +1989,7 @@
         "equation_EverCrypt.Hash.invariant", "equation_EverCrypt.Hash.state",
         "equation_FStar.HyperStack.ST.equal_domains",
         "equation_FStar.HyperStack.ST.inline_stack_inv",
+        "equation_FStar.Int.Cast.uint32_to_uint64",
         "equation_FStar.Monotonic.Heap.equal_dom",
         "equation_FStar.Monotonic.HyperHeap.hmap",
         "equation_FStar.Monotonic.HyperStack.fresh_frame",
@@ -2166,7 +2189,7 @@
         "typing_Spec.Hash.Definitions.word", "typing_Spec.Hash.PadFinish.pad"
       ],
       0,
-      "1ec05a62aaaac5231a3d6bd06bd28080"
+      "3e1550a61d21d116544860d6bfe5da11"
     ],
     [
       "EverCrypt.Hash.Incremental.finish",
@@ -2209,7 +2232,7 @@
         "typing_FStar.Ghost.reveal"
       ],
       0,
-      "bb978dc767283a31acb23b36bc5163af"
+      "d746c0ed91fadbbadedfb9620f678453"
     ],
     [
       "EverCrypt.Hash.Incremental.free",
@@ -2278,7 +2301,7 @@
         "typing_LowStar.Monotonic.Buffer.loc_buffer"
       ],
       0,
-      "d238c49540d78bad9661607b39249018"
+      "90238c9b6dd2e33c36e0e2e504377dbd"
     ]
   ]
 ]

--- a/lib/Lib.Buffer.fsti
+++ b/lib/Lib.Buffer.fsti
@@ -29,9 +29,9 @@ type buftype =
 inline_for_extraction
 let buffer_t (ty:buftype) (a:Type0) =
   match ty with
-  | IMMUT -> ib:IB.ibuffer a
-  | MUT -> b:B.buffer a
-  | CONST -> cb:CB.const_buffer a
+  | IMMUT -> IB.ibuffer a
+  | MUT -> B.buffer a
+  | CONST -> CB.const_buffer a
 
 (** Mutable buffer. Extracted as `a*` *)
 unfold let buffer (a:Type0) = buffer_t MUT a
@@ -310,7 +310,7 @@ inline_for_extraction noextract
 val createL_global:
     #a:Type0
   -> init:list a{normalize (List.Tot.length init <= max_size_t)} ->
-  ST (b:ilbuffer a (size (normalize_term (List.Tot.length init))))
+  ST (ilbuffer a (size (normalize_term (List.Tot.length init))))
     (requires fun h0 -> B.gcmalloc_of_list_pre #a HyperStack.root init)
     (ensures  fun h0 b h1 -> global_allocated b h0 h1 (Seq.of_list init) /\
                           recallable b /\
@@ -1034,7 +1034,7 @@ val mapiT:
   -> #b:Type
   -> clen:size_t
   -> o:lbuffer b clen
-  -> f:(i:size_t{v i < v clen} -> x:a -> r:b)
+  -> f:(i:size_t{v i < v clen} -> x:a -> b)
   -> i:lbuffer_t t a clen ->
   Stack unit
     (requires fun h0 -> live h0 o /\ live h0 i /\ eq_or_disjoint o i)

--- a/lib/Lib.IntVector.fsti
+++ b/lib/Lib.IntVector.fsti
@@ -131,7 +131,7 @@ val vec_get: #t:v_inttype -> #w:width
   x:uint_t t SEC{x == index (vec_v v) (size_v i)}
 
 inline_for_extraction noextract
-val vec_add_mod: #t:v_inttype -> #w:width -> v1:vec_t t w -> v2:vec_t t w -> v3:vec_t t w
+val vec_add_mod: #t:v_inttype -> #w:width -> v1:vec_t t w -> v2:vec_t t w -> vec_t t w
 
 noextract
 val vec_add_mod_lemma: #t:v_inttype -> #w:width -> v1:vec_t t w -> v2:vec_t t w -> Lemma
@@ -148,14 +148,14 @@ inline_for_extraction noextract
 val vec_smul_mod: #t:v_inttype{t <> U128} -> #w:width -> v1:vec_t t w -> v2:uint_t t SEC -> v3:vec_t t w{vec_v v3 == map ( mul_mod v2 ) (vec_v v1)}
 
 inline_for_extraction noextract
-val vec_xor: #t:v_inttype -> #w:width -> v1:vec_t t w -> v2:vec_t t w -> v3:vec_t t w
+val vec_xor: #t:v_inttype -> #w:width -> v1:vec_t t w -> v2:vec_t t w -> vec_t t w
 
 val vec_xor_lemma: #t:v_inttype -> #w:width -> v1:vec_t t w -> v2:vec_t t w -> Lemma
   (ensures (vec_v (vec_xor v1 v2) == map2 ( ^. ) (vec_v v1) (vec_v v2)))
   [SMTPat (vec_v #t #w (vec_xor v1 v2))]
 
 inline_for_extraction noextract
-val vec_and: #t:v_inttype -> #w:width -> v1:vec_t t w -> v2:vec_t t w -> v3:vec_t t w
+val vec_and: #t:v_inttype -> #w:width -> v1:vec_t t w -> v2:vec_t t w -> vec_t t w
 
 val vec_and_lemma: #t:v_inttype -> #w:width -> v1:vec_t t w -> v2:vec_t t w -> Lemma
   (ensures (vec_v (vec_and v1 v2) == map2 ( &. ) (vec_v v1) (vec_v v2)))
@@ -165,7 +165,7 @@ inline_for_extraction noextract
 val vec_or: #t:v_inttype -> #w:width -> v1:vec_t t w -> v2:vec_t t w -> v3:vec_t t w{vec_v v3 == map2 ( |. ) (vec_v v1) (vec_v v2)}
 
 inline_for_extraction noextract
-val vec_not: #t:v_inttype -> #w:width -> v1:vec_t t w -> v2:vec_t t w
+val vec_not: #t:v_inttype -> #w:width -> v1:vec_t t w -> vec_t t w
 
 val vec_not_lemma: #t:v_inttype -> #w:width -> v1:vec_t t w -> Lemma
   (ensures (vec_v (vec_not v1) == map lognot (vec_v v1)))
@@ -183,7 +183,7 @@ val vec_shift_left: #t:v_inttype -> #w:width
 
 inline_for_extraction noextract
 val vec_rotate_right: #t:v_inttype -> #w:width
-  -> v1:vec_t t w -> s:rotval t{t <> U128 \/ uint_v s % 8 == 0} -> v2:vec_t t w
+  -> v1:vec_t t w -> s:rotval t{t <> U128 \/ uint_v s % 8 == 0} -> vec_t t w
 
 val vec_rotate_right_lemma: #t:v_inttype -> #w:width
   -> v1:vec_t t w -> s:rotval t{t <> U128 \/ uint_v s % 8 == 0} ->
@@ -293,7 +293,7 @@ val vec_shift_right_uint128_small2: v1:vec_t U64 4 -> s:shiftval U128{uint_v s %
 inline_for_extraction noextract
 val vec_permute2: #t:v_inttype -> v1:vec_t t 2
   -> i1:vec_index 2 -> i2:vec_index 2 ->
-  v2:vec_t t 2
+  vec_t t 2
 
 inline_for_extraction noextract
 val vec_permute2_lemma: #t:v_inttype -> v1:vec_t t 2
@@ -305,7 +305,7 @@ val vec_permute2_lemma: #t:v_inttype -> v1:vec_t t 2
 inline_for_extraction noextract
 val vec_permute4: #t:v_inttype -> v1:vec_t t 4
   -> i1:vec_index 4 -> i2:vec_index 4 -> i3:vec_index 4 -> i4:vec_index 4 ->
-  v2:vec_t t 4
+  vec_t t 4
 
 inline_for_extraction noextract
 val vec_permute4_lemma: #t:v_inttype -> v1:vec_t t 4
@@ -364,21 +364,21 @@ type uint8x16 = vec_t U8 16
 type uint8x32 = vec_t U8 32
 
 inline_for_extraction noextract
-val vec_aes_enc: key:uint8x16 -> state:uint8x16 -> res:uint8x16
+val vec_aes_enc: key:uint8x16 -> state:uint8x16 -> uint8x16
 
 val vec_aes_enc_lemma: key:uint8x16 -> state:uint8x16 -> Lemma
   (ensures (vec_v (vec_aes_enc key state) == Spec.AES.aes_enc (vec_v key) (vec_v state)))
   [SMTPat (vec_v (vec_aes_enc key state))]
 
 inline_for_extraction noextract
-val vec_aes_enc_last: key:uint8x16 -> state:uint8x16 -> res:uint8x16
+val vec_aes_enc_last: key:uint8x16 -> state:uint8x16 -> uint8x16
 
 val vec_aes_enc_last_lemma: key:uint8x16 -> state:uint8x16 -> Lemma
   (ensures (vec_v (vec_aes_enc_last key state) == Spec.AES.aes_enc_last (vec_v key) (vec_v state)))
   [SMTPat (vec_v (vec_aes_enc_last key state))]
 
 inline_for_extraction noextract
-val vec_aes_keygen_assist: s:uint8x16 -> rcon:uint8 -> res:uint8x16
+val vec_aes_keygen_assist: s:uint8x16 -> rcon:uint8 -> uint8x16
 
 val vec_aes_keygen_assist_lemma: s:uint8x16 -> rcon:uint8 -> Lemma
   (ensures (vec_v (vec_aes_keygen_assist s rcon) == Spec.AES.aes_keygen_assist rcon (vec_v s)))

--- a/lib/Lib.LoopCombinators.fst
+++ b/lib/Lib.LoopCombinators.fst
@@ -84,7 +84,7 @@ let repeati_inductive #a n pred f x0 =
 
 let repeati_inductive_repeat_gen #a n pred f x0 =
   let a' i = x:a{pred i x} in
-  let f' (i:nat{i < n}) (x:a' i) : y:a' (i + 1) = f i x in
+  let f' (i:nat{i < n}) (x:a' i) : a' (i + 1) = f i x in
   repeat_left_right 0 n (fun i -> x:a{pred i x}) f x0;
   assert_norm (repeati_inductive n pred f x0 == repeat_right 0 n (fun i -> a' i) f' x0);
   assert (repeat_gen n (fun i -> x:a{pred i x}) f x0 == repeat_right 0 n a' f' x0);

--- a/lib/Lib.Sequence.fsti
+++ b/lib/Lib.Sequence.fsti
@@ -348,7 +348,7 @@ val generate_blocks_simple:
  -> blocksize:size_pos
  -> max:nat
  -> n:nat{n <= max}
- -> f:(i:nat{i < max} -> s:lseq a blocksize) ->
+ -> f:(i:nat{i < max} -> lseq a blocksize) ->
  Tot (s:seq a{length s == n * blocksize})
 
 (** The following functions allow us to bridge between unbounded and bounded sequences *)

--- a/providers/evercrypt/EverCrypt.Hash.fsti
+++ b/providers/evercrypt/EverCrypt.Hash.fsti
@@ -75,7 +75,7 @@ type e_alg = G.erased alg
 val state_s: alg -> Type0
 
 // pointer to abstract implementation state
-let state alg = b:B.pointer (state_s alg)
+let state alg = B.pointer (state_s alg)
 
 // abstract freeable (deep) predicate; only needed for create/free pairs
 val freeable_s: #(a: alg) -> state_s a -> Type0

--- a/providers/evercrypt/fst/EverCrypt.Hash.Incremental.fst
+++ b/providers/evercrypt/fst/EverCrypt.Hash.Incremental.fst
@@ -119,12 +119,18 @@ let split_at_last_empty (a: Hash.alg): Lemma
 =
   ()
 
+/// I'm very confused as to why the hint is non-replayable for this one. Bad
+/// interaction between allow_inversion and ifuel 0 for replaying hints...?
+let block_len_nonzero a: Lemma (U32.v (Hacl.Hash.Definitions.block_len a) > 0) =
+  ()
+
 #restart-solver
 #push-options "--z3rlimit 40 --using_facts_from '*,-LowStar.Monotonic.Buffer.unused_in_not_unused_in_disjoint_2'"
 let create_in a r =
   (**) let h0 = ST.get () in
 
   (**) B.loc_unused_in_not_unused_in_disjoint h0;
+  (**) block_len_nonzero a;
   let buf = B.malloc r (Lib.IntTypes.u8 0) (Hacl.Hash.Definitions.block_len a) in
   (**) let h1 = ST.get () in
   (**) assert (B.fresh_loc (B.loc_buffer buf) h0 h1);

--- a/secure_api/merkle_tree/MerkleTree.Low.Datastructures.fst
+++ b/secure_api/merkle_tree/MerkleTree.Low.Datastructures.fst
@@ -140,9 +140,9 @@ let hash_r_free #_ v =
   B.free v
 
 noextract inline_for_extraction
-val hreg (hsz:hash_size_t): regional (h:hash_size_t) (hash #hsz)
+val hreg (hsz:hash_size_t): regional (hash_size_t) (hash #hsz)
 let hreg hsz =
-  Rgl #(h:hash_size_t) #(hash #hsz) hsz
+  Rgl #(hash_size_t) #(hash #hsz) hsz
       (hash_region_of #hsz)
       (B.loc_buffer)
       (hash_dummy #hsz)
@@ -256,7 +256,7 @@ val hash_vec_r_alloc:
   #hsz':Ghost.erased hash_size_t ->
   hsz:hash_size_t { hsz == Ghost.reveal hsz' } ->
   r:HST.erid ->
-  HST.ST (v:hash_vec #hsz)
+  HST.ST (hash_vec #hsz)
     (requires (fun h0 -> true))
     (ensures (fun h0 v h1 ->
       Set.subset (Map.domain (MHS.get_hmap h0))

--- a/secure_api/merkle_tree/MerkleTree.Low.VectorExtras.fst
+++ b/secure_api/merkle_tree/MerkleTree.Low.VectorExtras.fst
@@ -112,7 +112,7 @@ inline_for_extraction
 val shrink:
   #a:Type -> vec:vector a ->
   new_size:uint32_t{new_size <= size_of vec} ->
-  HST.ST (r:vector a)
+  HST.ST (vector a)
   (requires (fun h0 -> live h0 vec /\ freeable vec))
   (ensures (fun h0 r h1 ->
                 live h1 vec /\ live h1 r /\ size_of r = new_size /\
@@ -131,7 +131,7 @@ inline_for_extraction
 val flush_inplace:
   #a:Type -> vec:vector a -> 
   i:uint32_t{i <= size_of vec} ->
-  HST.ST (fvec:vector a)
+  HST.ST (vector a)
     (requires (fun h0 ->
       live h0 vec /\ freeable vec /\
       HST.is_eternal_region (frameOf vec)))

--- a/secure_api/merkle_tree/MerkleTree.New.High.Correct.Base.fst
+++ b/secure_api/merkle_tree/MerkleTree.New.High.Correct.Base.fst
@@ -429,7 +429,7 @@ let create_pads #hsz len = S.create len (MTS.HPad #hsz)
 val hash_seq_spec:
   #hsz:pos -> 
   hs:hashes #hsz {S.length hs > 0} ->
-  GTot (smt:MTS.merkle_tree #hsz (log2c (S.length hs)))
+  GTot (MTS.merkle_tree #hsz (log2c (S.length hs)))
 let hash_seq_spec #hsz hs =
   S.append (hash_seq_lift #hsz hs)
            (create_pads (pow2 (log2c (S.length hs)) - S.length hs))
@@ -490,7 +490,7 @@ val hash_seq_spec_full:
   #hsz:pos -> #f:MTS.hash_fun_t #hsz ->
   hs:hashes #hsz {S.length hs > 0} ->
   acc:hash #hsz -> actd:bool ->
-  GTot (smt:MTS.merkle_tree #hsz (log2c (S.length hs)))
+  GTot (MTS.merkle_tree #hsz (log2c (S.length hs)))
 let hash_seq_spec_full #hsz #f hs acc actd =
   if actd
   then (S.upd (hash_seq_spec #hsz hs) (S.length hs) (MTS.HRaw acc))
@@ -635,7 +635,7 @@ val mt_spec:
   #hsz:pos -> 
   mt:merkle_tree #hsz {mt_wf_elts mt /\ MT?.j mt > 0} ->
   olds:hashess{S.length olds = 32 /\ mt_olds_inv #hsz 0 (MT?.i mt) olds} ->
-  GTot (smt:MTS.merkle_tree #hsz (log2c (MT?.j mt)))
+  GTot (MTS.merkle_tree #hsz (log2c (MT?.j mt)))
 let mt_spec #hsz mt olds =
   hash_seq_spec #_ (mt_base mt olds)
 

--- a/specs/Spec.Agile.Hash.fsti
+++ b/specs/Spec.Agile.Hash.fsti
@@ -20,4 +20,4 @@ val update_multi (a:hash_alg) (hash:words_state a) (blocks:bytes_blocks a):
   Tot (words_state a) (decreases (S.length blocks))
 
 val hash (a:hash_alg) (input:bytes{S.length input <= max_input_length a}):
-  Tot (hash:Lib.ByteSequence.lbytes (hash_length a))
+  Tot (Lib.ByteSequence.lbytes (hash_length a))

--- a/specs/Spec.Blake2.fst
+++ b/specs/Spec.Blake2.fst
@@ -128,14 +128,14 @@ unfold let rtable_t (a:alg) = lseq (rotval (wt a)) 4
 
 [@"opaque_to_smt"]
 inline_for_extraction
-let rTable_list_S : l:List.Tot.llist (rotval U32) 4 =
+let rTable_list_S : List.Tot.llist (rotval U32) 4 =
   [
     size 16; size 12; size 8; size 7
   ]
 
 [@"opaque_to_smt"]
 inline_for_extraction
-let rTable_list_B: l:List.Tot.llist (rotval U64) 4 =
+let rTable_list_B: List.Tot.llist (rotval U64) 4 =
   [
     size 32; size 24; size 16; size 63
   ]
@@ -148,7 +148,7 @@ let rTable (a:alg) : rtable_t a =
 
 [@"opaque_to_smt"]
 inline_for_extraction
-let list_iv_S: l:List.Tot.llist (uint_t U32 PUB) 8 =
+let list_iv_S: List.Tot.llist (uint_t U32 PUB) 8 =
   [@inline_let]
   let l = [
     0x6A09E667ul; 0xBB67AE85ul; 0x3C6EF372ul; 0xA54FF53Aul;

--- a/specs/Spec.Curve25519.fst
+++ b/specs/Spec.Curve25519.fst
@@ -22,7 +22,7 @@ let ( +% ) = fadd
 let ( -% ) = fsub
 let ( *% ) = fmul
 
-val fpow: a:elem -> b:pos -> Tot (res:elem) (decreases b)
+val fpow: a:elem -> b:pos -> Tot elem (decreases b)
 let rec fpow a b =
   if b = 1 then a
   else

--- a/specs/Spec.Hash.Definitions.fst
+++ b/specs/Spec.Hash.Definitions.fst
@@ -187,7 +187,7 @@ let words_of_bytes: a:hash_alg -> Tot (#len:size_nat{FStar.Mul.(len * word_lengt
 (** The data format taken and returned by the hash specifications. *)
 
 (* Input data. *)
-type bytes =  m:Seq.seq uint8
+type bytes = Seq.seq uint8
 
 (* Input data, multiple of a block length. *)
 let bytes_block a =
@@ -210,7 +210,7 @@ let init_t (a: hash_alg) =
 let update_t (a: hash_alg) =
   h:words_state a ->
   l:bytes { Seq.length l = block_length a } ->
-  h':words_state a
+  words_state a
 
 let pad_t (a: hash_alg) =
   l:nat { l <= max_input_length a } ->

--- a/specs/Spec.Hash.PadFinish.fst
+++ b/specs/Spec.Hash.PadFinish.fst
@@ -35,6 +35,6 @@ let pad (a:hash_alg)
 (** Extracting the hash, which we call "finish" *)
 
 (* Unflatten the hash from the sequence of words to bytes up to the correct size *)
-let finish (a:hash_alg) (hashw:words_state a): Tot (hash:lbytes (hash_length a)) =
+let finish (a:hash_alg) (hashw:words_state a): Tot (lbytes (hash_length a)) =
   let hash_final_w = S.slice hashw 0 (hash_word_length a) in
   bytes_of_words a #(hash_word_length a) hash_final_w

--- a/specs/Spec.SHA2.fst
+++ b/specs/Spec.SHA2.fst
@@ -134,7 +134,7 @@ val _sigma1: a:sha2_alg -> x:(word a) -> Tot (word a)
 inline_for_extraction
 let _sigma1 a x = (x >>>. (op0 a).e3) ^. (x >>>. (op0 a).e4) ^. (x >>. (op0 a).e5)
 
-let h0: a:sha2_alg -> Tot (m:words_state a) = function
+let h0: a:sha2_alg -> Tot (words_state a) = function
   | SHA2_224 -> C.h224
   | SHA2_256 -> C.h256
   | SHA2_384 -> C.h384

--- a/specs/ecdsap256sha2/Spec.P256.Lemmas.fst
+++ b/specs/ecdsap256sha2/Spec.P256.Lemmas.fst
@@ -15,7 +15,7 @@ open FStar.Tactics.Canon
 
 
 noextract
-val pow: a:nat -> b:nat -> res:nat
+val pow: a:nat -> b:nat -> nat
 
 let rec pow a b =
   if b = 0 then 1
@@ -122,7 +122,7 @@ type elem (n:pos) = x:nat{x < n}
 
 let fmul (#n:pos) (x:elem n) (y:elem n) : elem n = (x * y) % n
 
-val exp: #n: pos -> a: elem n -> b: pos -> Tot (res: elem n) (decreases b)
+val exp: #n: pos -> a: elem n -> b: pos -> Tot (elem n) (decreases b)
 
 let rec exp #n a b =
   if b = 1 then a
@@ -131,26 +131,26 @@ let rec exp #n a b =
     else fmul a (exp (fmul a a) (b / 2))
 
 
-noextract 
-let modp_inv_prime (prime: pos {prime > 3}) (x: elem prime) : Tot (r: elem prime) = 
+noextract
+let modp_inv_prime (prime: pos {prime > 3}) (x: elem prime) : Tot (elem prime) =
   (exp #prime x (prime - 2)) % prime
 
 noextract
-let modp_inv2_prime (x: int) (p: nat {p > 3}) : Tot (r: elem p) = modp_inv_prime p (x % p)
+let modp_inv2_prime (x: int) (p: nat {p > 3}) : Tot (elem p) = modp_inv_prime p (x % p)
 
 noextract
-let modp_inv2 (x: nat) : Tot (r: elem prime256) = 
+let modp_inv2 (x: nat) : Tot (elem prime256) =
   modp_inv2_prime x prime256
 
 
 noextract
-let modp_inv2_pow (x: nat) : Tot (r: elem prime256) = 
+let modp_inv2_pow (x: nat) : Tot (elem prime256) =
    power_distributivity x (prime256 - 2) prime256;
    pow x (prime256 - 2) % prime256
 
 
 noextract
-let min_one_prime (prime: pos {prime > 3}) (x: int) : Tot (r: elem prime) = 
+let min_one_prime (prime: pos {prime > 3}) (x: int) : Tot (elem prime) =
   let p = x % prime in 
   exp #prime p (prime - 1)
 

--- a/specs/frodo/Spec.Frodo.Encode.fst
+++ b/specs/frodo/Spec.Frodo.Encode.fst
@@ -109,7 +109,7 @@ let frodo_key_encode2 b a i res =
 val frodo_key_encode:
     b:size_nat{0 < b /\ b <= 8}
   -> a:lbytes (params_nbar * params_nbar * b / 8)
-  -> res:matrix params_nbar params_nbar
+  -> matrix params_nbar params_nbar
 let frodo_key_encode b a =
   let res = create params_nbar params_nbar in
   Loops.repeati params_nbar (frodo_key_encode2 b a) res
@@ -149,7 +149,7 @@ let frodo_key_decode2 b a i res =
 val frodo_key_decode:
     b:size_nat{0 < b /\ b <= 8}
   -> a:matrix params_nbar params_nbar
-  -> res:lbytes (params_nbar * params_nbar * b / 8)
+  -> lbytes (params_nbar * params_nbar * b / 8)
 let frodo_key_decode b a =
   let resLen = params_nbar * params_nbar * b / 8 in
   let res = Seq.create resLen (u8 0) in

--- a/specs/frodo/Spec.Frodo.Gen.fst
+++ b/specs/frodo/Spec.Frodo.Gen.fst
@@ -32,7 +32,7 @@ val frodo_gen_matrix_cshake0:
   -> res_i:lbytes (2 * n)
   -> j:size_nat{j < n}
   -> res0:matrix n n
-  -> res1:matrix n n
+  -> matrix n n
 let frodo_gen_matrix_cshake0 n i res_i j res0 =
     res0.(i, j) <- uint_from_bytes_le (Seq.sub res_i (j * 2) 2)
 
@@ -42,7 +42,7 @@ val frodo_gen_matrix_cshake1:
   -> seed:lbytes seedLen
   -> i:size_nat{i < n}
   -> res:matrix n n
-  -> res1:matrix n n
+  -> matrix n n
 let frodo_gen_matrix_cshake1 n seedLen seed i res =
   let res_i = cshake128_frodo seedLen seed (u16 (256 + i)) (2 * n) in
   Loops.repeati_inductive' #(matrix n n) n
@@ -93,7 +93,7 @@ val frodo_gen_matrix_cshake_4x0:
   -> r3:lbytes (2 * n)
   -> j:size_nat{j < n}
   -> res0:matrix n n
-  -> res1:matrix n n
+  -> matrix n n
 let frodo_gen_matrix_cshake_4x0 n i r0 r1 r2 r3 j res0 =
   let res0 = res0.(4 * i + 0, j) <- uint_from_bytes_le (Seq.sub r0 (j * 2) 2) in
   let res0 = res0.(4 * i + 1, j) <- uint_from_bytes_le (Seq.sub r1 (j * 2) 2) in
@@ -107,7 +107,7 @@ val frodo_gen_matrix_cshake_4x1:
   -> seed:lbytes seedLen
   -> i:size_nat{i < n / 4}
   -> res:matrix n n
-  -> res1:matrix n n
+  -> matrix n n
 let frodo_gen_matrix_cshake_4x1 n seedLen seed i res =
   let ctr0 = 256 + 4 * i + 0 in
   let ctr1 = 256 + 4 * i + 1 in
@@ -162,7 +162,7 @@ val frodo_gen_matrix_aes:
     n:size_nat{n * n <= max_size_t /\ n < maxint U16}
   -> seedLen:size_nat{seedLen == 16}
   -> seed:lbytes seedLen
-  -> res:matrix n n
+  -> matrix n n
 let frodo_gen_matrix_aes n seedLen seed =
   let res = Matrix.create n n in
   let key = aes128_key_expansion seed in

--- a/specs/frodo/Spec.Frodo.KEM.Decaps.fst
+++ b/specs/frodo/Spec.Frodo.KEM.Decaps.fst
@@ -114,7 +114,7 @@ let crypto_kem_dec_ss ct sk g mu_decode bp_matrix c_matrix =
 val crypto_kem_dec:
     ct:lbytes crypto_ciphertextbytes
   -> sk:lbytes crypto_secretkeybytes
-  -> ss:lbytes crypto_bytes
+  -> lbytes crypto_bytes
 let crypto_kem_dec ct sk =
   expand_crypto_secretkeybytes ();
   let bp_matrix, c_matrix = get_bp_c_matrices ct in

--- a/specs/frodo/Spec.Frodo.KEM.fst
+++ b/specs/frodo/Spec.Frodo.KEM.fst
@@ -24,5 +24,5 @@ let crypto_kem_enc state pk = Encaps.crypto_kem_enc state pk
 val crypto_kem_dec:
     ct:lbytes crypto_ciphertextbytes
   -> sk:lbytes crypto_secretkeybytes
-  -> ss:lbytes crypto_bytes
+  -> lbytes crypto_bytes
 let crypto_kem_dec ct sk = Decaps.crypto_kem_dec ct sk

--- a/specs/frodo/Spec.Frodo.Pack.fst
+++ b/specs/frodo/Spec.Frodo.Pack.fst
@@ -65,7 +65,7 @@ val frodo_pack:
   -> #n2:size_nat{n1 * n2 <= max_size_t /\ (n1 * n2) % 8 = 0}
   -> d:size_nat{d * ((n1 * n2) / 8) <= max_size_t /\ d <= 16}
   -> a:matrix n1 n2
-  -> res:lbytes (d * ((n1 * n2) / 8))
+  -> lbytes (d * ((n1 * n2) / 8))
 let frodo_pack #n1 #n2 d a =
   Loops.repeat_gen ((n1 * n2) / 8)
     (frodo_pack_state #n1 #n2 d)

--- a/specs/frodo/Spec.Frodo.Sample.fst
+++ b/specs/frodo/Spec.Frodo.Sample.fst
@@ -120,7 +120,7 @@ val frodo_sample_matrix:
   -> seedLen:size_nat
   -> seed:lbytes seedLen
   -> ctr:uint16
-  -> res:matrix n1 n2
+  -> matrix n1 n2
 let frodo_sample_matrix n1 n2 seedLen seed ctr =
   let res = Matrix.create n1 n2 in
   let r = frodo_prf_spec seedLen seed ctr (2 * n1 * n2) in

--- a/vale/code/arch/x64/Vale.X64.Decls.fsti
+++ b/vale/code/arch/x64/Vale.X64.Decls.fsti
@@ -557,7 +557,7 @@ val lemma_valid_cmp_gt : s:va_state -> o1:operand64{ not (OMem? o1 || OStack? o1
 
 val va_compute_merge_total (f0:va_fuel) (fM:va_fuel) : va_fuel
 
-val va_lemma_merge_total (b0:va_codes) (s0:va_state) (f0:va_fuel) (sM:va_state) (fM:va_fuel) (sN:va_state) : Ghost (fN:va_fuel)
+val va_lemma_merge_total (b0:va_codes) (s0:va_state) (f0:va_fuel) (sM:va_state) (fM:va_fuel) (sN:va_state) : Ghost va_fuel
   (requires
     Cons? b0 /\
     eval_code (Cons?.hd b0) s0 f0 sM /\
@@ -627,7 +627,7 @@ val va_lemma_whileFalse_total (b:ocmp) (c:va_code) (s0:va_state) (sW:va_state) (
     eval_code (While b c) s0 f1 s1
   )
 
-val va_lemma_whileMerge_total (c:va_code) (s0:va_state) (f0:va_fuel) (sM:va_state) (fM:va_fuel) (sN:va_state) : Ghost (fN:va_fuel)
+val va_lemma_whileMerge_total (c:va_code) (s0:va_state) (f0:va_fuel) (sM:va_state) (fM:va_fuel) (sN:va_state) : Ghost va_fuel
   (requires While? c /\ (
     let cond = While?.whileCond c in
     sN.vs_ok /\

--- a/vale/code/arch/x64/Vale.X64.Lemmas.fsti
+++ b/vale/code/arch/x64/Vale.X64.Lemmas.fsti
@@ -189,7 +189,7 @@ val lemma_whileFalse_total (b:ocmp) (c:code) (s0:vale_state) (sW:vale_state) (fW
     eval_code (While b c) s0 f1 s1
   )
 
-val lemma_whileMerge_total (c:code) (s0:vale_state) (f0:fuel) (sM:vale_state) (fM:fuel) (sN:vale_state) : Ghost (fN:fuel)
+val lemma_whileMerge_total (c:code) (s0:vale_state) (f0:fuel) (sM:vale_state) (fM:fuel) (sN:vale_state) : Ghost fuel
   (requires While? c /\ (
     let cond = While?.whileCond c in
     sN.vs_ok /\

--- a/vale/code/arch/x64/Vale.X64.Memory_Sems.fsti
+++ b/vale/code/arch/x64/Vale.X64.Memory_Sems.fsti
@@ -21,7 +21,7 @@ val lemma_same_domains (h:vale_heap) (m1:S.machine_heap) (m2:S.machine_heap) : L
 
 val get_heap (h:vale_heap) : GTot (m:S.machine_heap{same_domain h m})
 
-val upd_heap (h:vale_heap) (m:S.machine_heap{is_machine_heap_update (get_heap h) m}) : GTot (h':vale_heap)
+val upd_heap (h:vale_heap) (m:S.machine_heap{is_machine_heap_update (get_heap h) m}) : GTot vale_heap
 
 //val lemma_upd_get_heap (h:vale_heap) : Lemma (upd_heap h (get_heap h) == h)
 //  [SMTPat (upd_heap h (get_heap h))]

--- a/vale/code/arch/x64/interop/Vale.Wrapper.X64.Poly.fsti
+++ b/vale/code/arch/x64/interop/Vale.Wrapper.X64.Poly.fsti
@@ -21,7 +21,7 @@ let uint64 = UInt64.t
 noextract
 let uint64_to_nat_seq
       (b:Seq.seq UInt64.t)
-    : (s:Seq.lseq nat64 (Seq.length b))
+    : Seq.lseq nat64 (Seq.length b)
     = Seq.init (Seq.length b) (fun (i:nat{i < Seq.length b}) -> (UInt64.v (Seq.index b i) <: nat64))
 
 let math_aux (b:uint8_p) (n:nat) : Lemma

--- a/vale/code/crypto/aes/Vale.AES.GHash.fst
+++ b/vale/code/crypto/aes/Vale.AES.GHash.fst
@@ -240,11 +240,11 @@ let lemma_reverse_bytes_quad32_xor (a b:quad32) : Lemma
     Vale.Arch.TypesNative.reveal_ixor_all 32;
     lemma_small_logxor_32_8 a b
     in
-  let lemma_small_logxor_32_8 : (_:squash (forall (a b:nat8).{:pattern (logxor #32 a b)} logxor #32 a b < 0x100)) =
+  let lemma_small_logxor_32_8 : squash (forall (a b:nat8).{:pattern (logxor #32 a b)} logxor #32 a b < 0x100) =
     // FStar.Classical.forall_intro_2_with_pat didn't work; TODO: use new non-top-level SMTPat feature
     FStar.Classical.forall_intro_2 lemma_small_logxor_32_8
     in
-  let lemma_small_logxor_32_8 : (_:squash (forall (a b:nat8).{:pattern (nat32_xor a b)} nat32_xor a b < 0x100)) =
+  let lemma_small_logxor_32_8 : squash (forall (a b:nat8).{:pattern (nat32_xor a b)} nat32_xor a b < 0x100) =
     FStar.Classical.forall_intro_2 lemma_small_nat32_xor_32_8
     in
   let lemma_xor_mk4b (a0 a1 a2 a3 b0 b1 b2 b3:bv_t 32) : Lemma

--- a/vale/code/crypto/ecc/curve25519/Vale.Curve25519.FastUtil_helpers.fsti
+++ b/vale/code/crypto/ecc/curve25519/Vale.Curve25519.FastUtil_helpers.fsti
@@ -9,7 +9,7 @@ open Vale.Curve25519.Fast_defs
 
 let int_canon = fun _ -> norm [delta; zeta; iota]; int_semiring () //; dump "Final"
 
-let sub_carry (x y:nat64) (c:bit) : nat64 & (c':bit)
+let sub_carry (x y:nat64) (c:bit) : nat64 & bit
   =
   if x - (y + c) < 0 then
     (x - (y + c) + pow2_64, 1)

--- a/vale/code/crypto/sha/Vale.SHA.SHA_helpers.fsti
+++ b/vale/code/crypto/sha/Vale.SHA.SHA_helpers.fsti
@@ -31,7 +31,7 @@ val reveal_word (u:unit) : Lemma (word == Lib.IntTypes.uint32)
 
 (* Input data. *)
 type byte = UInt8.t
-type bytes =  m:Seq.seq byte
+type bytes = Seq.seq byte
 
 (* Input data, multiple of a block length. *)
 let bytes_blocks =

--- a/vale/specs/crypto/Vale.AES.GCTR_s.fst
+++ b/vale/specs/crypto/Vale.AES.GCTR_s.fst
@@ -15,7 +15,7 @@ open FStar.Seq
 // length plain < pow2_32 <= spec max of 2**39 - 256;
 let is_gctr_plain_LE (p:seq nat8) : prop0 = length p < pow2_32
 type gctr_plain_LE:eqtype = p:seq nat8 { is_gctr_plain_LE p }
-type gctr_plain_internal_LE:eqtype = p:seq quad32
+type gctr_plain_internal_LE:eqtype = seq quad32
 
 let inc32 (cb:quad32) (i:int) : quad32 =
   Mkfour ((cb.lo0 + i) % pow2_32) cb.lo1 cb.hi2 cb.hi3

--- a/vale/specs/interop/Vale.Interop.X64.fsti
+++ b/vale/specs/interop/Vale.Interop.X64.fsti
@@ -626,7 +626,7 @@ let register_of_arg_i (i:reg_nat (if IA.win then 4 else 6)) : MS.reg_64 =
 //A partial inverse of the above function
 [@__reduce__]
 let arg_of_register (r:MS.reg_64)
-  : option (i:reg_nat (if IA.win then 4 else 6))
+  : option (reg_nat (if IA.win then 4 else 6))
   = let open MS in
     if IA.win then
        match r with


### PR DESCRIPTION
This PR fixes spurious uses of names, as described in FStarLang/FStar#1905.

Here's one example change:
```diff
diff --git a/code/hash/Hacl.Hash.Core.SHA1.fst b/code/hash/Hacl.Hash.Core.SHA1.fst
index 9d06123a6..c625d428c 100644
--- a/code/hash/Hacl.Hash.Core.SHA1.fst
+++ b/code/hash/Hacl.Hash.Core.SHA1.fst
@@ -52,7 +52,7 @@ let legacy_init s =
   )
 
 inline_for_extraction
-let w_t = (b: B.lbuffer (word SHA1) 80)
+let w_t = B.lbuffer (word SHA1) 80
 
 inline_for_extraction
 let block_t = (block: B.buffer uint8 { B.length block == block_length SHA1 } )
```

F* will reject these uses when #1905 is fixed.