### PR TITLE
Removing `abstract` keyword

### DIFF
--- a/Makefile.common
+++ b/Makefile.common
@@ -55,10 +55,12 @@ endif
 # 241: corrupt cache file AND stale cache file (argh!) we wish to make the
 #      former fatal, and the latter non-fatal if it's the file we're about to
 #      verify... see https://github.com/FStarLang/FStar/issues/1652
+# 332: abstract keyword
 FSTAR_NO_FLAGS = $(FSTAR_HOME)/bin/fstar.exe $(FSTAR_HINTS) \
   --odir $(OUTPUT_DIR) --cache_checked_modules $(FSTAR_INCLUDES) --cmi \
   --already_cached 'Prims FStar LowStar C Spec.Loops TestLib WasmSupport' --warn_error '+241@247-272' \
-  --cache_dir $(OUTPUT_DIR) --trivial_pre_for_unannotated_effectful_fns false
+  --cache_dir $(OUTPUT_DIR) --trivial_pre_for_unannotated_effectful_fns false \
+  --warn_error @332
 
 FSTAR = $(FSTAR_NO_FLAGS) $(OTHERFLAGS)
 

--- a/code/curve25519/Hacl.Spec.Curve25519.Field51.Definition.fst
+++ b/code/curve25519/Hacl.Spec.Curve25519.Field51.Definition.fst
@@ -77,7 +77,7 @@ let ( *^ ) (x:scale64) (y:scale64_5) : scale128_5 =
    x * y4 ,
    x * y5)
 
-abstract
+[@"opaque_to_smt"]
 let pow51: (pow51: pos { pow2 64 == 8192 * pow51 /\ pow2 128 == 67108864 * pow51 * pow51 /\ pow51 == pow2 51 }) =
   let pow51: pos = normalize_term (pow2 51) in
   assert_norm (pow51 > 0);

--- a/code/ed25519/Hacl.Spec.Ed25519.Field56.Definition.fst
+++ b/code/ed25519/Hacl.Spec.Ed25519.Field56.Definition.fst
@@ -7,14 +7,14 @@ open Lib.IntTypes
 
 let felem5 = (uint64 * uint64 * uint64 * uint64 * uint64)
 
-abstract
+[@"opaque_to_smt"]
 let pow32: (pow32: pos { pow32 == pow2 32 }) =
   let pow32: pos = normalize_term (pow2 32) in
   assert_norm (pow32 == pow2 32);
   pow32
 
 
-abstract
+[@"opaque_to_smt"]
 let pow56: (pow56: pos { pow56 == pow2 56 }) =
   let pow56: pos = normalize_term (pow2 56) in
   assert_norm (pow56 == pow2 56);

--- a/lib/Lib.Sequence.fst
+++ b/lib/Lib.Sequence.fst
@@ -19,6 +19,9 @@ let of_list #a l = Seq.seq_of_list #a l
 let of_list_index #a l i =
   Seq.lemma_seq_of_list_index #a l i
 
+let equal #a #len s1 s2 =
+  forall (i:size_nat{i < len}).{:pattern (index s1 i); (index s2 i)} index s1 i == index s2 i
+
 let eq_intro #a #len s1 s2 =
   assert (forall (i:nat{i < len}).{:pattern (Seq.index s1 i); (Seq.index s2 i)}
     index s1 i == index s2 i);

--- a/lib/Lib.Sequence.fsti
+++ b/lib/Lib.Sequence.fsti
@@ -80,9 +80,7 @@ val of_list_index:
   Lemma (index (of_list l) i == List.Tot.index l i)
     [SMTPat (index (of_list l) i)]
 
-abstract
-type equal (#a:Type) (#len:size_nat) (s1:lseq a len) (s2:lseq a len) =
-  forall (i:size_nat{i < len}).{:pattern (index s1 i); (index s2 i)} index s1 i == index s2 i
+val equal (#a:Type) (#len:size_nat) (s1:lseq a len) (s2:lseq a len) : Type0
 
 val eq_intro: #a:Type -> #len:size_nat -> s1:lseq a len -> s2:lseq a len ->
   Lemma


### PR DESCRIPTION
This PR removes the instances of the `abstract` keyword from the code. Following are some explanations:

Hacl.Spec.Curve25519.Field51.Definition.fst: I think just `[@"opaque_to_smt]` should suffice, it seems the idea is to expose to the solver only the type of the definition.

Hacl.Spec.Ed25519.Field56.Definition.fst: same.

Lib.Sequence.fsti: I didn't even know we allowed `abstract` keyword in the interface files, seems wrong. Anyway, we are hoping that we will be able to remove `abstract` keyword soon.

Lib.Sequence.fst: Corresponds to the .fsti change.