### PR TITLE
Cleanup tests and makefiles

### DIFF
--- a/specs/Spec.Agile.HMAC.fst
+++ b/specs/Spec.Agile.HMAC.fst
@@ -6,8 +6,8 @@ open Lib.IntTypes
 
 #set-options "--max_fuel 0 --max_ifuel 0 --z3rlimit 50"
 
-let wrap 
-  (a: hash_alg) 
+let wrap
+  (a: hash_alg)
   (key: bytes{Seq.length key <= max_input_length a})
   : lbytes (block_length a)
 =
@@ -22,7 +22,7 @@ let xor (x: uint8) (v: bytes) : lbytes (Seq.length v) =
 
 let rec xor_lemma (x: uint8) (v: bytes) : Lemma
   (ensures xor x v == Spec.Loops.seq_map2 logxor (Seq.create (Seq.length v) x) v)
-  (decreases (Seq.length v)) 
+  (decreases (Seq.length v))
 =
   let l = Seq.length v in
   if l > 0 then (

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -1,22 +1,23 @@
 # A minimalistic Makefile for all testing options.
+# Note: on OSX, this necessitates a recent OpenSSL, possibly installed by brew,
+# so I had to do:
+# export CFLAGS="-I/usr/local/Cellar/openssl@1.1/1.1.1d/include/"
+# export LDFLAGS="-L/usr/local/Cellar/openssl@1.1/1.1.1d/lib"
 
 KREMLIN_HOME?=../dist/kremlin
 
 # Add GF128 tests once code/experimental/gf128 is promoted to code
 TARGETS = $(filter-out gf128-%, $(patsubst %.c,%.exe,$(wildcard *.c)))
-CFLAGS = -I$(KREMLIN_HOME)/include -I../dist/gcc64-only \
+CFLAGS := -I$(KREMLIN_HOME)/include -I../dist/gcc64-only \
   -I$(KREMLIN_HOME)/kremlib/dist/minimal \
   -I../secure_api/merkle_tree \
-  -O3 -march=native -mtune=native
+  -O3 -march=native -mtune=native $(CFLAGS)
 
 all: $(TARGETS)
 
 test: $(patsubst %.exe,%.test,$(TARGETS))
 
-arm: chacha20-arm-test.exe poly1305-arm-test.exe blake2-arm-test.exe
-	./chacha20-arm-test.exe
-	./poly1305-arm-test.exe
-	./blake2-arm-test.exe
+arm: chacha20-arm-test.test poly1305-arm-test.test blake2-arm-test.test
 
 # Dependency
 
@@ -34,19 +35,6 @@ curve64-rfc.exe: $(patsubst %.c,%.o,$(wildcard rfc7748_src/*.c))
 
 %.exe: %.o
 	$(CC) $(CFLAGS) $(LDFLAGS) $^ ../dist/gcc64-only/libevercrypt.a -o $@ -lcrypto
-
-chacha20-arm-test.exe: chacha20-arm-test.c
-	$(CC) $(CFLAGS) $(LDFLAGS) $^ ../dist/gcc64-only/Hacl_Chacha20.c ../dist/gcc64-only/Hacl_Chacha20_Vec128.c -o $@
-
-poly1305-arm-test.exe: poly1305-arm-test.c
-	$(CC) $(CFLAGS) $(LDFLAGS) $^ ../dist/gcc64-only/Hacl_Poly1305_32.c ../dist/gcc64-only/Hacl_Poly1305_128.c -o $@
-
-blake2-arm-test.exe: blake2-arm-test.c
-	$(CC) $(CFLAGS) $(LDFLAGS) $^ ../dist/gcc64-only/Hacl_Blake2s_32.c  ../dist/gcc64-only/Hacl_Blake2b_32.c ../dist/gcc64-only/Hacl_Blake2s_128.c -o $@
-
-curve25519-arm-test.exe: curve25519-arm-test.c
-	$(CC) $(CFLAGS) $(LDFLAGS) $^ ../dist/gcc64-only/Hacl_Curve25519_51.c -o $@
-
 
 # Running tests
 

--- a/tests/merkle_tree_test.c
+++ b/tests/merkle_tree_test.c
@@ -6,7 +6,7 @@
 #include "MerkleTree.h"
 #include "merkle_tree_test.h"
 
-static char hs[32U+1];
+static char hs[64U+1];
 
 static const uint32_t hash_size = 32;
 

--- a/tests/poly1305-test.c
+++ b/tests/poly1305-test.c
@@ -31,9 +31,9 @@ static __inline__ cycles cpucycles_end(void)
   //return ( (uint64_t)lo)|( ((uint64_t)hi)<<32 );
 }
 
-extern void Hacl_Poly1305_32_poly1305_mac(uint8_t* out, int in_len, uint8_t* in, uint8_t* k);
-extern void Hacl_Poly1305_128_poly1305_mac(uint8_t* out, int in_len, uint8_t* in, uint8_t* k);
-extern void Hacl_Poly1305_256_poly1305_mac(uint8_t* out, int in_len, uint8_t* in, uint8_t* k);
+#include "Hacl_Poly1305_32.h"
+#include "Hacl_Poly1305_128.h"
+#include "Hacl_Poly1305_256.h"
 
 #define ROUNDS 100000
 #define SIZE   16384


### PR DESCRIPTION
This is a minor cleanup of some things after the merge of the ARM tests.

- As far as I understand, all tests by default link against the static object (.a) which should be equivalent to linking against the .o, so deleting specific rules
- There was no support for overriding CFLAGS and LDFLAGS properly, which made the thing non-buildable on OSX since I have to export custom CFLAGS and LDFLAGS to get openssl/sha.h
- There was a buffer overflow in the hand-written merkle tree test
- There were already pseudo-targets for running a test, so I fixed that and now the `arm` target can be run in parallel
- I also removed hand-written extern declarations; if someone by chance decides to change the signature of the toplevel entry points for Poly, then we'll get a compile-time error rather than a segfault.

Generally it'd be good to start sharing some helpers in this tests/ directory -- can be done easily with a header containing static inline definitions, and no further build complication, but we can leave that for later.