### PR TITLE
Attempt to fix JS doc auto-publication

### DIFF
--- a/doc/ci.sh
+++ b/doc/ci.sh
@@ -21,7 +21,9 @@ make html
 cp -R _build/html/* $1
 
 mkdir -p $1/javascript_doc
-cp -R ../dist/wasm/doc/out/* $1/javascript_doc
+(cd ../bindings/js && node api_doc.js)
+(cd ../bindings/js/doc && jsdoc readable_api.js -d out)
+cp -R ../bindings/js/doc/out/* $1/javascript_doc
 
 cd $1
 rm -rf static && mv _static static


### PR DESCRIPTION
Does not rely on `make all` doc generation, but rather directly generates the doc from `bindings/js` in `ci.sh`.