### PR TITLE
Fixes for changes in F* VC generation

### DIFF
--- a/code/ed25519/Hacl.Bignum25519.fst
+++ b/code/ed25519/Hacl.Bignum25519.fst
@@ -278,7 +278,8 @@ let carry_top b =
          };
   calc (<) {
     v b0 + 19 * (v b4 / pow2 51);
-    (<) { Math.Lemmas.lemma_div_lt_nat (v b4) 64 51 }
+    (<) { Math.Lemmas.lemma_div_lt_nat (v b4) 64 51;  //(v b4 / pow2 51) < (pow2 13)
+          Math.Lemmas.lemma_mult_lt_left 19 (v b4 / pow2 51) (pow2 13) }  //(19 * (v b4 / pow2 51)) < (19 * (pow2 13)) }
     v b0 + 19 * (pow2 13);
     (<=) { }
     pow2 51 + 19 * pow2 13;

--- a/code/ed25519/Hacl.Spec.BignumQ.Lemmas.fst
+++ b/code/ed25519/Hacl.Spec.BignumQ.Lemmas.fst
@@ -886,7 +886,7 @@ let lemma_barrett_reduce'' (u:nat) (z:nat) (x:nat) (q:nat) : Lemma
   )
 
 
-
+#restart-solver
 #reset-options "--z3rlimit 600 --max_fuel 0 --max_ifuel 0"
 
 let lemma_barrett_reduce' x =
@@ -933,7 +933,6 @@ let lemma_barrett_reduce' x =
   let u = if r < qml then pow2 264 + r - qml else r - qml in
   let z = if u < l then u else u - l in
 
-  assert (u < 2 * l);
   Math.Lemmas.modulo_lemma u (pow2 264);
   assert (u == x - q * l);
   lemma_barrett_reduce'' u z x q

--- a/code/poly1305/Hacl.Spec.Poly1305.Field32xN.Lemmas.fst
+++ b/code/poly1305/Hacl.Spec.Poly1305.Field32xN.Lemmas.fst
@@ -595,14 +595,16 @@ val fmul_r4_normalize5_lemma:
     (feval5 out).[0] == Vec.normalize_4 (feval5 r).[0] (feval5 acc)))
   [SMTPat (fmul_r4_normalize5 acc r r_5 r4)]
 
+#restart-solver
+#push-options "--z3rlimit 500"
 let fmul_r4_normalize5_lemma acc fr fr_5 fr4 =
-  let fr2 = fmul_r5 fr fr fr_5 in
-  let fr3 = fmul_r5 fr2 fr fr_5 in
+  let fr2 = fmul_r5 #4 fr fr fr_5 in
+  let fr3 = fmul_r5 #4 fr2 fr fr_5 in
   let out = fmul_r4_normalize50 acc fr fr2 fr3 fr4 in
   let v2 = fmul_r4_normalize51 out in
   let res = carry_full_felem5 v2 in
   carry_full_felem5_lemma v2
-
+#pop-options
 
 val load_felem5_lemma:
     #w:lanes

--- a/hints/Hacl.Bignum25519.fst.hints
+++ b/hints/Hacl.Bignum25519.fst.hints
@@ -1,5 +1,5 @@
 [
-  "wkÛ\u001dNCn\nrÙ]˜rë™1",
+  "P¸Ò\u000fv/j\nj²°\u001dþÕtq",
   [
     [
       "Hacl.Bignum25519.getx",
@@ -45,7 +45,7 @@
         "typing_tok_Lib.Buffer.MUT@tok"
       ],
       0,
-      "08fc66a1ee9a811149280ce75da3edbf"
+      "8f7e0636c3a9ebc8fc1fac33db5e990f"
     ],
     [
       "Hacl.Bignum25519.gety",
@@ -89,7 +89,7 @@
         "typing_LowStar.Monotonic.Buffer.len"
       ],
       0,
-      "56110f74e7a6f2546922811057b2bd43"
+      "0efc0a1795590fc949acd089b35c7d04"
     ],
     [
       "Hacl.Bignum25519.getz",
@@ -133,7 +133,7 @@
         "typing_LowStar.Monotonic.Buffer.len"
       ],
       0,
-      "152ad7ef099a67a11d82a15b56aea90f"
+      "84181974e6465354b6f52eda1c253745"
     ],
     [
       "Hacl.Bignum25519.gett",
@@ -180,7 +180,7 @@
         "typing_LowStar.Monotonic.Buffer.len"
       ],
       0,
-      "2433e7c31f67eeb4a64134c8e98094c5"
+      "2a27009fd06ad34827e6648bdf2b43cf"
     ],
     [
       "Hacl.Bignum25519.mask_51",
@@ -204,7 +204,7 @@
         "typing_Lib.IntTypes.bits", "typing_tok_Lib.IntTypes.U64@tok"
       ],
       0,
-      "fb44fb9b406424aff790bec1bfb55edc"
+      "b797ca9434954c52a40177b20af969a5"
     ],
     [
       "Hacl.Bignum25519.make_u64_5",
@@ -282,7 +282,7 @@
         "typing_tok_Lib.Buffer.MUT@tok", "typing_tok_Lib.IntTypes.U32@tok"
       ],
       0,
-      "82bed8068841bcb5b1c6cbea7530151b"
+      "484f754f5820e5f8730dd01711c88324"
     ],
     [
       "Hacl.Bignum25519.make_u64_10",
@@ -341,7 +341,7 @@
         "typing_tok_Lib.Buffer.MUT@tok"
       ],
       0,
-      "12005f6812d503a05fda1f2fcade8883"
+      "ec027179b7ce73a64097d76e10aecfa2"
     ],
     [
       "Hacl.Bignum25519.make_u64_10",
@@ -423,7 +423,7 @@
         "typing_tok_Lib.Buffer.MUT@tok", "typing_tok_Lib.IntTypes.U32@tok"
       ],
       0,
-      "851ab7e2af0248b338a5bac565d961ac"
+      "a3e7749ef6ccdffd328a4422814f6e48"
     ],
     [
       "Hacl.Bignum25519.make_u128_9",
@@ -489,7 +489,7 @@
         "typing_tok_Lib.Buffer.MUT@tok", "typing_tok_Lib.IntTypes.U32@tok"
       ],
       0,
-      "747d446b1a56c22e5394dd66f6f85e4e"
+      "958bd039446d00afa7323b6c628e8632"
     ],
     [
       "Hacl.Bignum25519.make_zero",
@@ -599,7 +599,7 @@
         "typing_tok_Lib.IntTypes.U32@tok", "typing_tok_Lib.IntTypes.U64@tok"
       ],
       0,
-      "8668a9580b59f6ca7f42cd2e5114ad7a"
+      "a7b6b9af2c8b3f3514ae195c6e7f8e1a"
     ],
     [
       "Hacl.Bignum25519.make_one",
@@ -708,7 +708,7 @@
         "typing_tok_Lib.IntTypes.U64@tok"
       ],
       0,
-      "932225e8958ad04b5092a3264df68db5"
+      "6651451ba4a3bc57ac0233031be48b34"
     ],
     [
       "Hacl.Bignum25519.fsum",
@@ -732,7 +732,7 @@
         "refinement_interpretation_Tm_refine_d0b2515772aba03903eb0529ef4e1d75"
       ],
       0,
-      "4413514939d081faa2fca6fe15d9ea0b"
+      "00deef1afaeb1bd14c3384875a6343ac"
     ],
     [
       "Hacl.Bignum25519.fdifference",
@@ -763,7 +763,7 @@
         "typing_Lib.Buffer.loc", "typing_tok_Lib.Buffer.MUT@tok"
       ],
       0,
-      "5355da1b9b6239e8265bacbc47b36d32"
+      "df2df6aa5677b39e32cd9c0a049d4d51"
     ],
     [
       "Hacl.Bignum25519.lemma_carry_local",
@@ -777,7 +777,7 @@
         "refinement_interpretation_Tm_refine_542f9d4f129664613f2483a6c88bc7c2"
       ],
       0,
-      "663a8f6dfd04d233927214d020a060f8"
+      "123f891bc8e51231012252bc69601c42"
     ],
     [
       "Hacl.Bignum25519.lemma_carry_local",
@@ -797,7 +797,7 @@
         "typing_Prims.pow2"
       ],
       0,
-      "15c832944307fa4cf9f8605aa18d9f0d"
+      "59765659ca399e1a038d9c60f4cab022"
     ],
     [
       "Hacl.Bignum25519.lemma_change_as_nat_repr",
@@ -815,7 +815,7 @@
         "typing_Prims.pow2"
       ],
       0,
-      "fe0ad92a73dd78d821e7d53b685fdbb3"
+      "58b0e5c39e359117be4d491b9b50f371"
     ],
     [
       "Hacl.Bignum25519.lemma_fcontract_first_carry_pass",
@@ -834,7 +834,7 @@
         "typing_Prims.pow2"
       ],
       0,
-      "36818fa2338e24c6d1e36acc597715d9"
+      "d8623aa3a2ef0ffaeb72cf8d83868cb2"
     ],
     [
       "Hacl.Bignum25519.fcontract_first_carry_pass",
@@ -894,7 +894,7 @@
         "typing_tok_Lib.Buffer.MUT@tok"
       ],
       0,
-      "1c4a07a013634d9732a639d7d73a8b11"
+      "d952e3e33ea528bf5a9d9b77073fb0c8"
     ],
     [
       "Hacl.Bignum25519.fcontract_first_carry_pass",
@@ -1009,7 +1009,7 @@
         "typing_tok_Lib.IntTypes.U64@tok"
       ],
       0,
-      "f08bd4efb49b71b78bda96e2d0c902c3"
+      "cfe07982c9c48f73a281c8e15126e1bc"
     ],
     [
       "Hacl.Bignum25519.lemma_change_repr4",
@@ -1027,7 +1027,7 @@
         "typing_Prims.pow2"
       ],
       0,
-      "04ec6e4928b4f57a2a1722595b04e259"
+      "654c045581ec09664043a431fb398733"
     ],
     [
       "Hacl.Bignum25519.lemma_small_carry_top",
@@ -1043,7 +1043,7 @@
         "refinement_interpretation_Tm_refine_542f9d4f129664613f2483a6c88bc7c2"
       ],
       0,
-      "40eb291902324084923485af467e2648"
+      "83d6b9a5a998a0cfa32bdffdbdf4da93"
     ],
     [
       "Hacl.Bignum25519.carry_top",
@@ -1094,7 +1094,7 @@
         "typing_tok_Lib.Buffer.MUT@tok"
       ],
       0,
-      "34f6e0f8286534e8b32b1b7136531d93"
+      "2f03808a39d06ecc45005a3c54545f40"
     ],
     [
       "Hacl.Bignum25519.carry_top",
@@ -1224,7 +1224,7 @@
         "typing_tok_Lib.IntTypes.U64@tok"
       ],
       0,
-      "a1e02487171cfc02f1b6bed45de65883"
+      "582d9a6bc06ebb099fcda94d0930fa3e"
     ],
     [
       "Hacl.Bignum25519.reduce_513",
@@ -1279,7 +1279,7 @@
         "typing_Hacl.Spec.Curve25519.Field51.Definition.pow51"
       ],
       0,
-      "0761253545b81223c86b7fb7f7f9c31c"
+      "87ae499925108351c3fb6403cd0933b4"
     ],
     [
       "Hacl.Bignum25519.fcontract_first_carry_full",
@@ -1369,7 +1369,7 @@
         "typing_tok_Lib.IntTypes.U64@tok"
       ],
       0,
-      "a9d04d292488bb58c97fa972b65d780a"
+      "cce30816f4b6defad3f59fe79a303fe1"
     ],
     [
       "Hacl.Bignum25519.carry_0_to_1",
@@ -1417,7 +1417,7 @@
         "typing_tok_Lib.Buffer.MUT@tok"
       ],
       0,
-      "f52f81e2de55084724bb272f400e3b50"
+      "fa6002dac752d223b89def97353dc5bf"
     ],
     [
       "Hacl.Bignum25519.carry_0_to_1",
@@ -1543,7 +1543,7 @@
         "typing_tok_Lib.IntTypes.U64@tok"
       ],
       0,
-      "c869f4b006f43c10a8618c38d37dbd0f"
+      "770d1bfacd34e189b160ae3e4c61782a"
     ],
     [
       "Hacl.Bignum25519.fcontract_second_carry_pass",
@@ -1601,7 +1601,7 @@
         "typing_tok_Lib.Buffer.MUT@tok"
       ],
       0,
-      "19ba2587e5cd5b3f8600942bd26a7bd7"
+      "35b79b48697c71f84fa13a5878c6c5c2"
     ],
     [
       "Hacl.Bignum25519.fcontract_second_carry_pass",
@@ -1719,7 +1719,7 @@
         "typing_tok_Lib.IntTypes.U64@tok"
       ],
       0,
-      "64ec729633479bd755274782e9afc13f"
+      "e14b3139005527b9ea14c88e3778d89c"
     ],
     [
       "Hacl.Bignum25519.fcontract_second_carry_full",
@@ -1819,7 +1819,7 @@
         "typing_tok_Lib.IntTypes.U64@tok"
       ],
       0,
-      "f91954df955ea1517cec976600172291"
+      "ee12862ae8e77f0e9efbfbfbecfcc6f2"
     ],
     [
       "Hacl.Bignum25519.lemma_fcontract_trim",
@@ -1862,7 +1862,7 @@
         "typing_tok_Lib.IntTypes.SEC@tok", "typing_tok_Lib.IntTypes.U64@tok"
       ],
       0,
-      "03c102064970cb7750020b7774334150"
+      "5601d9334da03b57c0cb2b8c3c9fb4c7"
     ],
     [
       "Hacl.Bignum25519.fcontract_trim",
@@ -1993,7 +1993,7 @@
         "typing_tok_Lib.IntTypes.SEC@tok", "typing_tok_Lib.IntTypes.U64@tok"
       ],
       0,
-      "6421d396e608ed6d3bdc4d6ecf44ca49"
+      "0ec98ccb68e7e133a79d9022dd5f0d83"
     ],
     [
       "Hacl.Bignum25519.reduce_",
@@ -2029,7 +2029,7 @@
         "typing_tok_Lib.Buffer.MUT@tok"
       ],
       0,
-      "8d3d58d6d20919e2d878de3be983f225"
+      "1de3f1e7327613ac9732594fb9b0370b"
     ],
     [
       "Hacl.Bignum25519.fmul",
@@ -2205,7 +2205,7 @@
         "typing_tok_Lib.IntTypes.U32@tok"
       ],
       0,
-      "da265c0258b27aecec964cb029d7c449"
+      "4719a614348f8b20c019332c9da0b31d"
     ],
     [
       "Hacl.Bignum25519.times_2",
@@ -2221,7 +2221,7 @@
         "refinement_interpretation_Tm_refine_542f9d4f129664613f2483a6c88bc7c2"
       ],
       0,
-      "ba044f654f32202bc27b0904cff2beb5"
+      "846cca9f61d9ac2e1d340e6366fda5da"
     ],
     [
       "Hacl.Bignum25519.times_2",
@@ -2290,14 +2290,13 @@
         "function_token_typing_Lib.IntTypes.uint64", "int_inversion",
         "int_typing", "lemma_FStar.Map.lemma_ContainsDom",
         "lemma_FStar.UInt.pow2_values", "lemma_FStar.UInt32.vu_inv",
-        "lemma_Lib.IntTypes.mul_mod_lemma",
+        "lemma_Lib.IntTypes.mul_mod_lemma", "lemma_Lib.IntTypes.v_injective",
         "lemma_LowStar.Monotonic.Buffer.length_as_seq",
         "lemma_LowStar.Monotonic.Buffer.length_null_1",
         "lemma_LowStar.Monotonic.Buffer.length_null_2",
         "primitive_Prims.op_AmpAmp", "primitive_Prims.op_GreaterThanOrEqual",
-        "primitive_Prims.op_LessThan", "primitive_Prims.op_LessThanOrEqual",
-        "primitive_Prims.op_Modulus", "primitive_Prims.op_Multiply",
-        "primitive_Prims.op_Subtraction",
+        "primitive_Prims.op_LessThanOrEqual", "primitive_Prims.op_Modulus",
+        "primitive_Prims.op_Multiply", "primitive_Prims.op_Subtraction",
         "projection_inverse_BoxBool_proj_0",
         "projection_inverse_BoxInt_proj_0",
         "projection_inverse_FStar.Pervasives.Native.Mktuple5__1",
@@ -2308,6 +2307,7 @@
         "refinement_interpretation_Tm_refine_05e15190c946858f68c69156f585f95a",
         "refinement_interpretation_Tm_refine_0ec011aea9f93256a3547ad9f0c667f1",
         "refinement_interpretation_Tm_refine_2b9ac1d6c43e9e240d84837e7e466c45",
+        "refinement_interpretation_Tm_refine_365abba901205a01d0ef28ebf2198c47",
         "refinement_interpretation_Tm_refine_3871e437df8a6451fa68fcfdf4f6590e",
         "refinement_interpretation_Tm_refine_4e3bbd8eec0c3ef82902d2336c68c242",
         "refinement_interpretation_Tm_refine_542f9d4f129664613f2483a6c88bc7c2",
@@ -2321,6 +2321,8 @@
         "refinement_interpretation_Tm_refine_f13070840248fced9d9d60d77bdae3ec",
         "refinement_interpretation_Tm_refine_fd395a7c68ba47ba743b0f42bf0c166a",
         "typing_FStar.Map.contains", "typing_FStar.Monotonic.HyperHeap.rid",
+        "typing_FStar.Monotonic.HyperHeap.rid_freeable",
+        "typing_FStar.Monotonic.HyperHeap.root",
         "typing_FStar.Monotonic.HyperStack.get_hmap",
         "typing_FStar.Monotonic.HyperStack.get_tip",
         "typing_FStar.UInt.fits", "typing_FStar.UInt32.v",
@@ -2336,7 +2338,7 @@
         "typing_tok_Lib.IntTypes.U64@tok"
       ],
       0,
-      "0687c6105e75637d9873457dcd9a9449"
+      "eb27db78db679c63606864a462605af3"
     ],
     [
       "Hacl.Bignum25519.times_d",
@@ -2536,7 +2538,7 @@
         "typing_tok_Lib.IntTypes.U64@tok"
       ],
       0,
-      "592374905046e23a9ae37a2dc34e9d2d"
+      "3cbe25b78a61adc2575fbea3112d460c"
     ],
     [
       "Hacl.Bignum25519.times_2d",
@@ -2552,7 +2554,7 @@
         "refinement_interpretation_Tm_refine_542f9d4f129664613f2483a6c88bc7c2"
       ],
       0,
-      "4d81a5daef012c9c89acf5f438bc023f"
+      "a2675303197f47de2d808c6ddc72f4c5"
     ],
     [
       "Hacl.Bignum25519.times_2d",
@@ -2756,7 +2758,7 @@
         "typing_tok_Lib.IntTypes.SEC@tok", "typing_tok_Lib.IntTypes.U64@tok"
       ],
       0,
-      "619586d8686d939e9d537d60cc5b2059"
+      "00c572d9a5181e3543abdab25a78893b"
     ],
     [
       "Hacl.Bignum25519.fsquare",
@@ -2927,7 +2929,7 @@
         "typing_tok_Lib.Buffer.MUT@tok"
       ],
       0,
-      "8d096dbd8d59467f1338809cf08c45e0"
+      "52116e0718ab5f26f51d42e85dcf5d9e"
     ],
     [
       "Hacl.Bignum25519.fsquare_times_",
@@ -2939,7 +2941,7 @@
         "refinement_interpretation_Tm_refine_cfc41488cee641ca406ae764563b3947"
       ],
       0,
-      "d5de87fc0252c0bb82f7f042aa04de12"
+      "ecbc61bff4aed3c36d56a5f324b38410"
     ],
     [
       "Hacl.Bignum25519.fsquare_times_",
@@ -2970,7 +2972,7 @@
         "typing_Lib.Buffer.loc", "typing_tok_Lib.Buffer.MUT@tok"
       ],
       0,
-      "6c2c4e6212bc14848b708f7c61146af9"
+      "4f004d3805abc2bb3efe54a15a3dd621"
     ],
     [
       "Hacl.Bignum25519.fsquare_times",
@@ -2982,7 +2984,7 @@
         "refinement_interpretation_Tm_refine_cfc41488cee641ca406ae764563b3947"
       ],
       0,
-      "8db0376bbca78750ce423aca0b1a7d50"
+      "d94b91f24d88584684581baf4db2034f"
     ],
     [
       "Hacl.Bignum25519.fsquare_times",
@@ -3143,7 +3145,7 @@
         "typing_tok_Lib.Buffer.MUT@tok"
       ],
       0,
-      "cab3097ba0b7a007957bd79a113d4a4d"
+      "59d25ee96ecb3e9350ef7f66744bd29f"
     ],
     [
       "Hacl.Bignum25519.fsquare_times_inplace",
@@ -3155,7 +3157,7 @@
         "refinement_interpretation_Tm_refine_cfc41488cee641ca406ae764563b3947"
       ],
       0,
-      "5268b2a689b3b6a1861d7088ae71dd76"
+      "5abcb4ddeb4b441cee9372587606ad7b"
     ],
     [
       "Hacl.Bignum25519.fsquare_times_inplace",
@@ -3315,7 +3317,7 @@
         "typing_tok_Lib.Buffer.MUT@tok"
       ],
       0,
-      "1c1983738e34ad8866bb7c51dfe35ca7"
+      "1c3d698b79c940cbc78da771935b8ad5"
     ],
     [
       "Hacl.Bignum25519.inverse",
@@ -3489,7 +3491,7 @@
         "typing_tok_Lib.IntTypes.U32@tok"
       ],
       0,
-      "93ae07e03cda1f8628588db6a9456cc9"
+      "0bf252a83397e5b9dc6d5d8bffa99ed1"
     ],
     [
       "Hacl.Bignum25519.lemma_split_nat_from_bytes_le",
@@ -3527,7 +3529,7 @@
         "refinement_interpretation_Tm_refine_d8ff7f186e3b40eb6293ad051c6bfc18"
       ],
       0,
-      "925eff72c80b4e7ba4def3846c7852f1"
+      "5e54dafc48c41563763d58f1e2f55d4b"
     ],
     [
       "Hacl.Bignum25519.lemma_partial_nat_from_bytes_le",
@@ -3545,7 +3547,7 @@
         "refinement_interpretation_Tm_refine_542f9d4f129664613f2483a6c88bc7c2"
       ],
       0,
-      "bfc1c4f4be2bfc1c19db2c7d73735428"
+      "a09ecd5f015b6f72c61d59ce9afa1052"
     ],
     [
       "Hacl.Bignum25519.lemma_partial_nat_from_bytes_le",
@@ -3591,7 +3593,7 @@
         "typing_FStar.Seq.Base.length", "typing_FStar.UInt.min_int"
       ],
       0,
-      "68928e8fed554e560abb4b6884e850ec"
+      "33428bbd15faff8f52edc95fa79875f1"
     ],
     [
       "Hacl.Bignum25519.lemma_combine_div_mod_pow2",
@@ -3611,7 +3613,7 @@
         "typing_Prims.pow2"
       ],
       0,
-      "a5aa927b67db28e969b6ec27f526d2f1"
+      "78437f31059e76fba262d13b1e8c34e1"
     ],
     [
       "Hacl.Bignum25519.lemma_load_51",
@@ -3636,7 +3638,7 @@
         "refinement_interpretation_Tm_refine_542f9d4f129664613f2483a6c88bc7c2"
       ],
       0,
-      "786c098a8e15f28e0948f3eadd59da1c"
+      "6e1668f5825049bb1dd4fbbc0b45d6d1"
     ],
     [
       "Hacl.Bignum25519.lemma_load_51",
@@ -3654,7 +3656,7 @@
         "refinement_interpretation_Tm_refine_542f9d4f129664613f2483a6c88bc7c2"
       ],
       0,
-      "e6f192159ca896e3790e197845d1f968"
+      "5dc9c89bb602e379f27024ee4fd9fa90"
     ],
     [
       "Hacl.Bignum25519.lemma_load_51",
@@ -3694,7 +3696,7 @@
         "typing_tok_Lib.IntTypes.SEC@tok"
       ],
       0,
-      "a15b10dbf25548f4b2070ba1fdf2f159"
+      "6485eff501e8b4d2433d886f045e906f"
     ],
     [
       "Hacl.Bignum25519.load_51",
@@ -3762,7 +3764,7 @@
         "typing_tok_Lib.IntTypes.U32@tok"
       ],
       0,
-      "2c9884baf135a3a7392dc89b044aafe5"
+      "b60e45ac6949f69fa7b84f9c57c080e8"
     ],
     [
       "Hacl.Bignum25519.load_51",
@@ -3888,7 +3890,7 @@
         "typing_tok_Lib.IntTypes.U64@tok", "typing_tok_Lib.IntTypes.U8@tok"
       ],
       0,
-      "86c459b38b657ebe9f0276f5fac3381b"
+      "3c5e814cec0069faba283f60d32aa755"
     ],
     [
       "Hacl.Bignum25519.lemma_uints_to_bytes_le_split",
@@ -3942,7 +3944,7 @@
         "typing_tok_Lib.IntTypes.U64@tok"
       ],
       0,
-      "0469244268e9a5a3f71ad91b3b9319ac"
+      "814a75ae64fe4ceec63410ba726d7927"
     ],
     [
       "Hacl.Bignum25519.store_4",
@@ -3984,7 +3986,7 @@
         "typing_FStar.Monotonic.HyperStack.get_hmap"
       ],
       0,
-      "48b30fa1052471f8980f117c2e00bf1a"
+      "b2df2b265896e8217f0c2ed813e76e23"
     ],
     [
       "Hacl.Bignum25519.store_4",
@@ -4089,7 +4091,7 @@
         "typing_tok_Lib.IntTypes.U64@tok"
       ],
       0,
-      "d5d8e6db167fe44447ecab41a0a43999"
+      "de251ebc3b32f646fbfa7d6dbfdd8891"
     ],
     [
       "Hacl.Bignum25519.store_51",
@@ -4129,7 +4131,7 @@
         "typing_Lib.Buffer.length", "typing_tok_Lib.Buffer.MUT@tok"
       ],
       0,
-      "2dfeb937a51c23cfb45b46d139eac5a0"
+      "232cbb7ec9499cc59177eea159ad8f07"
     ],
     [
       "Hacl.Bignum25519.store_51",
@@ -4239,7 +4241,7 @@
         "typing_tok_Lib.IntTypes.U64@tok"
       ],
       0,
-      "d6dd5576adf38c4e0c9ba2626561371e"
+      "efb734ca40feba58dbec75f9a2b7a9ef"
     ]
   ]
 ]

--- a/hints/Hacl.Spec.BignumQ.Lemmas.fst.hints
+++ b/hints/Hacl.Spec.BignumQ.Lemmas.fst.hints
@@ -1,5 +1,5 @@
 [
-  "DžÝOˆ:/·Ë˜Gl`4ë•",
+  "I¯‹®w\u0019÷…cåîMtT\u0001™",
   [
     [
       "Hacl.Spec.BignumQ.Lemmas.feq",
@@ -8,7 +8,7 @@
       0,
       [ "@query" ],
       0,
-      "f1acad3294f540ac5d95413ecd908163"
+      "9eadf5d8050e28769fa0285e9f83680d"
     ],
     [
       "Hacl.Spec.BignumQ.Lemmas.eq_eq2",
@@ -17,7 +17,7 @@
       0,
       [ "@query" ],
       0,
-      "967707854850239d551d4b2bffef758c"
+      "7e28a12ee3b276506ab4bba47e518377"
     ],
     [
       "Hacl.Spec.BignumQ.Lemmas.lemma_mul_lt",
@@ -30,7 +30,7 @@
         "refinement_interpretation_Tm_refine_542f9d4f129664613f2483a6c88bc7c2"
       ],
       0,
-      "09747226465f036ac7213ff807d3274f"
+      "38f34849d28d6f3fae648058e45b8297"
     ],
     [
       "Hacl.Spec.BignumQ.Lemmas.lemma_as_nat5",
@@ -63,7 +63,7 @@
         "typing_Hacl.Spec.BignumQ.Definitions.pow56"
       ],
       0,
-      "2693a5c5e4cde6c8254fab36b8802482"
+      "4ca8d0a38e82729d37120aabe57a17ca"
     ],
     [
       "Hacl.Spec.BignumQ.Lemmas.lemma_choose_step",
@@ -92,7 +92,7 @@
         "typing_tok_Lib.IntTypes.SEC@tok", "typing_tok_Lib.IntTypes.U64@tok"
       ],
       0,
-      "f0c41e4a3efd66ed92a5db6c1129278c"
+      "7de1e24649243f77a1a0be5cf71d3bf1"
     ],
     [
       "Hacl.Spec.BignumQ.Lemmas.lemma_choose_step",
@@ -134,7 +134,7 @@
         "typing_tok_Lib.IntTypes.U64@tok"
       ],
       0,
-      "ff1646eac6a981821bd8f9756db475ee"
+      "9f422b47b52d7fda6da7273d1646e8ac"
     ],
     [
       "Hacl.Spec.BignumQ.Lemmas.lemma_subm_conditional",
@@ -149,7 +149,7 @@
         "projection_inverse_BoxInt_proj_0"
       ],
       0,
-      "40051aa4f20331f0479e1b2929634080"
+      "5d17fccd3d1b2c607b1f6c149fcff595"
     ],
     [
       "Hacl.Spec.BignumQ.Lemmas.lemma_div224",
@@ -158,7 +158,7 @@
       0,
       [ "@query" ],
       0,
-      "68da20417ef503db2d554a3845ab3c95"
+      "be3337dc8de39fad9b64839132b51a82"
     ],
     [
       "Hacl.Spec.BignumQ.Lemmas.lemma_div224",
@@ -224,7 +224,7 @@
         "typing_tok_Lib.IntTypes.U64@tok"
       ],
       0,
-      "07abc64cff8f67f22f927ba8ca823d1a"
+      "9e9a88b7ded4b2c8396c4007b1a584c7"
     ],
     [
       "Hacl.Spec.BignumQ.Lemmas.lemma_div248_aux",
@@ -233,7 +233,7 @@
       0,
       [ "@query" ],
       0,
-      "5c43abc6c37a59266f8788ba14e0b634"
+      "291d3a9bdff1ccf372de281544857554"
     ],
     [
       "Hacl.Spec.BignumQ.Lemmas.lemma_div248_aux",
@@ -275,7 +275,7 @@
         "typing_Hacl.Spec.BignumQ.Definitions.pow56"
       ],
       0,
-      "33d9df2e91cbec790dac868480b023f9"
+      "4cf40ece822d46d2e21f73e95d38c1db"
     ],
     [
       "Hacl.Spec.BignumQ.Lemmas.lemma_div248_aux",
@@ -300,7 +300,7 @@
         "typing_Hacl.Spec.BignumQ.Definitions.pow224"
       ],
       0,
-      "7e90323a586a92e5c1f96b1e5d00e63b"
+      "43e2baeef6b826214977908e04e9be4a"
     ],
     [
       "Hacl.Spec.BignumQ.Lemmas.lemma_div248_x5",
@@ -309,7 +309,7 @@
       0,
       [ "@query" ],
       0,
-      "c1ae76cead7087a966a5b7d4122e414a"
+      "e99b82ced9927e7400f2d0a102f747f2"
     ],
     [
       "Hacl.Spec.BignumQ.Lemmas.lemma_div248_x5",
@@ -338,7 +338,7 @@
         "typing_tok_Lib.IntTypes.U64@tok"
       ],
       0,
-      "c6d2ec4a9266d7cb65fe87d546514fce"
+      "eddc321f183225bd7d1b711dc4935735"
     ],
     [
       "Hacl.Spec.BignumQ.Lemmas.lemma_div248_x6",
@@ -347,7 +347,7 @@
       0,
       [ "@query" ],
       0,
-      "d215a4e91343bf9f42fb7ac34c98ae15"
+      "cb8f5f33fe6fae8ea07d74510056af16"
     ],
     [
       "Hacl.Spec.BignumQ.Lemmas.lemma_div248_x6",
@@ -377,7 +377,7 @@
         "typing_tok_Lib.IntTypes.U64@tok"
       ],
       0,
-      "5963e782eee9896cd0bb8c3ca8722ab5"
+      "5919c558c8f800cf50b7100b4334edff"
     ],
     [
       "Hacl.Spec.BignumQ.Lemmas.lemma_div248_x6",
@@ -386,7 +386,7 @@
       0,
       [ "@query" ],
       0,
-      "9dd18bd7b85f69fb36c977fcbfdd2f8d"
+      "0124e7ba2be7b54d772fc28c894c4933"
     ],
     [
       "Hacl.Spec.BignumQ.Lemmas.lemma_div248_x6",
@@ -395,7 +395,7 @@
       0,
       [ "@query" ],
       0,
-      "9ae7cfcd6e35e9f91c06977917c8d8e3"
+      "03d3c4e3aac65a3821d2ca97602c5092"
     ],
     [
       "Hacl.Spec.BignumQ.Lemmas.lemma_div248_x6",
@@ -407,7 +407,7 @@
         "refinement_interpretation_Tm_refine_0766302b68bb44ab7aff8c4d8be0b46f"
       ],
       0,
-      "ab17a298eac49e8e37f2458d983f3909"
+      "4084377db56509c6c290943f3571a6c7"
     ],
     [
       "Hacl.Spec.BignumQ.Lemmas.lemma_div248_x6",
@@ -419,7 +419,7 @@
         "refinement_interpretation_Tm_refine_0766302b68bb44ab7aff8c4d8be0b46f"
       ],
       0,
-      "f51669086aeaa7338b05281d17975bdf"
+      "f596ca36ed7f23c2227c4774fc72a4f4"
     ],
     [
       "Hacl.Spec.BignumQ.Lemmas.lemma_div248_x7",
@@ -428,7 +428,7 @@
       0,
       [ "@query" ],
       0,
-      "c41cd23d79a12888d617b5a063394460"
+      "3451ff7462b438e9c85083ac46bfce45"
     ],
     [
       "Hacl.Spec.BignumQ.Lemmas.lemma_div248_x7",
@@ -456,7 +456,7 @@
         "typing_tok_Lib.IntTypes.U64@tok"
       ],
       0,
-      "6a60959b5974a3cada97f93a0e819141"
+      "e2f0cbc1bbb736e828cc744ac899abe4"
     ],
     [
       "Hacl.Spec.BignumQ.Lemmas.lemma_div248_x7",
@@ -465,7 +465,7 @@
       0,
       [ "@query" ],
       0,
-      "f7b358e856be391483d307d5bff80098"
+      "db5f38bed38e41842d792741f991ea76"
     ],
     [
       "Hacl.Spec.BignumQ.Lemmas.lemma_div248_x7",
@@ -474,7 +474,7 @@
       0,
       [ "@query" ],
       0,
-      "f9e14d16bab1a3ab84a54ef5b0a4aff1"
+      "2715a31df5e680e2c14d723db815a2ce"
     ],
     [
       "Hacl.Spec.BignumQ.Lemmas.lemma_div248_x7",
@@ -486,7 +486,7 @@
         "refinement_interpretation_Tm_refine_0766302b68bb44ab7aff8c4d8be0b46f"
       ],
       0,
-      "63e3aa934c0c07c27a51057c0ba6dbd8"
+      "f53b06399d16f4ebca8b49486c35e31f"
     ],
     [
       "Hacl.Spec.BignumQ.Lemmas.lemma_div248_x7",
@@ -498,7 +498,7 @@
         "refinement_interpretation_Tm_refine_0766302b68bb44ab7aff8c4d8be0b46f"
       ],
       0,
-      "2e93f427e9bfdc30797564d79f7593a3"
+      "67069ac1de1c275460b8416e189181e7"
     ],
     [
       "Hacl.Spec.BignumQ.Lemmas.lemma_div248_x8",
@@ -507,7 +507,7 @@
       0,
       [ "@query" ],
       0,
-      "7faf4c65636590231b2430d2beed6ca7"
+      "cae26d93cfdbb1b54835e483f2073708"
     ],
     [
       "Hacl.Spec.BignumQ.Lemmas.lemma_div248_x8",
@@ -537,7 +537,7 @@
         "typing_tok_Lib.IntTypes.U64@tok"
       ],
       0,
-      "7d97dc4d596242afa8fcb36be094b5a4"
+      "b7f970311bbc31818e9120b9d23e5ba0"
     ],
     [
       "Hacl.Spec.BignumQ.Lemmas.lemma_div248_x8",
@@ -546,7 +546,7 @@
       0,
       [ "@query" ],
       0,
-      "44ac5aec583af42187eaf1db293704ce"
+      "d3ef5af7f669e0499e606b9c86f7c262"
     ],
     [
       "Hacl.Spec.BignumQ.Lemmas.lemma_div248_x8",
@@ -555,7 +555,7 @@
       0,
       [ "@query" ],
       0,
-      "013e11dc6555e1809b5689b463f79c70"
+      "d1d1ef33f899c7859e3eed86047e2db5"
     ],
     [
       "Hacl.Spec.BignumQ.Lemmas.lemma_div248_x8",
@@ -567,7 +567,7 @@
         "refinement_interpretation_Tm_refine_0766302b68bb44ab7aff8c4d8be0b46f"
       ],
       0,
-      "cfcd9001d0fbe2bb0ba5af841d75aebf"
+      "43fec7db0c4380ba2e1faf6d76e41547"
     ],
     [
       "Hacl.Spec.BignumQ.Lemmas.lemma_div248_x8",
@@ -579,7 +579,7 @@
         "refinement_interpretation_Tm_refine_0766302b68bb44ab7aff8c4d8be0b46f"
       ],
       0,
-      "b923aada7833b60fed89875a22b32b69"
+      "568efa7df0faf7985a5fc7afd4dc4fb5"
     ],
     [
       "Hacl.Spec.BignumQ.Lemmas.lemma_div248_x9",
@@ -588,7 +588,7 @@
       0,
       [ "@query" ],
       0,
-      "7c33cc6ee202ef58c4b6efbdb9d31898"
+      "0230ab5236a24e4ba2aff9741304f4d9"
     ],
     [
       "Hacl.Spec.BignumQ.Lemmas.lemma_div248_x9",
@@ -614,7 +614,7 @@
         "typing_tok_Lib.IntTypes.U64@tok"
       ],
       0,
-      "a4b9080f07d00e909f4adda5351640fd"
+      "9abb00e958a942a2ce036380b7035221"
     ],
     [
       "Hacl.Spec.BignumQ.Lemmas.lemma_div248_x9",
@@ -643,7 +643,7 @@
         "typing_tok_Lib.IntTypes.SEC@tok", "typing_tok_Lib.IntTypes.U64@tok"
       ],
       0,
-      "efe25f7ff00cf6efd60a11eb3b2dc63b"
+      "ae2a5c59380ce62ac7f8b2ad5da66f3e"
     ],
     [
       "Hacl.Spec.BignumQ.Lemmas.lemma_div248_x9",
@@ -665,7 +665,7 @@
         "typing_tok_Lib.IntTypes.U64@tok"
       ],
       0,
-      "f42ec2123aab3be22896618413247167"
+      "db43ae90a19a0381050bb50ade1176b4"
     ],
     [
       "Hacl.Spec.BignumQ.Lemmas.lemma_wide_as_nat_pow512",
@@ -711,7 +711,7 @@
         "typing_tok_Lib.IntTypes.U64@tok"
       ],
       0,
-      "9026cfd0cff6b5a511d8df7d8aa9aec6"
+      "18678bbd1cf1e7acf911e59bae278308"
     ],
     [
       "Hacl.Spec.BignumQ.Lemmas.lemma_div248",
@@ -723,7 +723,7 @@
         "refinement_interpretation_Tm_refine_0766302b68bb44ab7aff8c4d8be0b46f"
       ],
       0,
-      "a8f3b280e87644099913213666ac9a75"
+      "66e6d00e6f2ea3846c92615964c6bf2e"
     ],
     [
       "Hacl.Spec.BignumQ.Lemmas.lemma_div248",
@@ -757,7 +757,7 @@
         "typing_Hacl.Spec.BignumQ.Definitions.pow56"
       ],
       0,
-      "8257189931ed0cfbeca078569f5fa48b"
+      "7439438afe9e793fca1c3ccfbbc6ad49"
     ],
     [
       "Hacl.Spec.BignumQ.Lemmas.lemma_div248",
@@ -766,7 +766,7 @@
       0,
       [ "@query" ],
       0,
-      "36bc2ae33ee163d3341ff37f4da88682"
+      "967c454e7da9f1dc09b384fbe449faef"
     ],
     [
       "Hacl.Spec.BignumQ.Lemmas.lemma_div248",
@@ -775,7 +775,7 @@
       0,
       [ "@query" ],
       0,
-      "455bb0e50b84eb060f9c081d0d8b5193"
+      "01ad6dbbd1bc902ccc121c4348109cef"
     ],
     [
       "Hacl.Spec.BignumQ.Lemmas.lemma_div248",
@@ -784,7 +784,7 @@
       0,
       [ "@query" ],
       0,
-      "d8a3098dccef968e32e90939a3e4dc8a"
+      "5ffbb82caf392ceeeaaa41ca675df264"
     ],
     [
       "Hacl.Spec.BignumQ.Lemmas.lemma_div248",
@@ -793,7 +793,7 @@
       0,
       [ "@query" ],
       0,
-      "dc2cc46711d9bcfcf07f568b995f658e"
+      "9fad7d6074d621a4b20e46aa246bee49"
     ],
     [
       "Hacl.Spec.BignumQ.Lemmas.lemma_div248",
@@ -802,7 +802,7 @@
       0,
       [ "@query" ],
       0,
-      "f62cb99db232969887e79a540af85ca7"
+      "7fabe1818c1e5e6ecdd7753501d2b35f"
     ],
     [
       "Hacl.Spec.BignumQ.Lemmas.lemma_div248",
@@ -811,7 +811,7 @@
       0,
       [ "@query" ],
       0,
-      "7f52cf1a89d482e1f2224f1dfdf4c26d"
+      "00d78d611d1f1bfdb489eb2638258f53"
     ],
     [
       "Hacl.Spec.BignumQ.Lemmas.lemma_div248",
@@ -820,7 +820,7 @@
       0,
       [ "@query" ],
       0,
-      "1270d1c3c5968d4431bf7db0f7dfeb94"
+      "4f46d3f45c3972de6a766cf74c637798"
     ],
     [
       "Hacl.Spec.BignumQ.Lemmas.lemma_div248",
@@ -829,7 +829,7 @@
       0,
       [ "@query" ],
       0,
-      "825238ae28b0d20311197127d3728ddd"
+      "cced93b47a29ada89d450beb3dace2f5"
     ],
     [
       "Hacl.Spec.BignumQ.Lemmas.lemma_div248",
@@ -838,7 +838,7 @@
       0,
       [ "@query" ],
       0,
-      "f2c021972265322cb287138b4d47d915"
+      "bec1a5694419d2ac31694d41db4735a4"
     ],
     [
       "Hacl.Spec.BignumQ.Lemmas.lemma_div248",
@@ -868,7 +868,7 @@
         "typing_Lib.IntTypes.sec_int_v", "typing_tok_Lib.IntTypes.U64@tok"
       ],
       0,
-      "935f7fcacb02b833d811e4babd1b042f"
+      "3663dc2f2e8a363e1ccb0f9ef7f34ac3"
     ],
     [
       "Hacl.Spec.BignumQ.Lemmas.lemma_div248",
@@ -889,7 +889,7 @@
         "refinement_interpretation_Tm_refine_0766302b68bb44ab7aff8c4d8be0b46f"
       ],
       0,
-      "d215c06ec4bc0c6ff9226c86bd1a8e5d"
+      "4766524649e15948756b8bd440de4054"
     ],
     [
       "Hacl.Spec.BignumQ.Lemmas.lemma_add_modq5",
@@ -911,7 +911,7 @@
         "typing_Hacl.Spec.BignumQ.Definitions.as_nat5"
       ],
       0,
-      "2f5a47b855b51195199e848f1e32d1b9"
+      "a86cc23a2a73a811a6f82ebee80850ea"
     ],
     [
       "Hacl.Spec.BignumQ.Lemmas.lemma_add_modq5",
@@ -939,7 +939,7 @@
         "typing_Prims.pow2"
       ],
       0,
-      "7a0973f165d0fbe8587a8783c94d232d"
+      "47d6a4362591b83d4e2cde90b9076023"
     ],
     [
       "Hacl.Spec.BignumQ.Lemmas.lemma_wide_as_nat_pow528",
@@ -982,7 +982,7 @@
         "typing_tok_Lib.IntTypes.U64@tok"
       ],
       0,
-      "e72448ae1f271094fe8473cd47eca072"
+      "f1285ab32f61a26b0608a4c171a398c4"
     ],
     [
       "Hacl.Spec.BignumQ.Lemmas.lemma_div264_aux",
@@ -991,7 +991,7 @@
       0,
       [ "@query" ],
       0,
-      "c75d4bc4b1f399ca92a999f044c61bc7"
+      "e447258a5c7c11be6d26327821c7aa95"
     ],
     [
       "Hacl.Spec.BignumQ.Lemmas.lemma_div264_aux",
@@ -1041,7 +1041,7 @@
         "typing_Hacl.Spec.BignumQ.Definitions.pow56"
       ],
       0,
-      "a589b47393230a1233aaaa8941c599f3"
+      "d9f7f9aad5ee2272c0f6027621a930b6"
     ],
     [
       "Hacl.Spec.BignumQ.Lemmas.lemma_div264_aux",
@@ -1066,7 +1066,7 @@
         "typing_Hacl.Spec.BignumQ.Definitions.pow224"
       ],
       0,
-      "249ccb25860fec21431853c14bb81ed1"
+      "6b358427344a9dbbfee2442851f3c48c"
     ],
     [
       "Hacl.Spec.BignumQ.Lemmas.lemma_div264_x5",
@@ -1075,7 +1075,7 @@
       0,
       [ "@query" ],
       0,
-      "8dbddb4e413ce22fd492fdcc00641caf"
+      "5cc761988efd9f1713b6fb29679c883a"
     ],
     [
       "Hacl.Spec.BignumQ.Lemmas.lemma_div264_x5",
@@ -1100,7 +1100,7 @@
         "typing_Prims.pow2"
       ],
       0,
-      "7b35176577a3face742f3ca3f357f07b"
+      "7156545ec7d8706036d3d964fdf4acc3"
     ],
     [
       "Hacl.Spec.BignumQ.Lemmas.lemma_div264_x5",
@@ -1109,7 +1109,7 @@
       0,
       [ "@query" ],
       0,
-      "f8ff20787a312a5629761065db76ed83"
+      "b68bffcab9e78a73aaf071bdc1080668"
     ],
     [
       "Hacl.Spec.BignumQ.Lemmas.lemma_div264_x5",
@@ -1118,7 +1118,7 @@
       0,
       [ "@query" ],
       0,
-      "65f44bddc63f4e349b5eb4d736076917"
+      "2f2412c67138534dab142441f2859c24"
     ],
     [
       "Hacl.Spec.BignumQ.Lemmas.lemma_div264_x5",
@@ -1130,7 +1130,7 @@
         "refinement_interpretation_Tm_refine_0766302b68bb44ab7aff8c4d8be0b46f"
       ],
       0,
-      "d10f2a932ab9ce755f35d12652b49bf9"
+      "0695e1258f57abe2aa9863352b0b7791"
     ],
     [
       "Hacl.Spec.BignumQ.Lemmas.lemma_div264_x5",
@@ -1142,7 +1142,7 @@
         "refinement_interpretation_Tm_refine_0766302b68bb44ab7aff8c4d8be0b46f"
       ],
       0,
-      "59a295ec2e0a1b432bb8172d8561a293"
+      "e9af0728034edcaac3e7f681cf5879b1"
     ],
     [
       "Hacl.Spec.BignumQ.Lemmas.lemma_div264_x6",
@@ -1151,7 +1151,7 @@
       0,
       [ "@query" ],
       0,
-      "fdc24f1781561978c4a4c7dcf20782a6"
+      "aa6602e7ae7cd65aeb1f503d63b5d844"
     ],
     [
       "Hacl.Spec.BignumQ.Lemmas.lemma_div264_x6",
@@ -1164,7 +1164,7 @@
         "projection_inverse_BoxInt_proj_0"
       ],
       0,
-      "c598443165741ad9af360fb09f1b52c5"
+      "123c578a78c33ae4e2add18402a1b9c4"
     ],
     [
       "Hacl.Spec.BignumQ.Lemmas.lemma_div264_x6",
@@ -1173,7 +1173,7 @@
       0,
       [ "@query" ],
       0,
-      "f4f7b7c09036b84e59b4db05327c5669"
+      "a42297d82fb64afba2add381d700cc1e"
     ],
     [
       "Hacl.Spec.BignumQ.Lemmas.lemma_div264_x6",
@@ -1182,7 +1182,7 @@
       0,
       [ "@query" ],
       0,
-      "2c467168f852e7f4ebdb3d9b13b9aa7d"
+      "f60e9fa80d14fb802fe5632643b6a9c6"
     ],
     [
       "Hacl.Spec.BignumQ.Lemmas.lemma_div264_x6",
@@ -1212,7 +1212,7 @@
         "typing_Lib.IntTypes.sec_int_v", "typing_tok_Lib.IntTypes.U64@tok"
       ],
       0,
-      "71a058c9e589606f328e6418c0533ea7"
+      "ec105acfaa234d206eab21c38187a774"
     ],
     [
       "Hacl.Spec.BignumQ.Lemmas.lemma_div264_x6",
@@ -1224,7 +1224,7 @@
         "refinement_interpretation_Tm_refine_0766302b68bb44ab7aff8c4d8be0b46f"
       ],
       0,
-      "73d8fb07418ee3cea1628c4f78659763"
+      "c4c6ddf5fcce5aca67d96df000cf60b4"
     ],
     [
       "Hacl.Spec.BignumQ.Lemmas.lemma_div264_x7",
@@ -1233,7 +1233,7 @@
       0,
       [ "@query" ],
       0,
-      "4ce103fe41d97ffff3ec6a9c1f2c0e70"
+      "e86fd8736d140fdddefdc9609d5b0523"
     ],
     [
       "Hacl.Spec.BignumQ.Lemmas.lemma_div264_x7",
@@ -1261,7 +1261,7 @@
         "typing_Prims.pow2"
       ],
       0,
-      "87f4c4b6b5ee2481d8c87c282a5b6f98"
+      "555772f585ba89846c7a0f3934452656"
     ],
     [
       "Hacl.Spec.BignumQ.Lemmas.lemma_div264_x7",
@@ -1270,7 +1270,7 @@
       0,
       [ "@query" ],
       0,
-      "5cbbee142353b86d80f9cb66416f64c4"
+      "5fc05d665381e4ed549bf86bd4a26bc2"
     ],
     [
       "Hacl.Spec.BignumQ.Lemmas.lemma_div264_x7",
@@ -1279,7 +1279,7 @@
       0,
       [ "@query" ],
       0,
-      "ffc8c60bfa5ce1c4cfb64dd37e5a0f98"
+      "7b1965c31ead94e219331a0863242b37"
     ],
     [
       "Hacl.Spec.BignumQ.Lemmas.lemma_div264_x7",
@@ -1309,7 +1309,7 @@
         "typing_Lib.IntTypes.sec_int_v", "typing_tok_Lib.IntTypes.U64@tok"
       ],
       0,
-      "d1a29705de86a9ce8836eb162cfb60ab"
+      "3d20cb2c6339417060183a22a9ee1621"
     ],
     [
       "Hacl.Spec.BignumQ.Lemmas.lemma_div264_x7",
@@ -1321,7 +1321,7 @@
         "refinement_interpretation_Tm_refine_0766302b68bb44ab7aff8c4d8be0b46f"
       ],
       0,
-      "58a956fc9b3c0088db409d48f4833b31"
+      "de0238168a5288c495f934230356d74c"
     ],
     [
       "Hacl.Spec.BignumQ.Lemmas.lemma_div264_x8",
@@ -1330,7 +1330,7 @@
       0,
       [ "@query" ],
       0,
-      "164f0bacdcb6e7147da5253239ac6a6b"
+      "e15fde1466aea5d81e72ffe979426133"
     ],
     [
       "Hacl.Spec.BignumQ.Lemmas.lemma_div264_x8",
@@ -1360,7 +1360,7 @@
         "typing_tok_Lib.IntTypes.U64@tok"
       ],
       0,
-      "2022e92d6057dffe97aaad26d1394db9"
+      "3395f14bf720dffd04daac9365181b7e"
     ],
     [
       "Hacl.Spec.BignumQ.Lemmas.lemma_div264_x8",
@@ -1369,7 +1369,7 @@
       0,
       [ "@query" ],
       0,
-      "7a3289b0e235199049525303604d3047"
+      "d6dc44306b889f71a1842366b8d9213a"
     ],
     [
       "Hacl.Spec.BignumQ.Lemmas.lemma_div264_x8",
@@ -1378,7 +1378,7 @@
       0,
       [ "@query" ],
       0,
-      "62371cefec1771a0032deb2ea679df9c"
+      "753963708331b68414bc7cc94f8846fb"
     ],
     [
       "Hacl.Spec.BignumQ.Lemmas.lemma_div264_x8",
@@ -1408,7 +1408,7 @@
         "typing_Lib.IntTypes.sec_int_v", "typing_tok_Lib.IntTypes.U64@tok"
       ],
       0,
-      "76348b6bd2eda0b22cd51b177f9c784f"
+      "3f04e8352385097890268a226fce77de"
     ],
     [
       "Hacl.Spec.BignumQ.Lemmas.lemma_div264_x8",
@@ -1420,7 +1420,7 @@
         "refinement_interpretation_Tm_refine_0766302b68bb44ab7aff8c4d8be0b46f"
       ],
       0,
-      "4df858f04ade96315437c092fa7f2d2a"
+      "c3cf245091ec92ac7d3ad08887771b51"
     ],
     [
       "Hacl.Spec.BignumQ.Lemmas.lemma_div264_x9",
@@ -1429,7 +1429,7 @@
       0,
       [ "@query" ],
       0,
-      "79db776fe0b83bd5baa01392352bd650"
+      "a6b8bd5c48ece7fb7d77de2e0440d584"
     ],
     [
       "Hacl.Spec.BignumQ.Lemmas.lemma_div264_x9",
@@ -1441,7 +1441,7 @@
         "projection_inverse_BoxInt_proj_0"
       ],
       0,
-      "5900db89884a112a10516c4b9538870b"
+      "aa0849b7fb907d4b6c223365b9ac75f0"
     ],
     [
       "Hacl.Spec.BignumQ.Lemmas.lemma_div264_x9",
@@ -1470,7 +1470,7 @@
         "typing_tok_Lib.IntTypes.SEC@tok", "typing_tok_Lib.IntTypes.U64@tok"
       ],
       0,
-      "9fb94ba843dfd4d1ee6453c59961e9bc"
+      "c967608fc804342c4837b00977b54a9f"
     ],
     [
       "Hacl.Spec.BignumQ.Lemmas.lemma_div264_x9",
@@ -1492,7 +1492,7 @@
         "typing_tok_Lib.IntTypes.U64@tok"
       ],
       0,
-      "08d00a220cf9843f1294b1afd5d4acf1"
+      "08ebd2e101154a7b0f590bf067b62896"
     ],
     [
       "Hacl.Spec.BignumQ.Lemmas.lemma_div264",
@@ -1504,7 +1504,7 @@
         "refinement_interpretation_Tm_refine_0766302b68bb44ab7aff8c4d8be0b46f"
       ],
       0,
-      "7806089a3d21b0c89afb736429a36e38"
+      "98e66532301fde55af3573db016a678d"
     ],
     [
       "Hacl.Spec.BignumQ.Lemmas.lemma_div264",
@@ -1538,7 +1538,7 @@
         "typing_Hacl.Spec.BignumQ.Definitions.pow56"
       ],
       0,
-      "6ea64c3fee19449e5b334be6c01aaad7"
+      "15f924064787b690844a001cb6a3d287"
     ],
     [
       "Hacl.Spec.BignumQ.Lemmas.lemma_div264",
@@ -1547,7 +1547,7 @@
       0,
       [ "@query" ],
       0,
-      "88cd4e3bfe7f46a475f9d7bc9f6598f9"
+      "503dd1388fea811068e44c803d6f58ca"
     ],
     [
       "Hacl.Spec.BignumQ.Lemmas.lemma_div264",
@@ -1556,7 +1556,7 @@
       0,
       [ "@query" ],
       0,
-      "de0f4512f7021f73e27597757222afcb"
+      "00dc31f785668b7e370c9c3765b9f318"
     ],
     [
       "Hacl.Spec.BignumQ.Lemmas.lemma_div264",
@@ -1565,7 +1565,7 @@
       0,
       [ "@query" ],
       0,
-      "5cfcaf5717b62469400f1c1bc0078c72"
+      "7c1e80b6e83e566d966227c175db3875"
     ],
     [
       "Hacl.Spec.BignumQ.Lemmas.lemma_div264",
@@ -1574,7 +1574,7 @@
       0,
       [ "@query" ],
       0,
-      "f8fc9910c568248e4973080d47e6e45e"
+      "b696b8694e64f9b172592a261b3ad121"
     ],
     [
       "Hacl.Spec.BignumQ.Lemmas.lemma_div264",
@@ -1583,7 +1583,7 @@
       0,
       [ "@query" ],
       0,
-      "a461f08f0a5ccf9d8367b7b4a83e65f0"
+      "e7fd59e6579c9f5e98b2c80406820fd4"
     ],
     [
       "Hacl.Spec.BignumQ.Lemmas.lemma_div264",
@@ -1592,7 +1592,7 @@
       0,
       [ "@query" ],
       0,
-      "abb83e63916c41b797f14c7941b2a88e"
+      "d951e1d523d30723cad69559714f1773"
     ],
     [
       "Hacl.Spec.BignumQ.Lemmas.lemma_div264",
@@ -1601,7 +1601,7 @@
       0,
       [ "@query" ],
       0,
-      "967deb0dfcc2b6da0706ece0c8c4cdcb"
+      "866f3e8e2b2d05dd1c1d20ea1f3ae02c"
     ],
     [
       "Hacl.Spec.BignumQ.Lemmas.lemma_div264",
@@ -1610,7 +1610,7 @@
       0,
       [ "@query" ],
       0,
-      "a97e71ff59656e582602ee94e82460bf"
+      "fb201578e642cae70cdbd204b77a68ad"
     ],
     [
       "Hacl.Spec.BignumQ.Lemmas.lemma_div264",
@@ -1619,7 +1619,7 @@
       0,
       [ "@query" ],
       0,
-      "6eeec0a64564a9fd4e15b50fdd3a07b0"
+      "2040ec8e60363cae9b2712633b283ef6"
     ],
     [
       "Hacl.Spec.BignumQ.Lemmas.lemma_div264",
@@ -1649,7 +1649,7 @@
         "typing_Lib.IntTypes.sec_int_v", "typing_tok_Lib.IntTypes.U64@tok"
       ],
       0,
-      "5f93d565cb5dd5f8589b7e6e6f098c7b"
+      "0fc28dfddce17e9494d3bebf690a6dbc"
     ],
     [
       "Hacl.Spec.BignumQ.Lemmas.lemma_div264",
@@ -1670,7 +1670,7 @@
         "refinement_interpretation_Tm_refine_0766302b68bb44ab7aff8c4d8be0b46f"
       ],
       0,
-      "0a565675ebd7f574bae49b43a8d99bd8"
+      "ba1bdb6f3c2113130546e30752a368e1"
     ],
     [
       "Hacl.Spec.BignumQ.Lemmas.lemma_mod_264_aux",
@@ -1679,7 +1679,7 @@
       0,
       [ "@query" ],
       0,
-      "b7b7643dccc01afe428532535953f7dd"
+      "8dab9c730ba226315eb731cd136a4b01"
     ],
     [
       "Hacl.Spec.BignumQ.Lemmas.lemma_mod_264_aux",
@@ -1746,7 +1746,7 @@
         "typing_Hacl.Spec.BignumQ.Definitions.pow56"
       ],
       0,
-      "5e60ab8c319c01f9ae4738838ed788e4"
+      "8f89a86f922d3935143af436c9677796"
     ],
     [
       "Hacl.Spec.BignumQ.Lemmas.lemma_as_nat_pow264",
@@ -1787,7 +1787,7 @@
         "typing_Hacl.Spec.BignumQ.Definitions.pow56"
       ],
       0,
-      "8d4aea6596cc4814ad5be62cca59add7"
+      "953d3015c92b8ad7204b5f5011860026"
     ],
     [
       "Hacl.Spec.BignumQ.Lemmas.lemma_mod_264",
@@ -1810,7 +1810,7 @@
         "typing_Hacl.Spec.BignumQ.Definitions.pow56"
       ],
       0,
-      "d2a22c5fbc11d08abc9287fc5fcfa80b"
+      "c70ee1916cc226d46788b4ab93909406"
     ],
     [
       "Hacl.Spec.BignumQ.Lemmas.lemma_mod_264",
@@ -1895,7 +1895,7 @@
         "typing_tok_Lib.IntTypes.U64@tok"
       ],
       0,
-      "d371b1e1c634aa082083656cc9ad5124"
+      "5f1a36da3ceb793e958cf16328d08111"
     ],
     [
       "Hacl.Spec.BignumQ.Lemmas.lemma_as_nat_pow264_x4",
@@ -1935,7 +1935,7 @@
         "typing_tok_Lib.IntTypes.U64@tok"
       ],
       0,
-      "8b793f0bea88e2f7f967773af53ad476"
+      "48a3671087da16dbc25916bbce93ff6c"
     ],
     [
       "Hacl.Spec.BignumQ.Lemmas.lemma_sub_mod_264_aux",
@@ -1962,7 +1962,7 @@
         "typing_Hacl.Spec.BignumQ.Definitions.pow56"
       ],
       0,
-      "6954bfcec06e5a702a5314d2ccec49cb"
+      "486f7d6b5da79d0d780cb47e8b5e311a"
     ],
     [
       "Hacl.Spec.BignumQ.Lemmas.lemma_sub_mod_264",
@@ -1996,7 +1996,7 @@
         "typing_tok_Lib.IntTypes.SEC@tok", "typing_tok_Lib.IntTypes.U64@tok"
       ],
       0,
-      "f0f133a81ae152840b370887ef800e03"
+      "9c905b3f69cc3caab834ee25b95f1e91"
     ],
     [
       "Hacl.Spec.BignumQ.Lemmas.lemma_mul_qelem5",
@@ -2005,7 +2005,7 @@
       0,
       [ "@query", "true_interp" ],
       0,
-      "2be1635ea739929fd6a2b0fd32c03aad"
+      "c581d253d58f65fe7bf2eee35c15cdbf"
     ],
     [
       "Hacl.Spec.BignumQ.Lemmas.lemma_mul_5_low_264",
@@ -2014,7 +2014,7 @@
       0,
       [ "@query", "projection_inverse_BoxInt_proj_0" ],
       0,
-      "d85b879392a661283ed61d5b457655c2"
+      "d2c6d2ee71bd9b937420ab5d9f007ace"
     ],
     [
       "Hacl.Spec.BignumQ.Lemmas.lemma_mul_nat_is_nat",
@@ -2027,7 +2027,7 @@
         "refinement_interpretation_Tm_refine_542f9d4f129664613f2483a6c88bc7c2"
       ],
       0,
-      "74f8a81e7bdf39a50b906edee7548373"
+      "59e1b8bad106eb3a9129b174562faf7b"
     ],
     [
       "Hacl.Spec.BignumQ.Lemmas.lemma_div_nat_is_nat",
@@ -2042,7 +2042,7 @@
         "refinement_interpretation_Tm_refine_774ba3f728d91ead8ef40be66c9802e5"
       ],
       0,
-      "4057387ed2eb06126302f1efb82e539e"
+      "ba7b108a61f8b98ac5442f1c44201738"
     ],
     [
       "Hacl.Spec.BignumQ.Lemmas.lemma_mul_5'''",
@@ -2051,7 +2051,7 @@
       0,
       [ "@query" ],
       0,
-      "b54b987567f0ebb606be9bed46bf6dd0"
+      "844258848f6f55068d27bee8f9fc3bc9"
     ],
     [
       "Hacl.Spec.BignumQ.Lemmas.lemma_mul_5'''",
@@ -2094,7 +2094,7 @@
         "typing_Hacl.Spec.BignumQ.Definitions.pow56", "typing_Prims.pow2"
       ],
       0,
-      "df45654bef366fa89cb835bf6f0bf5c0"
+      "90558cf7c8aa9295c5c4ddffc405bbf2"
     ],
     [
       "Hacl.Spec.BignumQ.Lemmas.lemma_mul_5'''",
@@ -2106,7 +2106,7 @@
         "refinement_interpretation_Tm_refine_0766302b68bb44ab7aff8c4d8be0b46f"
       ],
       0,
-      "7339de939f4e9affd0b22f1f098603ea"
+      "d93b626bb7cad697ae4764f1b6f6cab9"
     ],
     [
       "Hacl.Spec.BignumQ.Lemmas.lemma_mod_264''",
@@ -2115,7 +2115,7 @@
       0,
       [ "@query" ],
       0,
-      "f4c34dcf6d578d2758eb03c42d4032a5"
+      "6b7c20fd133e5574fe835fa8f98389bf"
     ],
     [
       "Hacl.Spec.BignumQ.Lemmas.lemma_mod_264''",
@@ -2128,7 +2128,7 @@
         "primitive_Prims.op_Multiply", "projection_inverse_BoxInt_proj_0"
       ],
       0,
-      "1354d3e5facf3e0deb6b0fa19bba56e4"
+      "4394d99cae5f48c8a4cac4a058947fc9"
     ],
     [
       "Hacl.Spec.BignumQ.Lemmas.lemma_mod_264'",
@@ -2137,7 +2137,7 @@
       0,
       [ "@query" ],
       0,
-      "2f1c669c345ea540a8b6daa1796f1e19"
+      "5c9b00be67e93bb4d817a65cbc5d3c6b"
     ],
     [
       "Hacl.Spec.BignumQ.Lemmas.lemma_mod_264'",
@@ -2155,7 +2155,7 @@
         "refinement_interpretation_Tm_refine_542f9d4f129664613f2483a6c88bc7c2"
       ],
       0,
-      "f1ceeb3cfd913e0166b599d8cfe5a5f7"
+      "232b38a8a9c350dde2a48ba3f35b534f"
     ],
     [
       "Hacl.Spec.BignumQ.Lemmas.lemma_aux_0",
@@ -2174,7 +2174,7 @@
         "typing_Prims.pow2"
       ],
       0,
-      "4652cd866d628372b2de5e69b98898f5"
+      "2208dc1a54edf42d041ee369926c23ad"
     ],
     [
       "Hacl.Spec.BignumQ.Lemmas.lemma_mod_264_small",
@@ -2186,7 +2186,7 @@
         "refinement_interpretation_Tm_refine_0766302b68bb44ab7aff8c4d8be0b46f"
       ],
       0,
-      "0cbc325c397bc401c6f4ae1095241bba"
+      "c702d20f4bda553031cd36a073fa2671"
     ],
     [
       "Hacl.Spec.BignumQ.Lemmas.lemma_mod_264_small",
@@ -2206,7 +2206,7 @@
         "typing_Prims.pow2"
       ],
       0,
-      "205690a4ec2dbfdd56acd2a764d59a77"
+      "f5a2b6effb44a31fc0ffbaac1041164f"
     ],
     [
       "Hacl.Spec.BignumQ.Lemmas.lemma_mod_264_",
@@ -2220,7 +2220,7 @@
         "refinement_interpretation_Tm_refine_0766302b68bb44ab7aff8c4d8be0b46f"
       ],
       0,
-      "d9e51f0f27965ad3e8f70ce671ce0607"
+      "d4c458750e7df757d554245a19a45027"
     ],
     [
       "Hacl.Spec.BignumQ.Lemmas.lemma_mod_264_",
@@ -2240,7 +2240,7 @@
         "typing_Hacl.Spec.BignumQ.Definitions.pow56"
       ],
       0,
-      "a3e5030cd89c5978ea123bf5fccf17e6"
+      "0a618728ac58491ddf07d916525417e1"
     ],
     [
       "Hacl.Spec.BignumQ.Lemmas.lemma_mul_5_low_264",
@@ -2257,7 +2257,7 @@
         "refinement_interpretation_Tm_refine_542f9d4f129664613f2483a6c88bc7c2"
       ],
       0,
-      "0226eb98bdd72316f7ecdf957ff814a5"
+      "bd1c124ad99e2b2aa322f5badfddc6d6"
     ],
     [
       "Hacl.Spec.BignumQ.Lemmas.lemma_optimized_barrett_reduce",
@@ -2275,7 +2275,7 @@
         "typing_Prims.pow2"
       ],
       0,
-      "e85f2fec8c6add06865515bb79f1fe9f"
+      "a1b3518857f003c936e3299cf6b930fd"
     ],
     [
       "Hacl.Spec.BignumQ.Lemmas.lemma_optimized_barrett_reduce",
@@ -2291,7 +2291,7 @@
         "refinement_interpretation_Tm_refine_ffd0c5340ae953c83a5f54ff2e5d47b3"
       ],
       0,
-      "d3456428e110ace3b4dcf8f1d37e2a84"
+      "e963d9ced3c8041f6128c67fa05538f9"
     ],
     [
       "Hacl.Spec.BignumQ.Lemmas.lemma_optimized_barrett_reduce2",
@@ -2309,7 +2309,7 @@
         "typing_Prims.pow2"
       ],
       0,
-      "3c0282db4dc4a70d990e8813823959c6"
+      "0cdcf1a4d5fec15aa1472bc1626d82a9"
     ],
     [
       "Hacl.Spec.BignumQ.Lemmas.lemma_optimized_barrett_reduce2",
@@ -2323,7 +2323,7 @@
         "refinement_interpretation_Tm_refine_ffd0c5340ae953c83a5f54ff2e5d47b3"
       ],
       0,
-      "3839a084a08146f6bd7a751c867d9005"
+      "5dfe907be2be7682c13278716e03d691"
     ],
     [
       "Hacl.Spec.BignumQ.Lemmas.lemma_0",
@@ -2342,7 +2342,7 @@
         "refinement_interpretation_Tm_refine_774ba3f728d91ead8ef40be66c9802e5"
       ],
       0,
-      "8e868109a087a79c2f1f5a3829c6494c"
+      "a68af8f5cdab23b3761d0b63bbab2a0e"
     ],
     [
       "Hacl.Spec.BignumQ.Lemmas.lemma_1",
@@ -2364,7 +2364,7 @@
         "refinement_interpretation_Tm_refine_774ba3f728d91ead8ef40be66c9802e5"
       ],
       0,
-      "6994b592ebebacc280e7ffdbf946fc82"
+      "0e96675a9d82c6328c798b23e04097c3"
     ],
     [
       "Hacl.Spec.BignumQ.Lemmas.lemma_barrett_reduce'",
@@ -2383,7 +2383,7 @@
         "typing_Prims.pow2"
       ],
       0,
-      "50ceaf485ffc40ae541840f28ed6ac37"
+      "481fb74856d11f1a03edf09f1f56ab13"
     ],
     [
       "Hacl.Spec.BignumQ.Lemmas.lemma_barrett_reduce''",
@@ -2407,7 +2407,7 @@
         "typing_Prims.pow2"
       ],
       0,
-      "0c7e6fc2aa9a55a58b13be5ee01fbed5"
+      "0c19e4d01d94a5c833ec5d04c83b5737"
     ],
     [
       "Hacl.Spec.BignumQ.Lemmas.lemma_barrett_reduce'",
@@ -2425,7 +2425,7 @@
         "refinement_interpretation_Tm_refine_ffd0c5340ae953c83a5f54ff2e5d47b3"
       ],
       0,
-      "9f279cd8348cf516026386124b571984"
+      "637940ed40e7a9de8a5f183dd09cf486"
     ]
   ]
 ]

--- a/hints/Hacl.Spec.Poly1305.Field32xN.Lemmas.fst.hints
+++ b/hints/Hacl.Spec.Poly1305.Field32xN.Lemmas.fst.hints
@@ -1,5 +1,5 @@
 [
-  "4\nîë«’-Å¦Ã€1â½A¿",
+  "À\u0018Pí6‡ƒgZ¯ðåþè\u001b5",
   [
     [
       "Hacl.Spec.Poly1305.Field32xN.Lemmas.lemma_feval_is_fas_nat_i",
@@ -26,7 +26,7 @@
         "typing_Hacl.Spec.Poly1305.Field32xN.feval5"
       ],
       0,
-      "80cd4c509c37e2a33d01a24b34554233"
+      "193d8c25ec4b3553ac84887bc11cbc71"
     ],
     [
       "Hacl.Spec.Poly1305.Field32xN.Lemmas.lemma_feval_is_fas_nat_i",
@@ -95,7 +95,7 @@
         "typing_tok_Lib.IntTypes.SEC@tok", "typing_tok_Lib.IntTypes.U8@tok"
       ],
       0,
-      "2a4b85100fe91450bfcf3056706d6ae6"
+      "f57fbb9732554eb74ee3481f47e5c2a7"
     ],
     [
       "Hacl.Spec.Poly1305.Field32xN.Lemmas.lemma_feval_is_fas_nat_i",
@@ -160,7 +160,7 @@
         "typing_tok_Lib.IntTypes.U8@tok"
       ],
       0,
-      "0835865d46e3ac4a38564623bcd1b135"
+      "837606bf7eb7d35c5bb5b83f6ceaff00"
     ],
     [
       "Hacl.Spec.Poly1305.Field32xN.Lemmas.lemma_feval_is_fas_nat",
@@ -186,7 +186,7 @@
         "typing_Hacl.Spec.Poly1305.Field32xN.feval5"
       ],
       0,
-      "956ae92ae4e9afe50610d4f46087596a"
+      "4d4a7e85e797bc248efb03a57564b0a4"
     ],
     [
       "Hacl.Spec.Poly1305.Field32xN.Lemmas.lemma_feval_is_fas_nat",
@@ -209,7 +209,7 @@
         "typing_Hacl.Spec.Poly1305.Vec.size_key"
       ],
       0,
-      "c46bcd4faf2e66e27a661048d3f842bf"
+      "fd3b6766ba6f2e0aa47ac336ddff523b"
     ],
     [
       "Hacl.Spec.Poly1305.Field32xN.Lemmas.lemma_feval_is_fas_nat",
@@ -236,7 +236,7 @@
         "typing_Hacl.Spec.Poly1305.Field32xN.feval5"
       ],
       0,
-      "39e52b3817e3c9c6fb5bd37d847b3c6f"
+      "7354386df76dfb5c27bf94064208bb3d"
     ],
     [
       "Hacl.Spec.Poly1305.Field32xN.Lemmas.precomp_r5_fits_lemma",
@@ -339,7 +339,7 @@
         "typing_tok_Lib.IntTypes.SEC@tok", "typing_tok_Lib.IntTypes.U64@tok"
       ],
       0,
-      "28b4e8e79a42339bb73e41d3490db020"
+      "2fbaadc299833519b4c316c3fa69ffd4"
     ],
     [
       "Hacl.Spec.Poly1305.Field32xN.Lemmas.precomp_r5_fits_lemma2",
@@ -440,7 +440,7 @@
         "typing_tok_Lib.IntTypes.SEC@tok", "typing_tok_Lib.IntTypes.U64@tok"
       ],
       0,
-      "d8cb2c2bd9dd1304b9ca378275b6d52e"
+      "55c3582cd4467b698dea277147f0e7ff"
     ],
     [
       "Hacl.Spec.Poly1305.Field32xN.Lemmas.fadd5_fits_lemma",
@@ -526,7 +526,7 @@
         "typing_tok_Lib.IntTypes.SEC@tok", "typing_tok_Lib.IntTypes.U64@tok"
       ],
       0,
-      "de4805307ce8e8e35788308a4edf2ae0"
+      "2d75fbb7b04e458ed2f52497412ab78d"
     ],
     [
       "Hacl.Spec.Poly1305.Field32xN.Lemmas.fadd5_eval_lemma",
@@ -568,7 +568,7 @@
         "typing_Lib.Sequence.map2", "typing_Spec.Poly1305.size_key"
       ],
       0,
-      "ad9d9db4355ea587859988e09474b663"
+      "967ca89e85aea3e956664d5374c9bb11"
     ],
     [
       "Hacl.Spec.Poly1305.Field32xN.Lemmas.mul_felem5_fits_lemma",
@@ -607,7 +607,7 @@
         "refinement_interpretation_Tm_refine_f9ef44be18cc114628758c5595133aa5"
       ],
       0,
-      "cb2e6ebe35517d4bb73f2b18fbc27361"
+      "d3d48539266eed033ecf2c1b9c75923d"
     ],
     [
       "Hacl.Spec.Poly1305.Field32xN.Lemmas.mul_felem5_eval_lemma_i",
@@ -623,7 +623,7 @@
         "refinement_interpretation_Tm_refine_c1424615841f28cac7fc34e92b7ff33c"
       ],
       0,
-      "3ce1fb896672af10542d219b355b8939"
+      "86f3466de0c0ddeba421bc6f93dd565e"
     ],
     [
       "Hacl.Spec.Poly1305.Field32xN.Lemmas.mul_felem5_eval_lemma_i",
@@ -727,7 +727,7 @@
         "typing_Tm_abs_baadd0755aa20f9b2a01722e1436594a"
       ],
       0,
-      "83db94ca96360f8f968e7357f0bba7b0"
+      "362debaaf44262636026e0ab5c8b4764"
     ],
     [
       "Hacl.Spec.Poly1305.Field32xN.Lemmas.mul_felem5_eval_lemma",
@@ -762,7 +762,7 @@
         "typing_Hacl.Spec.Poly1305.Field32xN.mul_felem5"
       ],
       0,
-      "1d03f3e6a1933f819acd5907da0f5b00"
+      "197f1ea0baad08de3899fd13ef1538ea"
     ],
     [
       "Hacl.Spec.Poly1305.Field32xN.Lemmas.fmul_r5_fits_lemma",
@@ -785,7 +785,7 @@
         "projection_inverse_FStar.Pervasives.Native.Mktuple5__5"
       ],
       0,
-      "96959595953ff62f9beeb0a6131fef60"
+      "91e1748eb31ad3a0e6c3e4a598282e58"
     ],
     [
       "Hacl.Spec.Poly1305.Field32xN.Lemmas.fmul_r5_eval_lemma",
@@ -814,7 +814,7 @@
         "refinement_interpretation_Tm_refine_f9ef44be18cc114628758c5595133aa5"
       ],
       0,
-      "4939103d07ec6c21a93ec2f8a281455f"
+      "3c7afd2b60def72b3980a5227ac20776"
     ],
     [
       "Hacl.Spec.Poly1305.Field32xN.Lemmas.fadd_mul_r5_fits_lemma",
@@ -855,7 +855,7 @@
         "typing_Hacl.Spec.Poly1305.Field32xN.pow26"
       ],
       0,
-      "4b28047361d5898ea095a041d34f09df"
+      "e7a45ea16dc45f3fec97bb8e17f8938b"
     ],
     [
       "Hacl.Spec.Poly1305.Field32xN.Lemmas.fadd_mul_r5_eval_lemma",
@@ -901,7 +901,7 @@
         "typing_Hacl.Spec.Poly1305.Field32xN.pow26"
       ],
       0,
-      "7aa5ed0f2af5848d6ed2512f7cf617d4"
+      "26f30e5a0a4a8f5385884e96b02e34f6"
     ],
     [
       "Hacl.Spec.Poly1305.Field32xN.Lemmas.reduce_felem5_eval_lemma",
@@ -931,7 +931,7 @@
         "typing_Spec.Poly1305.size_key"
       ],
       0,
-      "932b35daa84424f0d518e003cb984d88"
+      "cf5fa507d1514183335c5ff8369be05a"
     ],
     [
       "Hacl.Spec.Poly1305.Field32xN.Lemmas.reduce_felem5_eval_lemma",
@@ -977,7 +977,7 @@
         "typing_Spec.GaloisField.__proj__GF__item__t"
       ],
       0,
-      "16954cb217af66c8db48c03dc46bae96"
+      "bc3bb0ba881ed84fead7213da7e7c57d"
     ],
     [
       "Hacl.Spec.Poly1305.Field32xN.Lemmas.fmul_r2_normalize50",
@@ -991,7 +991,7 @@
         "typing_Spec.Poly1305.size_key"
       ],
       0,
-      "8ff2b8dbf18ed50a84e7f8a878fb886e"
+      "48165945898aee92090eb62b6a4fcd25"
     ],
     [
       "Hacl.Spec.Poly1305.Field32xN.Lemmas.fmul_r2_normalize50",
@@ -1005,7 +1005,7 @@
         "typing_Spec.Poly1305.size_key"
       ],
       0,
-      "0bb03a12daa9472955caf4305a92eada"
+      "54f2be807d172974c2c47eedaba28b16"
     ],
     [
       "Hacl.Spec.Poly1305.Field32xN.Lemmas.fmul_r2_normalize50",
@@ -1100,7 +1100,7 @@
         "typing_tok_Lib.IntTypes.U8@tok"
       ],
       0,
-      "0a7e9b79ea9aabded38594a5517bafb2"
+      "37375b77d3f9e8a2cae21ebdcb3c9bcc"
     ],
     [
       "Hacl.Spec.Poly1305.Field32xN.Lemmas.fmul_r2_normalize51",
@@ -1114,7 +1114,7 @@
         "typing_Spec.Poly1305.size_key"
       ],
       0,
-      "9d4f8c4bfd5ef54cf4de11003fac55a6"
+      "0a4c8164d26ad31c3b81964993651160"
     ],
     [
       "Hacl.Spec.Poly1305.Field32xN.Lemmas.fmul_r2_normalize51",
@@ -1128,7 +1128,7 @@
         "typing_Spec.Poly1305.size_key"
       ],
       0,
-      "79bf150c5c954098193ff9a8c3bb9626"
+      "f2000cb396613cba05eb0039b47b4de1"
     ],
     [
       "Hacl.Spec.Poly1305.Field32xN.Lemmas.fmul_r2_normalize51",
@@ -1147,6 +1147,7 @@
         "constructor_distinct_Lib.IntTypes.S16",
         "constructor_distinct_Lib.IntTypes.S32",
         "constructor_distinct_Lib.IntTypes.S8",
+        "constructor_distinct_Lib.IntTypes.SEC",
         "constructor_distinct_Lib.IntTypes.U32",
         "constructor_distinct_Lib.IntTypes.U64",
         "constructor_distinct_Lib.IntTypes.U8",
@@ -1209,7 +1210,6 @@
         "refinement_interpretation_Tm_refine_0ec011aea9f93256a3547ad9f0c667f1",
         "refinement_interpretation_Tm_refine_26b730cb944f71bac9def42c920eb7ed",
         "refinement_interpretation_Tm_refine_2b9ac1d6c43e9e240d84837e7e466c45",
-        "refinement_interpretation_Tm_refine_2e0ba8debf838e5d58ab7f0df7e69c5a",
         "refinement_interpretation_Tm_refine_387e6d282145573240ab7b8a4b94cce5",
         "refinement_interpretation_Tm_refine_40d37ebab7c1b683bff04f4efbb0b134",
         "refinement_interpretation_Tm_refine_542f9d4f129664613f2483a6c88bc7c2",
@@ -1227,6 +1227,7 @@
         "token_correspondence_Hacl.Spec.Poly1305.Field32xN.as_pfelem5",
         "token_correspondence_Lib.IntTypes.add_mod",
         "typing_Hacl.Spec.Poly1305.Field32xN.feval5",
+        "typing_Hacl.Spec.Poly1305.Field32xN.max26",
         "typing_Hacl.Spec.Poly1305.Field32xN.pow26",
         "typing_Hacl.Spec.Poly1305.Field32xN.transpose",
         "typing_Lib.IntTypes.minint", "typing_Lib.IntTypes.v",
@@ -1240,7 +1241,7 @@
         "typing_tok_Lib.IntTypes.U8@tok"
       ],
       0,
-      "7cfc948efc3de7d8ee59fcead5565146"
+      "a329ca9d3ee93484336074a5740209f7"
     ],
     [
       "Hacl.Spec.Poly1305.Field32xN.Lemmas.fmul_r2_normalize5_lemma",
@@ -1254,7 +1255,7 @@
         "typing_Spec.Poly1305.size_key"
       ],
       0,
-      "8d5ffdf7c731f2221d2d8dc7df7f9df5"
+      "b59da192c07bc981f2ca3328fbdace35"
     ],
     [
       "Hacl.Spec.Poly1305.Field32xN.Lemmas.fmul_r2_normalize5_lemma",
@@ -1268,7 +1269,7 @@
         "typing_Spec.Poly1305.size_key"
       ],
       0,
-      "1785374f8ec9536fb9b9082e38e0b4ce"
+      "16781ccbbe5f55574e54b0eb8404ba35"
     ],
     [
       "Hacl.Spec.Poly1305.Field32xN.Lemmas.fmul_r2_normalize5_lemma",
@@ -1363,7 +1364,7 @@
         "typing_tok_Lib.IntTypes.U8@tok"
       ],
       0,
-      "a5ed0edb87dbb3820aa2a0b6421366b4"
+      "d5d81f32ec1336d3204d978f8675563c"
     ],
     [
       "Hacl.Spec.Poly1305.Field32xN.Lemmas.fmul_r4_normalize50",
@@ -1377,7 +1378,7 @@
         "typing_Spec.Poly1305.size_key"
       ],
       0,
-      "d950fb4f8276dd056525de16e16135db"
+      "9276ca7f01922105c6ea8dcda49bf6b9"
     ],
     [
       "Hacl.Spec.Poly1305.Field32xN.Lemmas.fmul_r4_normalize50",
@@ -1391,7 +1392,7 @@
         "typing_Spec.Poly1305.size_key"
       ],
       0,
-      "72a685ef3280fe6b26c353309d731cf0"
+      "55367a2ac61c094136aed93d80f05d61"
     ],
     [
       "Hacl.Spec.Poly1305.Field32xN.Lemmas.fmul_r4_normalize50",
@@ -1479,7 +1480,7 @@
         "typing_tok_Lib.IntTypes.U8@tok"
       ],
       0,
-      "276ca49ee1d60ec42b88630cbdb3dddc"
+      "9c82a690e1d8046b3d6ac4b2a81eb362"
     ],
     [
       "Hacl.Spec.Poly1305.Field32xN.Lemmas.lemma_fmul_r4_normalize51",
@@ -1511,7 +1512,7 @@
         "typing_Spec.Poly1305.size_key"
       ],
       0,
-      "7d28bca791502ef423ff7b5fcb1c7327"
+      "c1058fe10c220b2ab270856fe3ed91fa"
     ],
     [
       "Hacl.Spec.Poly1305.Field32xN.Lemmas.lemma_fmul_r4_normalize51",
@@ -1525,7 +1526,7 @@
         "typing_Spec.Poly1305.size_key"
       ],
       0,
-      "7dde9f59e4a42e70d55670328e2e154d"
+      "e2c848e6ee69dde26d0673f679522bf2"
     ],
     [
       "Hacl.Spec.Poly1305.Field32xN.Lemmas.lemma_fmul_r4_normalize51",
@@ -1633,7 +1634,7 @@
         "typing_tok_Lib.IntTypes.U8@tok"
       ],
       0,
-      "928e74f7a6054cb8b56a15e01d08bc92"
+      "81ecab1961cfc7b37a149b997f135fe6"
     ],
     [
       "Hacl.Spec.Poly1305.Field32xN.Lemmas.lemma_fmul_r4_normalize51_expand",
@@ -1647,7 +1648,7 @@
         "typing_Spec.Poly1305.size_key"
       ],
       0,
-      "9a070217d2a282f62553b2e8b7b643d0"
+      "3a2c78264f60ca4cd379219975f841f3"
     ],
     [
       "Hacl.Spec.Poly1305.Field32xN.Lemmas.lemma_fmul_r4_normalize51_expand",
@@ -1661,7 +1662,7 @@
         "typing_Spec.Poly1305.size_key"
       ],
       0,
-      "f3be723ae087794536823f5be9ceb450"
+      "a5c580c61cb3679182efff387a59a7bf"
     ],
     [
       "Hacl.Spec.Poly1305.Field32xN.Lemmas.lemma_fmul_r4_normalize51_expand",
@@ -1721,6 +1722,7 @@
         "projection_inverse_Spec.GaloisField.GF_t",
         "refinement_interpretation_Tm_refine_0ec011aea9f93256a3547ad9f0c667f1",
         "refinement_interpretation_Tm_refine_26b730cb944f71bac9def42c920eb7ed",
+        "refinement_interpretation_Tm_refine_2b9ac1d6c43e9e240d84837e7e466c45",
         "refinement_interpretation_Tm_refine_40d37ebab7c1b683bff04f4efbb0b134",
         "refinement_interpretation_Tm_refine_542f9d4f129664613f2483a6c88bc7c2",
         "refinement_interpretation_Tm_refine_774ba3f728d91ead8ef40be66c9802e5",
@@ -1742,7 +1744,7 @@
         "typing_tok_Lib.IntTypes.U8@tok"
       ],
       0,
-      "e5b5f4ceb497e9f2c7b45bd1803a5485"
+      "d58cc7fe5923fbeeb3317afadd19bb58"
     ],
     [
       "Hacl.Spec.Poly1305.Field32xN.Lemmas.fmul_r4_normalize51",
@@ -1756,7 +1758,7 @@
         "typing_Spec.Poly1305.size_key"
       ],
       0,
-      "7489789b45e383ea08486c3d4b12d940"
+      "a03ff03f182c460ef63a3a7d5bf3e1c1"
     ],
     [
       "Hacl.Spec.Poly1305.Field32xN.Lemmas.fmul_r4_normalize51",
@@ -1771,7 +1773,7 @@
         "typing_Spec.Poly1305.size_block"
       ],
       0,
-      "3dd7f49be133487e0fd30969daa0ee90"
+      "444c20eb57bb543ad4afd61650e48e84"
     ],
     [
       "Hacl.Spec.Poly1305.Field32xN.Lemmas.fmul_r4_normalize51",
@@ -1806,7 +1808,7 @@
         "typing_Spec.Poly1305.size_key"
       ],
       0,
-      "0373becb3c193110e919e6f045fed60e"
+      "157c75bbb463b1fe3299c6f2b82351d0"
     ],
     [
       "Hacl.Spec.Poly1305.Field32xN.Lemmas.fmul_r4_normalize5_lemma",
@@ -1820,7 +1822,7 @@
         "typing_Spec.Poly1305.size_key"
       ],
       0,
-      "268bc30e4cf69b0c5e8765c89eae686b"
+      "f92d88544c9197c977d39a5018bc71ef"
     ],
     [
       "Hacl.Spec.Poly1305.Field32xN.Lemmas.fmul_r4_normalize5_lemma",
@@ -1834,7 +1836,7 @@
         "typing_Spec.Poly1305.size_key"
       ],
       0,
-      "b83e9ea231a2717eb25aedaae0ad69ac"
+      "530b616c29b6a0f7a21d977404ea0035"
     ],
     [
       "Hacl.Spec.Poly1305.Field32xN.Lemmas.fmul_r4_normalize5_lemma",
@@ -1842,9 +1844,8 @@
       0,
       1,
       [
-        "@MaxIFuel_assumption", "@query",
-        "FStar.Seq.Base_interpretation_Tm_arrow_44bb45ed5c2534b346e0f58ea5033251",
-        "Hacl.Spec.Poly1305.Field32xN_interpretation_Tm_arrow_a7361ff514189f826f088552abd677d3",
+        "@MaxFuel_assumption", "@MaxIFuel_assumption",
+        "@fuel_correspondence_Prims.pow2.fuel_instrumented", "@query",
         "Hacl.Spec.Poly1305.Vec_interpretation_Tm_arrow_fc0a7b2ced624ae8e81f22573822751a",
         "Lib.IntTypes_interpretation_Tm_arrow_b6c7b131dcab59a8eb8f50c70226d5b9",
         "Lib.IntTypes_interpretation_Tm_arrow_f4a9562bad893d799188b75efefcbe4b",
@@ -1885,10 +1886,10 @@
         "equation_Hacl.Spec.Poly1305.Field32xN.mask26",
         "equation_Hacl.Spec.Poly1305.Field32xN.max26",
         "equation_Hacl.Spec.Poly1305.Field32xN.mul_felem5",
+        "equation_Hacl.Spec.Poly1305.Field32xN.pow26",
         "equation_Hacl.Spec.Poly1305.Field32xN.precomp_r5",
         "equation_Hacl.Spec.Poly1305.Field32xN.smul_add_felem5",
         "equation_Hacl.Spec.Poly1305.Field32xN.smul_felem5",
-        "equation_Hacl.Spec.Poly1305.Field32xN.tup64_5",
         "equation_Hacl.Spec.Poly1305.Field32xN.uint64xN",
         "equation_Hacl.Spec.Poly1305.Vec.compute_r4",
         "equation_Hacl.Spec.Poly1305.Vec.fmul",
@@ -1906,7 +1907,6 @@
         "equation_Spec.GaloisField.gf", "equation_Spec.Poly1305.felem",
         "equation_Spec.Poly1305.size_key",
         "fuel_guarded_inversion_FStar.Pervasives.Native.tuple5",
-        "function_token_typing_Hacl.Spec.Poly1305.Field32xN.tup64_5",
         "function_token_typing_Hacl.Spec.Poly1305.Vec.pfmul",
         "function_token_typing_Lib.IntTypes.add_mod",
         "function_token_typing_Lib.IntTypes.logand",
@@ -1915,8 +1915,7 @@
         "function_token_typing_Lib.IntVector.vec_and",
         "function_token_typing_Lib.IntVector.vec_shift_right",
         "function_token_typing_Prims.__cache_version_number__",
-        "int_inversion", "int_typing",
-        "interpretation_Tm_abs_baadd0755aa20f9b2a01722e1436594a",
+        "int_inversion", "int_typing", "lemma_FStar.UInt.pow2_values",
         "lemma_FStar.UInt32.vu_inv",
         "lemma_Hacl.Spec.Poly1305.Field32xN.Lemmas.fmul_r5_eval_lemma",
         "lemma_Hacl.Spec.Poly1305.Field32xN.Lemmas.fmul_r5_fits_lemma",
@@ -1924,6 +1923,7 @@
         "lemma_Lib.IntVector.vec_add_mod_lemma",
         "lemma_Lib.IntVector.vec_and_lemma", "primitive_Prims.op_AmpAmp",
         "primitive_Prims.op_LessThanOrEqual", "primitive_Prims.op_Multiply",
+        "primitive_Prims.op_Subtraction",
         "proj_equation_Spec.GaloisField.GF_t",
         "projection_inverse_BoxBool_proj_0",
         "projection_inverse_BoxInt_proj_0",
@@ -1946,6 +1946,7 @@
         "refinement_interpretation_Tm_refine_0ec011aea9f93256a3547ad9f0c667f1",
         "refinement_interpretation_Tm_refine_13236e0c52dbe4f6e0704a273d0ea060",
         "refinement_interpretation_Tm_refine_1d9d3fa86e53fad766cc041660ba4ad0",
+        "refinement_interpretation_Tm_refine_26b730cb944f71bac9def42c920eb7ed",
         "refinement_interpretation_Tm_refine_2b9ac1d6c43e9e240d84837e7e466c45",
         "refinement_interpretation_Tm_refine_387e6d282145573240ab7b8a4b94cce5",
         "refinement_interpretation_Tm_refine_38d4ad77f1b33c4b1f7343a28e6fdd11",
@@ -1960,7 +1961,6 @@
         "refinement_interpretation_Tm_refine_93a47a2cc1704fc757fa7c8f83ef7db5",
         "refinement_interpretation_Tm_refine_9920ad7fdb83d776ac74c5ec84d5fe0e",
         "refinement_interpretation_Tm_refine_a658c976a9118ef6c4559f187aff2181",
-        "refinement_interpretation_Tm_refine_abbfe228c7a3d1ae1f16ed243e0e6a67",
         "refinement_interpretation_Tm_refine_c7434c6c05b6023e64eda6cbe46f4ac9",
         "refinement_interpretation_Tm_refine_de8080fdc4bd6678af723874a7d70466",
         "refinement_interpretation_Tm_refine_e40dba697735a60216c598c2a27841b5",
@@ -1974,21 +1974,20 @@
         "typing_Hacl.Spec.Poly1305.Field32xN.feval5",
         "typing_Hacl.Spec.Poly1305.Field32xN.mask26",
         "typing_Hacl.Spec.Poly1305.Field32xN.mul_felem5",
+        "typing_Hacl.Spec.Poly1305.Field32xN.pow26",
         "typing_Hacl.Spec.Poly1305.Vec.pfmul", "typing_Lib.IntTypes.minint",
         "typing_Lib.IntTypes.v", "typing_Lib.IntVector.vec_add_mod",
         "typing_Lib.IntVector.vec_and", "typing_Lib.IntVector.vec_mul_mod",
         "typing_Lib.IntVector.vec_shift_left",
         "typing_Lib.IntVector.vec_shift_right", "typing_Lib.IntVector.vec_v",
-        "typing_Lib.Sequence.create", "typing_Lib.Sequence.createi",
-        "typing_Lib.Sequence.index", "typing_Lib.Sequence.map2",
-        "typing_Spec.AES.gf8", "typing_Spec.GaloisField.__proj__GF__item__t",
-        "typing_Spec.Poly1305.size_key",
-        "typing_Tm_abs_baadd0755aa20f9b2a01722e1436594a",
-        "typing_tok_Lib.IntTypes.SEC@tok", "typing_tok_Lib.IntTypes.U64@tok",
-        "typing_tok_Lib.IntTypes.U8@tok"
+        "typing_Lib.Sequence.create", "typing_Lib.Sequence.index",
+        "typing_Lib.Sequence.map2", "typing_Spec.AES.gf8",
+        "typing_Spec.GaloisField.__proj__GF__item__t",
+        "typing_Spec.Poly1305.size_key", "typing_tok_Lib.IntTypes.SEC@tok",
+        "typing_tok_Lib.IntTypes.U64@tok", "typing_tok_Lib.IntTypes.U8@tok"
       ],
       0,
-      "bbb069f2f44e1c9a035ca6db656bad75"
+      "9b8775cb20fd0e328521bb98e886ff18"
     ],
     [
       "Hacl.Spec.Poly1305.Field32xN.Lemmas.load_felem5_lemma",
@@ -2051,7 +2050,7 @@
         "typing_tok_Lib.IntTypes.SEC@tok", "typing_tok_Lib.IntTypes.U64@tok"
       ],
       0,
-      "be173d43a1046bdf27601fb70cde859c"
+      "e558dadd9d7781b4cdab86f04178ced9"
     ],
     [
       "Hacl.Spec.Poly1305.Field32xN.Lemmas.load_felem5_lemma",
@@ -2153,7 +2152,7 @@
         "typing_tok_Lib.IntTypes.U8@tok"
       ],
       0,
-      "6f67bb6e24c5a2fb2d10d69d64a0e3a6"
+      "ddac7185fe3b661183b7fe88b4dd6b48"
     ],
     [
       "Hacl.Spec.Poly1305.Field32xN.Lemmas.load_felem5_4_interleave",
@@ -2175,7 +2174,6 @@
         "constructor_distinct_Lib.IntTypes.U64",
         "constructor_distinct_Lib.IntTypes.U8",
         "disc_equation_Lib.IntTypes.U1", "equality_tok_Lib.IntTypes.PUB@tok",
-        "equality_tok_Lib.IntTypes.SEC@tok",
         "equality_tok_Lib.IntTypes.U128@tok",
         "equality_tok_Lib.IntTypes.U1@tok",
         "equality_tok_Lib.IntTypes.U32@tok",
@@ -2185,11 +2183,10 @@
         "equation_FStar.UInt.size", "equation_FStar.UInt.uint_t",
         "equation_Lib.IntTypes.bits", "equation_Lib.IntTypes.int_t",
         "equation_Lib.IntTypes.minint", "equation_Lib.IntTypes.pub_int_t",
-        "equation_Lib.IntTypes.pub_int_v", "equation_Lib.IntTypes.range",
-        "equation_Lib.IntTypes.shiftval", "equation_Lib.IntTypes.unsigned",
-        "equation_Lib.IntTypes.v", "equation_Spec.AES.gf8",
-        "equation_Spec.AES.irred", "equation_Spec.GaloisField.gf",
-        "equation_Spec.Poly1305.size_block",
+        "equation_Lib.IntTypes.pub_int_v", "equation_Lib.IntTypes.shiftval",
+        "equation_Lib.IntTypes.unsigned", "equation_Lib.IntTypes.v",
+        "equation_Spec.AES.gf8", "equation_Spec.AES.irred",
+        "equation_Spec.GaloisField.gf", "equation_Spec.Poly1305.size_block",
         "equation_Spec.Poly1305.size_key",
         "function_token_typing_Prims.__cache_version_number__", "int_typing",
         "lemma_FStar.UInt.pow2_values", "lemma_FStar.UInt32.vu_inv",
@@ -2202,20 +2199,15 @@
         "projection_inverse_Spec.GaloisField.GF_t",
         "refinement_interpretation_Tm_refine_0ea1fba779ad5718e28476faeef94d56",
         "refinement_interpretation_Tm_refine_0ec011aea9f93256a3547ad9f0c667f1",
-        "refinement_interpretation_Tm_refine_48486e77aa5457d9a27027fef170c244",
-        "refinement_interpretation_Tm_refine_83845a86f2550cdf941eeb1d9b59602b",
         "refinement_interpretation_Tm_refine_de8080fdc4bd6678af723874a7d70466",
         "refinement_interpretation_Tm_refine_e40dba697735a60216c598c2a27841b5",
         "refinement_interpretation_Tm_refine_f13070840248fced9d9d60d77bdae3ec",
         "typing_FStar.UInt.fits", "typing_FStar.UInt32.uint_to_t",
-        "typing_Lib.IntTypes.v", "typing_Spec.AES.gf8",
-        "typing_Spec.AES.irred",
-        "typing_Spec.GaloisField.__proj__GF__item__t",
-        "typing_Spec.Poly1305.size_block", "typing_Spec.Poly1305.size_key",
-        "typing_tok_Lib.IntTypes.SEC@tok", "typing_tok_Lib.IntTypes.U8@tok"
+        "typing_Spec.AES.gf8", "typing_Spec.GaloisField.__proj__GF__item__t",
+        "typing_Spec.Poly1305.size_block", "typing_Spec.Poly1305.size_key"
       ],
       0,
-      "1e95339282e6f8969b42a32e0d8d3658"
+      "5112860d59fe485c80f2d7cd5303de45"
     ],
     [
       "Hacl.Spec.Poly1305.Field32xN.Lemmas.load_felem5_4_interleave",
@@ -2229,7 +2221,7 @@
         "typing_Spec.Poly1305.size_key"
       ],
       0,
-      "060c5e7d3702d82f87b5b399c7d3dddc"
+      "30d19ec07834c5a754f74d4005962280"
     ],
     [
       "Hacl.Spec.Poly1305.Field32xN.Lemmas.load_felem5_4_interleave",
@@ -2334,7 +2326,7 @@
         "typing_tok_Lib.IntTypes.U64@tok", "typing_tok_Lib.IntTypes.U8@tok"
       ],
       0,
-      "e5d702e65339a1d891419f55591c091d"
+      "dc473d41a8b8db05425953c978a09cf4"
     ],
     [
       "Hacl.Spec.Poly1305.Field32xN.Lemmas.load_felem5_4_compact",
@@ -2348,7 +2340,7 @@
         "typing_Spec.Poly1305.size_key"
       ],
       0,
-      "41c292b9648f27f0f8ed55c3d6cc763a"
+      "9a5113b42f437ec6589f531dfaef0791"
     ],
     [
       "Hacl.Spec.Poly1305.Field32xN.Lemmas.load_felem5_4_compact",
@@ -2362,7 +2354,7 @@
         "typing_Spec.Poly1305.size_key"
       ],
       0,
-      "8df24b82af6811f0e7eed7ff450a3ac9"
+      "c5418b22781a812d64a8b52667b73e66"
     ],
     [
       "Hacl.Spec.Poly1305.Field32xN.Lemmas.load_felem5_4_compact",
@@ -2422,7 +2414,7 @@
         "typing_tok_Lib.IntTypes.U8@tok"
       ],
       0,
-      "48ae02f146b5ff35543860d8c951b6ae"
+      "6d693e1274d27a6136b28d987d1842d5"
     ],
     [
       "Hacl.Spec.Poly1305.Field32xN.Lemmas.load_felem5_4_compact_lemma_i",
@@ -2447,7 +2439,7 @@
         "typing_Spec.Poly1305.size_key"
       ],
       0,
-      "8887ce6f6145157fcf901de906a30c27"
+      "35b182c0391518469edf0092ce189491"
     ],
     [
       "Hacl.Spec.Poly1305.Field32xN.Lemmas.load_felem5_4_compact_lemma_i",
@@ -2461,7 +2453,7 @@
         "typing_Spec.Poly1305.size_key"
       ],
       0,
-      "a2cbf10b9f0f8f7997338c8d064a75b9"
+      "65ca11b5e0036a19552f3b5c3c4f5d8a"
     ],
     [
       "Hacl.Spec.Poly1305.Field32xN.Lemmas.load_felem5_4_compact_lemma_i",
@@ -2587,7 +2579,7 @@
         "typing_tok_Lib.IntTypes.U8@tok"
       ],
       0,
-      "3e19bf3ca39d73021e26dc44052cfb5c"
+      "c1419bb3c139ff879c25d0bbd0248489"
     ],
     [
       "Hacl.Spec.Poly1305.Field32xN.Lemmas.load_felem5_4_lemma",
@@ -2667,7 +2659,7 @@
         "typing_tok_Lib.IntTypes.U8@tok"
       ],
       0,
-      "23b3e1f7c58a6603093b7418b09badcd"
+      "504354f522633955046790180f15f81d"
     ],
     [
       "Hacl.Spec.Poly1305.Field32xN.Lemmas.load_felem5_4_lemma",
@@ -2681,7 +2673,7 @@
         "typing_Spec.Poly1305.size_key"
       ],
       0,
-      "cfbbc46f9681dba73f5eb6516d387142"
+      "74527195c749e9f44abb74bc191caf3f"
     ],
     [
       "Hacl.Spec.Poly1305.Field32xN.Lemmas.load_felem5_4_lemma",
@@ -2807,7 +2799,7 @@
         "typing_tok_Lib.IntTypes.U8@tok"
       ],
       0,
-      "c7f1b23498d9d045a124bc70584cbd7a"
+      "e34c81bcb41fee392e3a532c2501ecc6"
     ],
     [
       "Hacl.Spec.Poly1305.Field32xN.Lemmas.load_felem5_le",
@@ -2842,7 +2834,7 @@
         "typing_Spec.Poly1305.size_key"
       ],
       0,
-      "136828dc36758e2afda347c5dec94010"
+      "f337f5d49775f5d01fd91591246ccfcd"
     ],
     [
       "Hacl.Spec.Poly1305.Field32xN.Lemmas.load_felem5_le",
@@ -2870,7 +2862,7 @@
         "typing_Spec.Poly1305.size_key"
       ],
       0,
-      "dc59076a2d37843409efdd596d820058"
+      "028b7985917dc419d578185814783dda"
     ],
     [
       "Hacl.Spec.Poly1305.Field32xN.Lemmas.load_felem5_le",
@@ -2967,7 +2959,7 @@
         "typing_tok_Lib.IntTypes.U8@tok"
       ],
       0,
-      "f472fc88e76326f49f0d1fa77999f3c9"
+      "3735786a156ead4f36b2f84ac09cacdf"
     ],
     [
       "Hacl.Spec.Poly1305.Field32xN.Lemmas.load_acc5_2_lemma",
@@ -2983,7 +2975,7 @@
         "typing_Spec.Poly1305.prime", "typing_Spec.Poly1305.size_key"
       ],
       0,
-      "f4de361890bc48ce5cd8a4ca0e6a3d81"
+      "6a170cefa216693e1a8350317166637d"
     ],
     [
       "Hacl.Spec.Poly1305.Field32xN.Lemmas.load_acc5_2_lemma",
@@ -2997,7 +2989,7 @@
         "typing_Spec.Poly1305.size_key"
       ],
       0,
-      "638d038679f6a9604830242680955a66"
+      "3d27362e063bb2bd3d6947506eefbe50"
     ],
     [
       "Hacl.Spec.Poly1305.Field32xN.Lemmas.load_acc5_2_lemma",
@@ -3091,7 +3083,6 @@
         "refinement_interpretation_Tm_refine_40d37ebab7c1b683bff04f4efbb0b134",
         "refinement_interpretation_Tm_refine_48486e77aa5457d9a27027fef170c244",
         "refinement_interpretation_Tm_refine_542f9d4f129664613f2483a6c88bc7c2",
-        "refinement_interpretation_Tm_refine_5d7fc65a01f63f2bc577298c179f855a",
         "refinement_interpretation_Tm_refine_7469e637a8c96cb70cd78854c6904f1b",
         "refinement_interpretation_Tm_refine_774ba3f728d91ead8ef40be66c9802e5",
         "refinement_interpretation_Tm_refine_7c43973fc4019941dc225bf271ac5a2a",
@@ -3114,14 +3105,12 @@
         "refinement_kinding_Tm_refine_7469e637a8c96cb70cd78854c6904f1b",
         "token_correspondence_Hacl.Spec.Poly1305.Field32xN.as_pfelem5",
         "typing_FStar.UInt32.uint_to_t",
-        "typing_Hacl.Spec.Poly1305.Field32xN.as_nat5",
         "typing_Hacl.Spec.Poly1305.Field32xN.pow26",
         "typing_Hacl.Spec.Poly1305.Field32xN.transpose",
         "typing_Lib.IntTypes.bits", "typing_Lib.IntTypes.v",
         "typing_Lib.IntVector.vec_v", "typing_Lib.Sequence.createi",
-        "typing_Lib.Sequence.index", "typing_Lib.Sequence.map",
-        "typing_Lib.Sequence.upd", "typing_Prims.pow2",
-        "typing_Spec.AES.gf8", "typing_Spec.AES.irred",
+        "typing_Lib.Sequence.map", "typing_Lib.Sequence.upd",
+        "typing_Prims.pow2", "typing_Spec.AES.gf8", "typing_Spec.AES.irred",
         "typing_Spec.GaloisField.__proj__GF__item__t",
         "typing_Spec.Poly1305.size_key",
         "typing_Tm_abs_baadd0755aa20f9b2a01722e1436594a",
@@ -3129,7 +3118,7 @@
         "typing_tok_Lib.IntTypes.U8@tok"
       ],
       0,
-      "1c27e928420a3ba893334e8e5e4a4837"
+      "3407278e62db4b5a1822ac3bdb7a266a"
     ],
     [
       "Hacl.Spec.Poly1305.Field32xN.Lemmas.load_acc5_4_lemma",
@@ -3148,7 +3137,7 @@
         "typing_Spec.Poly1305.size_key"
       ],
       0,
-      "db5ea8919a102e874a65c85b2777a4d9"
+      "bc2e7524698a88241470f0c5a7a54fad"
     ],
     [
       "Hacl.Spec.Poly1305.Field32xN.Lemmas.load_acc5_4_lemma",
@@ -3162,7 +3151,7 @@
         "typing_Spec.Poly1305.size_key"
       ],
       0,
-      "70838e930cda6578c4e6671af1fa5514"
+      "66d8d4c722c05515f08082cefc36c8f8"
     ],
     [
       "Hacl.Spec.Poly1305.Field32xN.Lemmas.load_acc5_4_lemma",
@@ -3297,7 +3286,7 @@
         "typing_tok_Lib.IntTypes.U8@tok"
       ],
       0,
-      "ef5ba59e3353e3133786a02843c4fd00"
+      "9fb942a9baa406c8aa0444753294c4b4"
     ],
     [
       "Hacl.Spec.Poly1305.Field32xN.Lemmas.store_felem5_lemma",
@@ -3327,7 +3316,7 @@
         "typing_Spec.GaloisField.__proj__GF__item__t"
       ],
       0,
-      "ba666adea95f1ca61d24e95831ac8f9b"
+      "9e6f033194912122d1d4dce190016951"
     ],
     [
       "Hacl.Spec.Poly1305.Field32xN.Lemmas.store_felem5_lemma",
@@ -3339,7 +3328,7 @@
         "refinement_interpretation_Tm_refine_32fa55545657d174d24f9d18b564fe78"
       ],
       0,
-      "0cf70d3dcbbcbc22aad39f376757e48e"
+      "b5e414b72229c05f4a0c0bf7f1e7aaec"
     ],
     [
       "Hacl.Spec.Poly1305.Field32xN.Lemmas.set_bit5_lemma",
@@ -3360,7 +3349,7 @@
         "typing_Prims.pow2", "typing_Spec.Poly1305.size_key"
       ],
       0,
-      "f415ccbe283acc8887d52315e5bcd9ac"
+      "d118a57caf876debf631387d9cc414d3"
     ],
     [
       "Hacl.Spec.Poly1305.Field32xN.Lemmas.set_bit5_lemma",
@@ -3375,7 +3364,7 @@
         "typing_Spec.Poly1305.size_block"
       ],
       0,
-      "16c92dd692466d9609464873212d1de0"
+      "f54f7563432aaf9d58d007ebea996717"
     ],
     [
       "Hacl.Spec.Poly1305.Field32xN.Lemmas.set_bit5_lemma",
@@ -3488,7 +3477,7 @@
         "typing_tok_Lib.IntTypes.U8@tok"
       ],
       0,
-      "2c60eb51c75d568a27f172c12ef335e7"
+      "433a9927044530d04e74cbf329504337"
     ],
     [
       "Hacl.Spec.Poly1305.Field32xN.Lemmas.add_mod_small",
@@ -3510,7 +3499,7 @@
         "typing_Spec.AES.gf8", "typing_Spec.GaloisField.__proj__GF__item__t"
       ],
       0,
-      "29045560d36c16fbc6437b3d3cca257c"
+      "13c9ffda910dbe676a7b8e614da2679f"
     ],
     [
       "Hacl.Spec.Poly1305.Field32xN.Lemmas.add_mod_small",
@@ -3533,7 +3522,7 @@
         "typing_Spec.AES.gf8", "typing_Spec.GaloisField.__proj__GF__item__t"
       ],
       0,
-      "6b0413cc6be76bc9a5477a4363563e12"
+      "521d77276ba1c6c4ec727f55daee14d8"
     ],
     [
       "Hacl.Spec.Poly1305.Field32xN.Lemmas.mod_add128_lemma",
@@ -3548,7 +3537,7 @@
         "refinement_interpretation_Tm_refine_a658c976a9118ef6c4559f187aff2181"
       ],
       0,
-      "5c4a679137be18f891fb05b10d07826b"
+      "ff4f121a61912c157e85dfef60b521f9"
     ],
     [
       "Hacl.Spec.Poly1305.Field32xN.Lemmas.mod_add128_lemma",
@@ -3616,7 +3605,7 @@
         "typing_tok_Lib.IntTypes.U64@tok", "typing_tok_Lib.IntTypes.U8@tok"
       ],
       0,
-      "a5afbea10b74dd550ee02aeb80631e91"
+      "0b25e0ced9018a52a44f1790edf9be6d"
     ]
   ]
 ]

--- a/hints/Lib.IntTypes.fst.hints
+++ b/hints/Lib.IntTypes.fst.hints
@@ -1,5 +1,5 @@
 [
-  "sgΩ:ú›\u0006{o-õ¿v@+À",
+  "«˚Ã*‡CCcRÂ÷\\HﬁxV",
   [
     [
       "Lib.IntTypes.pow2_2",
@@ -8,7 +8,7 @@
       1,
       [ "@query" ],
       0,
-      "555b0b344bbd34bf89d3524d7c72de9f"
+      "6ad3bf88a989ad23811b8c627b0626bf"
     ],
     [
       "Lib.IntTypes.pow2_3",
@@ -17,7 +17,7 @@
       1,
       [ "@query" ],
       0,
-      "a2ef3b11b46253e6101558651c4e8409"
+      "6ae0f8ef10054d651b42f69e1bca86cf"
     ],
     [
       "Lib.IntTypes.pow2_4",
@@ -26,7 +26,7 @@
       1,
       [ "@query" ],
       0,
-      "c7adc540a3efff233c1b4a9ea09fa234"
+      "740156c585b78590469bd7c867436609"
     ],
     [
       "Lib.IntTypes.pow2_127",
@@ -35,7 +35,7 @@
       1,
       [ "@query" ],
       0,
-      "16933bdbdd348bd0de5f85f90811a7b7"
+      "3cffb13b5cb2e1396e353ab47f368a53"
     ],
     [
       "Lib.IntTypes.numbytes",
@@ -52,7 +52,7 @@
         "fuel_guarded_inversion_Lib.IntTypes.inttype"
       ],
       0,
-      "e0cfcf8f137b81df0cc5bb5050dc5869"
+      "e47610da8d40c59b62bbb676764ca078"
     ],
     [
       "Lib.IntTypes.bits",
@@ -69,7 +69,7 @@
         "fuel_guarded_inversion_Lib.IntTypes.inttype"
       ],
       0,
-      "f424d3f0cd9d9b2d4276c49388e7337a"
+      "919770220eda5f46b98ba539a6a3c5a6"
     ],
     [
       "Lib.IntTypes.bits_numbytes",
@@ -85,7 +85,7 @@
         "refinement_interpretation_Tm_refine_70769f76f84273b3587aeaec18364fbc"
       ],
       0,
-      "eb01621cc1bdcf3edf7cbbac16aae482"
+      "1f94e6aa12567ead297d25bc3196407f"
     ],
     [
       "Lib.IntTypes.modulus",
@@ -98,7 +98,7 @@
         "projection_inverse_BoxInt_proj_0"
       ],
       0,
-      "f3873d5a707d7068348b2293ea079620"
+      "bed267d2fae526809f9327551a1728e9"
     ],
     [
       "Lib.IntTypes.maxint",
@@ -112,7 +112,7 @@
         "primitive_Prims.op_Subtraction", "projection_inverse_BoxInt_proj_0"
       ],
       0,
-      "daa95e76437748770098abb5eeccab21"
+      "36c3650cafd20875b711fae4b9810cb9"
     ],
     [
       "Lib.IntTypes.minint",
@@ -126,7 +126,7 @@
         "primitive_Prims.op_Subtraction", "projection_inverse_BoxInt_proj_0"
       ],
       0,
-      "a678e8a94b8b099e670eaf417bf2423c"
+      "e6b312d5187add3819af384cd3950298"
     ],
     [
       "Lib.IntTypes.pub_int_t",
@@ -143,7 +143,7 @@
         "fuel_guarded_inversion_Lib.IntTypes.inttype"
       ],
       0,
-      "57addcf975c1a54a7aa74a1a5228ba05"
+      "4c9b98aba11bee6354ba233312516a0b"
     ],
     [
       "Lib.IntTypes.pub_int_v",
@@ -189,7 +189,7 @@
         "typing_Lib.IntTypes.bits", "typing_tok_Lib.IntTypes.U1@tok"
       ],
       0,
-      "34a7f0688ab86b7b11423bfd19b830d0"
+      "1f1e5cc2f3d5a2761cdd5c88f144a402"
     ],
     [
       "Lib.IntTypes.int_t",
@@ -202,7 +202,7 @@
         "fuel_guarded_inversion_Lib.IntTypes.secrecy_level"
       ],
       0,
-      "e83f3eaf781fff4e3be56ee756614a3a"
+      "2f1b897722ba215676cce52a80418368"
     ],
     [
       "Lib.IntTypes.v",
@@ -217,7 +217,7 @@
         "projection_inverse_BoxBool_proj_0"
       ],
       0,
-      "068ed15ef3bbe8edc0fd544b692d3f94"
+      "eace8924fd326a5e4bd27d5b2facf3a7"
     ],
     [
       "Lib.IntTypes.uint1",
@@ -230,7 +230,7 @@
         "projection_inverse_BoxBool_proj_0"
       ],
       0,
-      "b29194e50074194c27daeecbf23af5ea"
+      "bbe69ab4288b3a299d7ae565d20ac0d1"
     ],
     [
       "Lib.IntTypes.uint8",
@@ -243,7 +243,7 @@
         "projection_inverse_BoxBool_proj_0"
       ],
       0,
-      "f97f2e15938b0ede13ab9f0f0b0b8037"
+      "b681ef8a975c7bd5e7999e20b2953c1a"
     ],
     [
       "Lib.IntTypes.int8",
@@ -256,7 +256,7 @@
         "projection_inverse_BoxBool_proj_0"
       ],
       0,
-      "cd8992479ec8d1171c64e114ff127609"
+      "9fc9240fa445701476ee0a7fec2fb742"
     ],
     [
       "Lib.IntTypes.uint16",
@@ -269,7 +269,7 @@
         "equation_Lib.IntTypes.unsigned", "projection_inverse_BoxBool_proj_0"
       ],
       0,
-      "bf76c811a23a3a5f38b1db1b8b61e0e0"
+      "9d3cdeb555d7789685e2815217f5b959"
     ],
     [
       "Lib.IntTypes.int16",
@@ -282,7 +282,7 @@
         "projection_inverse_BoxBool_proj_0"
       ],
       0,
-      "1536b26f448812e5a618c7924a12bae0"
+      "5fb675d39f4ee10c8bf51150c4a57360"
     ],
     [
       "Lib.IntTypes.uint32",
@@ -295,7 +295,7 @@
         "equation_Lib.IntTypes.unsigned", "projection_inverse_BoxBool_proj_0"
       ],
       0,
-      "73a1f09c63c55283a06c0eb97f84d03b"
+      "78f44fbe0f32c7bab8ae8e1ea9e29abb"
     ],
     [
       "Lib.IntTypes.int32",
@@ -308,7 +308,7 @@
         "projection_inverse_BoxBool_proj_0"
       ],
       0,
-      "b0fe01e01e87648abfef2f22a9599c3e"
+      "9087335a04287548feb1b63ddbd1cd0b"
     ],
     [
       "Lib.IntTypes.uint64",
@@ -321,7 +321,7 @@
         "equation_Lib.IntTypes.unsigned", "projection_inverse_BoxBool_proj_0"
       ],
       0,
-      "9e4c09e864e536421cff6d72a33cd075"
+      "29f1bb79d371ced30b97413d4722d4a6"
     ],
     [
       "Lib.IntTypes.int64",
@@ -334,7 +334,7 @@
         "projection_inverse_BoxBool_proj_0"
       ],
       0,
-      "41eef61eac8d6f1fda36465778f6f200"
+      "7c37f40819d6bd424b6c9dc1bbfc6ced"
     ],
     [
       "Lib.IntTypes.uint128",
@@ -347,7 +347,7 @@
         "equation_Lib.IntTypes.unsigned", "projection_inverse_BoxBool_proj_0"
       ],
       0,
-      "4e88e2bd294a51b56a4afed18f26a701"
+      "3c8cdcb28d38c49f08ed1fdc7026174e"
     ],
     [
       "Lib.IntTypes.int128",
@@ -360,7 +360,7 @@
         "projection_inverse_BoxBool_proj_0"
       ],
       0,
-      "6c0aac3ae4aa645a2c599c25966544b8"
+      "e261e7c5b439af6099b5e70ce1ff8eaf"
     ],
     [
       "Lib.IntTypes.bit_t",
@@ -373,7 +373,7 @@
         "projection_inverse_BoxBool_proj_0"
       ],
       0,
-      "b98e4928062e92adca71478644b14f91"
+      "ad65c057b26885e9c259318c9557b49d"
     ],
     [
       "Lib.IntTypes.byte_t",
@@ -386,7 +386,7 @@
         "projection_inverse_BoxBool_proj_0"
       ],
       0,
-      "64fb99bb7236dba360dad70257607309"
+      "859b4bab19c896058d016b16ab217b4f"
     ],
     [
       "Lib.IntTypes.size_t",
@@ -399,7 +399,7 @@
         "equation_Lib.IntTypes.unsigned", "projection_inverse_BoxBool_proj_0"
       ],
       0,
-      "0a991d3eb9fb47c89582b2fb08520df2"
+      "71a96bc9d7ed3e5973539b87ce32e6fc"
     ],
     [
       "Lib.IntTypes.size128_t",
@@ -412,7 +412,7 @@
         "equation_Lib.IntTypes.unsigned", "projection_inverse_BoxBool_proj_0"
       ],
       0,
-      "422dd5f53785be6533bc7c9ed011b609"
+      "cd477bcfb604e5efe5a41d6fd345fde3"
     ],
     [
       "Lib.IntTypes.pub_uint8",
@@ -425,7 +425,7 @@
         "projection_inverse_BoxBool_proj_0"
       ],
       0,
-      "7b2ef3236cc86c0644165f3c302152ef"
+      "2474b1e7dae5fb8cb4cbbcb036e1507b"
     ],
     [
       "Lib.IntTypes.pub_int8",
@@ -438,7 +438,7 @@
         "projection_inverse_BoxBool_proj_0"
       ],
       0,
-      "019f8aa248e777f9522bcdccfc36d2a3"
+      "fafbbb4b79ed329b65909db55a8e25de"
     ],
     [
       "Lib.IntTypes.pub_uint16",
@@ -451,7 +451,7 @@
         "equation_Lib.IntTypes.unsigned", "projection_inverse_BoxBool_proj_0"
       ],
       0,
-      "eb9a34097a0fcb1109ee317c8710fd5e"
+      "ebfcc75f2ff41573c3e94dc7157ea4c9"
     ],
     [
       "Lib.IntTypes.pub_int16",
@@ -464,7 +464,7 @@
         "projection_inverse_BoxBool_proj_0"
       ],
       0,
-      "46fb81742da70f4df676d0a7c38f3487"
+      "a594c88905cc921e4af37e8edae47709"
     ],
     [
       "Lib.IntTypes.pub_uint32",
@@ -477,7 +477,7 @@
         "equation_Lib.IntTypes.unsigned", "projection_inverse_BoxBool_proj_0"
       ],
       0,
-      "6faab791ab643956d202894d028b077b"
+      "16088306da15f88e7643fd6a9ea2dfed"
     ],
     [
       "Lib.IntTypes.pub_int32",
@@ -490,7 +490,7 @@
         "projection_inverse_BoxBool_proj_0"
       ],
       0,
-      "dd50878ca6f095f53c83446529be7117"
+      "fe26bee63d53c7ed3234b9eb471d2313"
     ],
     [
       "Lib.IntTypes.pub_uint64",
@@ -503,7 +503,7 @@
         "equation_Lib.IntTypes.unsigned", "projection_inverse_BoxBool_proj_0"
       ],
       0,
-      "e28e6eb6f04b82e85e661f984880f8bc"
+      "ccfa100ada494c40d9122d4cdc9561c6"
     ],
     [
       "Lib.IntTypes.pub_int64",
@@ -516,7 +516,7 @@
         "projection_inverse_BoxBool_proj_0"
       ],
       0,
-      "e99d013d3243eaa867ffd0bbd13c356f"
+      "4123dac3b3ca07702d6d4200e30c3a0c"
     ],
     [
       "Lib.IntTypes.pub_uint128",
@@ -529,7 +529,7 @@
         "equation_Lib.IntTypes.unsigned", "projection_inverse_BoxBool_proj_0"
       ],
       0,
-      "5a45e2a26972fbf5d853108839c5dfcd"
+      "7c437cb3cd7f2f49e51ccce6d95640fa"
     ],
     [
       "Lib.IntTypes.pub_int128",
@@ -542,7 +542,7 @@
         "projection_inverse_BoxBool_proj_0"
       ],
       0,
-      "858c2c1fe2949f31fca6443bcf4ad213"
+      "15c09535da89dc4fac0b2dafaa17bd1f"
     ],
     [
       "Lib.IntTypes.secret",
@@ -557,7 +557,7 @@
         "equation_Lib.IntTypes.sec_int_v", "equation_Lib.IntTypes.v"
       ],
       0,
-      "e7fcb1551262d172500819c2d385fd40"
+      "454c1c10549cee05821d8fa5222647ce"
     ],
     [
       "Lib.IntTypes.mk_int",
@@ -620,7 +620,7 @@
         "typing_Lib.IntTypes.maxint"
       ],
       0,
-      "003489374178a29796ebc4569caf555c"
+      "f65bf575ba922e0c921291c741b1ef2f"
     ],
     [
       "Lib.IntTypes.v_extensionality",
@@ -668,7 +668,7 @@
         "refinement_interpretation_Tm_refine_e0b16d74ee3644bd585df5e7938934c6"
       ],
       0,
-      "8c271dd000cd24e1724477da55d1baf0"
+      "1c3b5d453b926d8962ae31a4457c7179"
     ],
     [
       "Lib.IntTypes.v_injective",
@@ -682,7 +682,7 @@
         "typing_Lib.IntTypes.mk_int", "typing_Lib.IntTypes.v"
       ],
       0,
-      "35f3ee11b015071a7c4eb38895f7046f"
+      "af1acd5ad8bc33a77abc06a6eb5c4641"
     ],
     [
       "Lib.IntTypes.v_mk_int",
@@ -695,7 +695,7 @@
         "typing_Lib.IntTypes.mk_int"
       ],
       0,
-      "4e9525e4d22af540213819b746b87bc6"
+      "a641808f45a049ca4d85cdcfda3b6257"
     ],
     [
       "Lib.IntTypes.u1",
@@ -708,7 +708,7 @@
         "projection_inverse_BoxBool_proj_0"
       ],
       0,
-      "0aec24565dfec0e2978b4150823ed0c8"
+      "4907cee376491cd0d99c2af372633679"
     ],
     [
       "Lib.IntTypes.u8",
@@ -721,7 +721,7 @@
         "projection_inverse_BoxBool_proj_0"
       ],
       0,
-      "94cf6d590d30493a567455199663beec"
+      "c01dc99da7108508901bb2c932ce9a6b"
     ],
     [
       "Lib.IntTypes.i8",
@@ -734,7 +734,7 @@
         "projection_inverse_BoxBool_proj_0"
       ],
       0,
-      "74d7157bbbc93f0b918bba1fe6075750"
+      "f967687fed88e4383ad32755cbd4e9ee"
     ],
     [
       "Lib.IntTypes.u16",
@@ -747,7 +747,7 @@
         "equation_Lib.IntTypes.unsigned", "projection_inverse_BoxBool_proj_0"
       ],
       0,
-      "dcb8a2a4ee6833a28cdf3c7d915ab573"
+      "db159ad744c3b50fdcec75f838c519f1"
     ],
     [
       "Lib.IntTypes.i16",
@@ -760,7 +760,7 @@
         "projection_inverse_BoxBool_proj_0"
       ],
       0,
-      "14d2fc6a0459374178f48acbf3a77d7b"
+      "717e9b8e9c8ac34654bad00dd417b38c"
     ],
     [
       "Lib.IntTypes.u32",
@@ -773,7 +773,7 @@
         "equation_Lib.IntTypes.unsigned", "projection_inverse_BoxBool_proj_0"
       ],
       0,
-      "02fdd20ce076330689db38dbaf177611"
+      "d5edf030f0bb798cbfb4f6e024455136"
     ],
     [
       "Lib.IntTypes.i32",
@@ -789,7 +789,7 @@
         "typing_tok_Lib.IntTypes.S32@tok"
       ],
       0,
-      "ba090336bbb207369c767f50fb0fca57"
+      "af973bfe6128e184e6574559bf627de0"
     ],
     [
       "Lib.IntTypes.u64",
@@ -802,7 +802,7 @@
         "equation_Lib.IntTypes.unsigned", "projection_inverse_BoxBool_proj_0"
       ],
       0,
-      "8add148572333ab4ee56d51ba54ea545"
+      "9d4effd0621110f3d9d61a5b7234201a"
     ],
     [
       "Lib.IntTypes.i64",
@@ -818,7 +818,7 @@
         "typing_tok_Lib.IntTypes.S64@tok"
       ],
       0,
-      "d8add49da48a475dd5105d22ad7ba159"
+      "09bf12759fb9932ff979c66c2d1b550f"
     ],
     [
       "Lib.IntTypes.u128",
@@ -827,7 +827,7 @@
       1,
       [ "@query" ],
       0,
-      "8b7ea6f6ed2929dd75761c67aa9f235c"
+      "53d7d9cf9fcac1ea64c323a613503df0"
     ],
     [
       "Lib.IntTypes.u128",
@@ -851,7 +851,7 @@
         "typing_tok_Lib.IntTypes.U64@tok"
       ],
       0,
-      "d890db43c719cd459d511bdb28f1534b"
+      "1840211fae5c25b748cecdfc15f83ea5"
     ],
     [
       "Lib.IntTypes.i128",
@@ -860,7 +860,7 @@
       1,
       [ "@query" ],
       0,
-      "69833d3998774c2d1fb0e2d5715330cf"
+      "b407a71ce45225cd5bc53e450d97b5fd"
     ],
     [
       "Lib.IntTypes.i128",
@@ -882,7 +882,7 @@
         "refinement_interpretation_Tm_refine_360500544b85bc92abd73f53c89e0565"
       ],
       0,
-      "f44eaa7faf95dadb81ed587c2463df61"
+      "73912c4d60c531e4be329e61e2f655e7"
     ],
     [
       "Lib.IntTypes.size",
@@ -900,7 +900,7 @@
         "refinement_interpretation_Tm_refine_542f9d4f129664613f2483a6c88bc7c2"
       ],
       0,
-      "d95e94138203f406b0c780523009dd00"
+      "028999b501f3efb688ebde867882ea4f"
     ],
     [
       "Lib.IntTypes.byte",
@@ -923,7 +923,7 @@
         "typing_Lib.IntTypes.bits", "typing_tok_Lib.IntTypes.U8@tok"
       ],
       0,
-      "01b3df23c4c9783605eb7bbb76584499"
+      "dab5d17e96a217f899ab50e4e638e820"
     ],
     [
       "Lib.IntTypes.byte_v",
@@ -946,7 +946,7 @@
         "typing_tok_Lib.IntTypes.U8@tok"
       ],
       0,
-      "dc79393c855030cc88814f5621bc4caa"
+      "9eca72b3632fac2d9f990520aad8c0b2"
     ],
     [
       "Lib.IntTypes.size_to_uint32",
@@ -962,7 +962,7 @@
         "typing_tok_Lib.IntTypes.PUB@tok", "typing_tok_Lib.IntTypes.U32@tok"
       ],
       0,
-      "90e5ca7b6c6ed1f7435a59013ef832c0"
+      "4b5319d68086126554232b341b1327a4"
     ],
     [
       "Lib.IntTypes.size_to_uint64",
@@ -988,7 +988,7 @@
         "typing_tok_Lib.IntTypes.U64@tok"
       ],
       0,
-      "fc2567999eb3bef3869e1c113c53c75b"
+      "d566e1ebc288bd73565407b09c4b35b6"
     ],
     [
       "Lib.IntTypes.size_to_uint64",
@@ -1008,7 +1008,7 @@
         "equation_Lib.IntTypes.v"
       ],
       0,
-      "251e5ee52f9ec2e3c8efca68607054cd"
+      "ee27547b2ea4656c83d1ddb787eea5d1"
     ],
     [
       "Lib.IntTypes.byte_to_uint8",
@@ -1024,7 +1024,7 @@
         "typing_tok_Lib.IntTypes.PUB@tok", "typing_tok_Lib.IntTypes.U8@tok"
       ],
       0,
-      "307289571e7467f21dca9676024ef71e"
+      "3071796a90e2f1a9f876c5fc6d38f079"
     ],
     [
       "Lib.IntTypes.op_At_Percent_Dot",
@@ -1042,7 +1042,7 @@
         "typing_Lib.IntTypes.bits"
       ],
       0,
-      "b0f43f661b48f5d36571e109905dd093"
+      "832ead471d2e6bf9c4f79d1b9ac2601e"
     ],
     [
       "Lib.IntTypes.uint128_to_int128",
@@ -1054,7 +1054,7 @@
         "projection_inverse_BoxInt_proj_0"
       ],
       0,
-      "52ba0c10fd973937e1410a1428e5a1d5"
+      "3e243d0a1dbcde2a63fc1973f84d3f15"
     ],
     [
       "Lib.IntTypes.int128_to_uint128",
@@ -1063,7 +1063,7 @@
       1,
       [ "@query" ],
       0,
-      "76363ca2e46e0fff4491f92e4483e44c"
+      "10364d918a4c1fadfac381cd6f0d24fa"
     ],
     [
       "Lib.IntTypes.int64_to_int128",
@@ -1072,7 +1072,7 @@
       1,
       [ "@query" ],
       0,
-      "e50e630fcc08db7c5c03ff71a9899945"
+      "2361b16aca857ef34246b16c14749898"
     ],
     [
       "Lib.IntTypes.uint64_to_int128",
@@ -1081,7 +1081,7 @@
       1,
       [ "@query" ],
       0,
-      "7e9e4b95fcf0dc192a183d31dd3cc81f"
+      "45f179b1dc5edeb0540554a52ace5538"
     ],
     [
       "Lib.IntTypes.uint64_to_int128",
@@ -1115,7 +1115,7 @@
         "typing_FStar.UInt64.v"
       ],
       0,
-      "88222c8a4c5caf4f604da5c244204817"
+      "0dbf3c1e907fbfe9e26d7bd6519777ea"
     ],
     [
       "Lib.IntTypes.int64_to_uint128",
@@ -1124,7 +1124,7 @@
       1,
       [ "@query" ],
       0,
-      "db31c1bf7cf1a10cfea4b98f122b52a4"
+      "80931dbdaad5f9c5625e9060708b776d"
     ],
     [
       "Lib.IntTypes.int64_to_uint128",
@@ -1137,7 +1137,7 @@
         "typing_Lib.IntTypes.int64_to_int128"
       ],
       0,
-      "8e938610c4f759e82d938c79b0dd4b8a"
+      "b9ab3a1627f2e18ad80944d38ee3bbce"
     ],
     [
       "Lib.IntTypes.int128_to_uint64",
@@ -1146,7 +1146,7 @@
       1,
       [ "@query" ],
       0,
-      "581ac6048ae5f31873a0297b5e3e7d82"
+      "ab82a991818dd1c9e6812be3be93440e"
     ],
     [
       "Lib.IntTypes.int128_to_uint64",
@@ -1164,7 +1164,7 @@
         "typing_Lib.IntTypes.int128_to_uint128"
       ],
       0,
-      "7a847bb2f32a22c0ccd2290886639fbc"
+      "804878260f885e59908d165e7a84c74b"
     ],
     [
       "Lib.IntTypes.cast",
@@ -1227,7 +1227,7 @@
         "equation_FStar.UInt.fits", "equation_FStar.UInt.max_int",
         "equation_FStar.UInt.min_int", "equation_FStar.UInt.mod",
         "equation_FStar.UInt.size", "equation_FStar.UInt.uint_t",
-        "equation_Lib.IntTypes.bits",
+        "equation_FStar.UInt128.n", "equation_Lib.IntTypes.bits",
         "equation_Lib.IntTypes.int128_to_uint64",
         "equation_Lib.IntTypes.int_t", "equation_Lib.IntTypes.maxint",
         "equation_Lib.IntTypes.minint", "equation_Lib.IntTypes.mk_int",
@@ -1239,9 +1239,9 @@
         "equation_Prims.nat", "equation_Prims.pos",
         "fuel_guarded_inversion_Lib.IntTypes.inttype",
         "fuel_guarded_inversion_Lib.IntTypes.secrecy_level", "int_inversion",
-        "int_typing", "lemma_FStar.Int32.vu_inv", "lemma_FStar.Int64.vu_inv",
-        "lemma_FStar.UInt.pow2_values", "lemma_FStar.UInt16.vu_inv",
-        "lemma_FStar.UInt32.vu_inv", "lemma_FStar.UInt64.vu_inv",
+        "int_typing", "lemma_FStar.Int.pow2_values",
+        "lemma_FStar.Int128.uv_inv", "lemma_FStar.Int32.vu_inv",
+        "lemma_FStar.Int64.vu_inv", "lemma_FStar.UInt.pow2_values",
         "lemma_FStar.UInt8.vu_inv", "lemma_Lib.IntTypes.pow2_127",
         "lemma_Lib.IntTypes.pow2_3", "lemma_Lib.IntTypes.pow2_4",
         "lemma_Lib.IntTypes.v_injective", "primitive_Prims.op_AmpAmp",
@@ -1318,6 +1318,7 @@
         "refinement_interpretation_Tm_refine_a26519a40aab867b4821f7c4709fce2f",
         "refinement_interpretation_Tm_refine_a3e91433acc705e2c7f5ab6f610b2493",
         "refinement_interpretation_Tm_refine_a83e612d0efa5d8d50911d277043d4d7",
+        "refinement_interpretation_Tm_refine_a8cb57fcf32c2764d2e39fc97ecb3aa0",
         "refinement_interpretation_Tm_refine_a995c3cc7036f692b497220b043bcc27",
         "refinement_interpretation_Tm_refine_aa10b26044072a79c677f1b78e9d2240",
         "refinement_interpretation_Tm_refine_aaa419c732c303ea718cda472f97909d",
@@ -1367,20 +1368,21 @@
         "typing_FStar.Int.Cast.uint16_to_uint8",
         "typing_FStar.Int.Cast.uint32_to_uint8",
         "typing_FStar.Int.Cast.uint64_to_uint8", "typing_FStar.Int.fits",
-        "typing_FStar.Int.op_At_Percent", "typing_FStar.Int128.v",
-        "typing_FStar.Int16.v", "typing_FStar.Int32.v",
-        "typing_FStar.Int64.v", "typing_FStar.Int8.v",
-        "typing_FStar.UInt.fits", "typing_FStar.UInt16.v",
-        "typing_FStar.UInt32.v", "typing_FStar.UInt64.v",
-        "typing_FStar.UInt8.rem", "typing_FStar.UInt8.v",
-        "typing_Lib.IntTypes.bits", "typing_Lib.IntTypes.int128_to_uint64",
-        "typing_Lib.IntTypes.maxint", "typing_Lib.IntTypes.minint",
+        "typing_FStar.Int128.v", "typing_FStar.Int16.v",
+        "typing_FStar.Int32.v", "typing_FStar.Int64.v",
+        "typing_FStar.Int8.v", "typing_FStar.UInt.fits",
+        "typing_FStar.UInt128.v", "typing_FStar.UInt8.rem",
+        "typing_FStar.UInt8.v", "typing_Lib.IntTypes.bits",
+        "typing_Lib.IntTypes.int128_to_uint64", "typing_Lib.IntTypes.maxint",
+        "typing_Lib.IntTypes.minint",
         "typing_Lib.IntTypes.op_At_Percent_Dot",
-        "typing_Lib.IntTypes.unsigned", "typing_Lib.IntTypes.v",
-        "typing_Prims.pow2", "typing_tok_Lib.IntTypes.U1@tok"
+        "typing_Lib.IntTypes.pub_int_v", "typing_Lib.IntTypes.unsigned",
+        "typing_Lib.IntTypes.v", "typing_Prims.pow2",
+        "typing_tok_Lib.IntTypes.PUB@tok", "typing_tok_Lib.IntTypes.SEC@tok",
+        "typing_tok_Lib.IntTypes.U1@tok"
       ],
       0,
-      "ccdf5eff1f96e708a4900fbc9f6857ac"
+      "59b39f0a372c96eb98b557a844176096"
     ],
     [
       "Lib.IntTypes.to_u1",
@@ -1394,7 +1396,7 @@
         "projection_inverse_BoxBool_proj_0"
       ],
       0,
-      "6f98eebf52cddf328b94075859b60ebd"
+      "1586c4372e53668913dcd11b0be2cffb"
     ],
     [
       "Lib.IntTypes.to_u8",
@@ -1408,7 +1410,7 @@
         "projection_inverse_BoxBool_proj_0"
       ],
       0,
-      "6bf1372a9bb2a638495750508e552a2c"
+      "f643d75e732f469db5802785eb6bae78"
     ],
     [
       "Lib.IntTypes.to_i8",
@@ -1422,7 +1424,7 @@
         "projection_inverse_BoxBool_proj_0"
       ],
       0,
-      "f05f5e6e439621b81b907b447754e810"
+      "ebb0f132e0fa30fe17f86b64b7ada5ec"
     ],
     [
       "Lib.IntTypes.to_u16",
@@ -1436,7 +1438,7 @@
         "projection_inverse_BoxBool_proj_0"
       ],
       0,
-      "97eb42e5a5775c7ed8b270b7d53ab6b6"
+      "db4c6ad5211a2fe4cd705fe5cb84cd12"
     ],
     [
       "Lib.IntTypes.to_i16",
@@ -1450,7 +1452,7 @@
         "projection_inverse_BoxBool_proj_0"
       ],
       0,
-      "c2bb42037ab4ef6247cf883af7737431"
+      "be39ff8d74e15e543074faac19197fc0"
     ],
     [
       "Lib.IntTypes.to_u32",
@@ -1464,7 +1466,7 @@
         "projection_inverse_BoxBool_proj_0"
       ],
       0,
-      "bfc44bfac28a936d8e2c11c46eb61b0d"
+      "00fad69b28aab0570403c63afac0d19b"
     ],
     [
       "Lib.IntTypes.to_i32",
@@ -1478,7 +1480,7 @@
         "projection_inverse_BoxBool_proj_0"
       ],
       0,
-      "b9a38d4f86f2ede2b6c5476a724f5e78"
+      "f6b29350d23484dd425cb39f29799338"
     ],
     [
       "Lib.IntTypes.to_u64",
@@ -1492,7 +1494,7 @@
         "projection_inverse_BoxBool_proj_0"
       ],
       0,
-      "d21b529d08e6ca69a258977094fe6b7e"
+      "ac247e74a8006cc01cdbeafffe5f6dfc"
     ],
     [
       "Lib.IntTypes.to_i64",
@@ -1506,7 +1508,7 @@
         "projection_inverse_BoxBool_proj_0"
       ],
       0,
-      "455df6c0f322086c06dfb70b207ce221"
+      "7bc018cfeee3980e6d6c4ab4cdfd94e0"
     ],
     [
       "Lib.IntTypes.to_u128",
@@ -1520,7 +1522,7 @@
         "projection_inverse_BoxBool_proj_0"
       ],
       0,
-      "67f921f825533310a025e5f2aa440fb2"
+      "25b040832e20dbc1f8a8b2aa005a98a3"
     ],
     [
       "Lib.IntTypes.to_i128",
@@ -1534,7 +1536,7 @@
         "projection_inverse_BoxBool_proj_0"
       ],
       0,
-      "7a6d1f0b18eef824dc6f838760750f73"
+      "448b12dc65ee2686c1dcad087b52cfbd"
     ],
     [
       "Lib.IntTypes.ones_v",
@@ -1551,7 +1553,7 @@
         "fuel_guarded_inversion_Lib.IntTypes.inttype"
       ],
       0,
-      "477249b67db8cd115b110676b4776152"
+      "818df63b472d6865cfe0f6ea5d77783d"
     ],
     [
       "Lib.IntTypes.ones",
@@ -1632,7 +1634,7 @@
         "typing_tok_Lib.IntTypes.U8@tok"
       ],
       0,
-      "453de9633fd3035e8b5a044c01b85feb"
+      "9b543b69e85e173d2ae2fec456cd2190"
     ],
     [
       "Lib.IntTypes.zeros",
@@ -1675,7 +1677,7 @@
         "typing_tok_Lib.IntTypes.U8@tok"
       ],
       0,
-      "2a709b4d7a7c39a69b409f55a66041b6"
+      "a5294622db661c2e9a7f31f06d57ff92"
     ],
     [
       "Lib.IntTypes.add_mod",
@@ -1714,7 +1716,7 @@
         "typing_Lib.IntTypes.unsigned"
       ],
       0,
-      "aa2bde436f54226500e2cbf000e3878b"
+      "09188ecefefbe38b8fc5c3dec11cb1ed"
     ],
     [
       "Lib.IntTypes.add_mod_lemma",
@@ -1777,7 +1779,7 @@
         "typing_Lib.IntTypes.unsigned", "typing_Lib.IntTypes.v"
       ],
       0,
-      "f75ba66f40df1ffc44ba98506bdd58f1"
+      "edb3576d3165dfb31434050df981dd5f"
     ],
     [
       "Lib.IntTypes.add",
@@ -1845,7 +1847,7 @@
         "typing_FStar.UInt8.v"
       ],
       0,
-      "d13adef8eff303b090749c1c6450340a"
+      "e19721a548621b305d18b8c2d57e41fc"
     ],
     [
       "Lib.IntTypes.add_lemma",
@@ -1916,7 +1918,7 @@
         "typing_Lib.IntTypes.add", "typing_Lib.IntTypes.v"
       ],
       0,
-      "010e84a5dd437f5b9cf0d157f6de9ff3"
+      "d6ada431acf2281ba2297a04ad9ca62e"
     ],
     [
       "Lib.IntTypes.incr",
@@ -1992,7 +1994,7 @@
         "typing_Lib.IntTypes.v", "typing_tok_Lib.IntTypes.U128@tok"
       ],
       0,
-      "bd30d2af041d5e915569fcf01bd1bf62"
+      "d6eac65060a5517deb60ed20b6a1f47a"
     ],
     [
       "Lib.IntTypes.incr_lemma",
@@ -2089,7 +2091,7 @@
         "typing_Lib.IntTypes.v", "typing_Prims.pow2"
       ],
       0,
-      "c8ccaa17af37dabe7ccf779585d33e03"
+      "3b58e4957a1f7e718afb202003da2588"
     ],
     [
       "Lib.IntTypes.mul_mod",
@@ -2135,7 +2137,7 @@
         "typing_FStar.UInt8.v", "typing_Lib.IntTypes.unsigned"
       ],
       0,
-      "a2c2ac778d1745f6f9f00f888728bef0"
+      "1218ebe233b8e914fb05ae84142caf4e"
     ],
     [
       "Lib.IntTypes.mul_mod_lemma",
@@ -2188,7 +2190,7 @@
         "typing_Lib.IntTypes.v", "typing_Prims.pow2"
       ],
       0,
-      "e0f323e763bb96eb6ce15bbde7ea83c9"
+      "2c2a8fd02bb3d160feeb18214949c0cf"
     ],
     [
       "Lib.IntTypes.mul",
@@ -2255,7 +2257,7 @@
         "typing_Lib.IntTypes.uu___is_S128"
       ],
       0,
-      "8c9c55440610fad8c4a11eed2e04f704"
+      "a984cf7a187e8a4c977874633598891e"
     ],
     [
       "Lib.IntTypes.mul_lemma",
@@ -2321,7 +2323,7 @@
         "typing_Lib.IntTypes.uu___is_S128", "typing_Lib.IntTypes.v"
       ],
       0,
-      "8dd7662624a82652b83e3c0814f86052"
+      "27d8455addb7477f516f3b38a140fd07"
     ],
     [
       "Lib.IntTypes.mul64_wide_lemma",
@@ -2344,7 +2346,7 @@
         "typing_FStar.UInt128.mul_wide"
       ],
       0,
-      "66c1d27fbe6bd0b15b4fbfdef4436753"
+      "e015526398979875bf4222d3000bafa1"
     ],
     [
       "Lib.IntTypes.mul_s64_wide_lemma",
@@ -2367,7 +2369,7 @@
         "typing_FStar.Int128.mul_wide"
       ],
       0,
-      "5b884ea17e09e5427b056727111156b5"
+      "7a64c1578457a4fbf45de4e13f44e0e5"
     ],
     [
       "Lib.IntTypes.sub_mod",
@@ -2406,7 +2408,7 @@
         "typing_Lib.IntTypes.unsigned"
       ],
       0,
-      "d664003aeab68884206537f7af05693a"
+      "0b23ce42ccbf0a2196e25551228c726c"
     ],
     [
       "Lib.IntTypes.sub_mod_lemma",
@@ -2469,7 +2471,7 @@
         "typing_Lib.IntTypes.v"
       ],
       0,
-      "57f3004b4944c0cbae593470cb69d13f"
+      "f84f84d231a16e48e51f3fad9d41c9f4"
     ],
     [
       "Lib.IntTypes.sub",
@@ -2534,7 +2536,7 @@
         "typing_FStar.UInt8.v", "typing_Lib.IntTypes.v"
       ],
       0,
-      "d3e6b2b797a1f2c7c4e067dd9ea6b159"
+      "8326adcba317c1a9005522dc8d1a8f3f"
     ],
     [
       "Lib.IntTypes.sub_lemma",
@@ -2599,7 +2601,7 @@
         "typing_Lib.IntTypes.sub", "typing_Lib.IntTypes.v"
       ],
       0,
-      "1b29baf8f0cb3f37f5e4f0d6be904421"
+      "98c7222f327630ef588f19b670f0f00a"
     ],
     [
       "Lib.IntTypes.decr",
@@ -2675,7 +2677,7 @@
         "typing_FStar.UInt8.v", "typing_Lib.IntTypes.v"
       ],
       0,
-      "8f4c938fea9181e76af65c5df38af2d1"
+      "600bea36e20e50b2c7f158e3c560669e"
     ],
     [
       "Lib.IntTypes.decr_lemma",
@@ -2772,7 +2774,7 @@
         "typing_Lib.IntTypes.v"
       ],
       0,
-      "f2f169f13ca18efb728285f2312a8563"
+      "d925e552168eff921d0bd838f6a6314f"
     ],
     [
       "Lib.IntTypes.logxor",
@@ -2828,7 +2830,7 @@
         "typing_FStar.UInt8.v"
       ],
       0,
-      "e4c8b863361baa751aa3b6a0d5228f2b"
+      "001e57ae565ba1f7645ce61d6f5a74e3"
     ],
     [
       "Lib.IntTypes.logxor_lemma_",
@@ -2971,7 +2973,7 @@
         "typing_tok_Lib.IntTypes.U128@tok", "typing_tok_Lib.IntTypes.U1@tok"
       ],
       0,
-      "5f4bc8fdf198dd0a15b1c2db8ba59009"
+      "64da46bc43e09f56aec8313be25bb99b"
     ],
     [
       "Lib.IntTypes.logxor_lemma",
@@ -3025,7 +3027,7 @@
         "typing_Prims.pow2", "typing_tok_Lib.IntTypes.U1@tok"
       ],
       0,
-      "7f449d0b0978c14752f06b6597b987d3"
+      "61f3d16b12162d49affecba6d5b58ee1"
     ],
     [
       "Lib.IntTypes.logxor_lemma",
@@ -3191,7 +3193,7 @@
         "typing_tok_Lib.IntTypes.U32@tok", "typing_tok_Lib.IntTypes.U64@tok"
       ],
       0,
-      "3382e6af766d73dc9ea1bace9240fbe2"
+      "bdd380664a5cc11c95cb15f96cd84d38"
     ],
     [
       "Lib.IntTypes.logxor_lemma1",
@@ -3283,7 +3285,7 @@
         "typing_Lib.IntTypes.v", "typing_tok_Lib.IntTypes.U1@tok"
       ],
       0,
-      "91fb196d12b43ba3af59b9a74489a638"
+      "b19e715f2ac161e43edc5ed9756d7228"
     ],
     [
       "Lib.IntTypes.logxor_v",
@@ -3319,7 +3321,7 @@
         "refinement_interpretation_Tm_refine_83845a86f2550cdf941eeb1d9b59602b"
       ],
       0,
-      "59af7ec9f9abc7b163b00abe4fc9c8f7"
+      "424bc4d484b135f4350edb6089b001d7"
     ],
     [
       "Lib.IntTypes.logxor_spec",
@@ -3437,7 +3439,7 @@
         "typing_tok_Lib.IntTypes.SEC@tok", "typing_tok_Lib.IntTypes.U1@tok"
       ],
       0,
-      "ff46b7a244a51646186a3cae29f169e1"
+      "9cd136b4d187308f0483fd81c0b98019"
     ],
     [
       "Lib.IntTypes.logand",
@@ -3493,7 +3495,7 @@
         "typing_FStar.UInt8.v"
       ],
       0,
-      "8d40e071c8803d0ad6764774f77f6fa1"
+      "f6d429a2e1bcf08e818f7a40bfc3db2c"
     ],
     [
       "Lib.IntTypes.logand_zeros",
@@ -3618,7 +3620,7 @@
         "typing_tok_Lib.IntTypes.U8@tok"
       ],
       0,
-      "fa1598e4f8178323c113adbe4f0c1eac"
+      "bb2cdfd0e868097c8e5dccad71c96e30"
     ],
     [
       "Lib.IntTypes.logand_ones",
@@ -3742,7 +3744,7 @@
         "typing_tok_Lib.IntTypes.U8@tok"
       ],
       0,
-      "3422abd763b902282df15d1d03a68cc6"
+      "e247293a100416cac6d6c0e965be01db"
     ],
     [
       "Lib.IntTypes.logand_lemma",
@@ -3858,7 +3860,7 @@
         "typing_tok_Lib.IntTypes.U1@tok"
       ],
       0,
-      "a5aed9f5afd0566c431ffe27df606dcf"
+      "5a9793a9af6cd6dd771a8071c862db44"
     ],
     [
       "Lib.IntTypes.logand_v",
@@ -3894,7 +3896,7 @@
         "refinement_interpretation_Tm_refine_83845a86f2550cdf941eeb1d9b59602b"
       ],
       0,
-      "676a3f262bcc6d2acf55a771ae7e2a42"
+      "f7a532a9982f6a5680de0ec24e44e12c"
     ],
     [
       "Lib.IntTypes.logand_spec",
@@ -3992,7 +3994,7 @@
         "typing_tok_Lib.IntTypes.SEC@tok", "typing_tok_Lib.IntTypes.U1@tok"
       ],
       0,
-      "5d6bfcaea16a65ce61e36b6a586f1691"
+      "84c9b491df2746778cbaa208c8db07c8"
     ],
     [
       "Lib.IntTypes.logand_le",
@@ -4077,7 +4079,7 @@
         "typing_tok_Lib.IntTypes.U32@tok", "typing_tok_Lib.IntTypes.U64@tok"
       ],
       0,
-      "3da7dc6789bb7865e091bf1d4c3e0313"
+      "1daf59ca3ab7b7a38d2838ada25fc6c4"
     ],
     [
       "Lib.IntTypes.logand_mask",
@@ -4090,7 +4092,7 @@
         "refinement_interpretation_Tm_refine_812109ba662576a3f745174092d33c56"
       ],
       0,
-      "27fb491b98b8954483fd219d8086ba8a"
+      "4c15887d1966dc86c19a23193495b628"
     ],
     [
       "Lib.IntTypes.logand_mask",
@@ -4161,7 +4163,7 @@
         "typing_tok_Lib.IntTypes.U64@tok", "typing_tok_Lib.IntTypes.U8@tok"
       ],
       0,
-      "47887bf81d769286fae7523e108d1b47"
+      "72d6374bf4ec16f60891f7ab2b7c2ae8"
     ],
     [
       "Lib.IntTypes.logor",
@@ -4217,7 +4219,7 @@
         "typing_FStar.UInt8.v"
       ],
       0,
-      "f28878bbdeb72377e1cd26127f56210d"
+      "5e57a7bd0220b9d0652cdd6a8257c0d0"
     ],
     [
       "Lib.IntTypes.logor_disjoint",
@@ -4226,7 +4228,7 @@
       1,
       [ "@query" ],
       0,
-      "cdf06c2ee56db0c0a37518aa884a117e"
+      "379574ba871e36724472e2914d25b4b2"
     ],
     [
       "Lib.IntTypes.logor_disjoint",
@@ -4311,7 +4313,7 @@
         "typing_Prims.pow2"
       ],
       0,
-      "2a3f24d9fd2a9d11ea7e30e49720abd1"
+      "2d9e4ee37dc3f90a4a4b0032b36e1f41"
     ],
     [
       "Lib.IntTypes.logor_zeros",
@@ -4440,7 +4442,7 @@
         "typing_tok_Lib.IntTypes.U8@tok"
       ],
       0,
-      "5e3ea209a12f10e6070ef38ee73a00b1"
+      "06aa9cc94f50eaf63d1b7b75978d11df"
     ],
     [
       "Lib.IntTypes.logor_ones",
@@ -4567,7 +4569,7 @@
         "typing_tok_Lib.IntTypes.U8@tok"
       ],
       0,
-      "f548b2e84c7f3b2e80826a2c445adf83"
+      "9a5ccd1c84d11aa6e2acf455ce9c43a7"
     ],
     [
       "Lib.IntTypes.logor_lemma",
@@ -4704,7 +4706,7 @@
         "typing_tok_Lib.IntTypes.U1@tok"
       ],
       0,
-      "719cf4953365960979ce639c1fcd21d9"
+      "d3d990018a82971e7483fbf9dbf4e1c2"
     ],
     [
       "Lib.IntTypes.logor_v",
@@ -4740,7 +4742,7 @@
         "refinement_interpretation_Tm_refine_83845a86f2550cdf941eeb1d9b59602b"
       ],
       0,
-      "df9a189116a1db0de81d407059f46905"
+      "d37e4c52d6c7add72374cd180f34989c"
     ],
     [
       "Lib.IntTypes.logor_spec",
@@ -4837,7 +4839,7 @@
         "typing_tok_Lib.IntTypes.U1@tok"
       ],
       0,
-      "e33e07c3f100785f34ed150e160e567d"
+      "f705bc8138c0fa844281867c6d89a728"
     ],
     [
       "Lib.IntTypes.lognot",
@@ -4887,7 +4889,7 @@
         "refinement_interpretation_Tm_refine_e0b16d74ee3644bd585df5e7938934c6"
       ],
       0,
-      "d8954c0625cd72a6c0342e55ea321a62"
+      "b7a263bd39452af9652a87c6c40b7f05"
     ],
     [
       "Lib.IntTypes.lognot_lemma",
@@ -4983,7 +4985,7 @@
         "typing_tok_Lib.IntTypes.U1@tok"
       ],
       0,
-      "5d57c0fdb6fbbe82921faa2fc6284111"
+      "b1dfc4af51826e738e43535cff525f2c"
     ],
     [
       "Lib.IntTypes.shift_right",
@@ -5051,7 +5053,7 @@
         "typing_tok_Lib.IntTypes.U32@tok"
       ],
       0,
-      "2b3cb4e5bffea41bcfd383fe1da3ae3d"
+      "5d920b283fc23f0b642370179630a375"
     ],
     [
       "Lib.IntTypes.shift_right_value_aux_1",
@@ -5060,7 +5062,7 @@
       1,
       [ "@query" ],
       0,
-      "fa09f1c6b71c89e67d738e472d4241aa"
+      "178fd1eaba45ebb434ac22774bf8704a"
     ],
     [
       "Lib.IntTypes.shift_right_value_aux_1",
@@ -5111,7 +5113,7 @@
         "typing_FStar.UInt.fits", "typing_Prims.pow2"
       ],
       0,
-      "43bb9a1dbfc7298d9ce69e100e48caa0"
+      "f34214c03ffffb9cef52dc8ebb3857fa"
     ],
     [
       "Lib.IntTypes.shift_right_value_aux_2",
@@ -5185,7 +5187,7 @@
         "typing_Prims.pow2"
       ],
       0,
-      "d2f95adb2dc8a1679aa38de508c34e11"
+      "f59a5db301d2079fe3a2c1543ea3ff9b"
     ],
     [
       "Lib.IntTypes.shift_right_value_aux_3",
@@ -5198,7 +5200,7 @@
         "refinement_interpretation_Tm_refine_dd319c5462eccabc540582a4c9a72d35"
       ],
       0,
-      "eab271216b5dde3e3e3fcf725874394e"
+      "dee105da2c33515ad1b2ab9aa686ae75"
     ],
     [
       "Lib.IntTypes.shift_right_value_aux_3",
@@ -5211,7 +5213,7 @@
         "refinement_interpretation_Tm_refine_c69b88dd42ed0186d185f73533fc4d74"
       ],
       0,
-      "cf6cd0f79a578fac3546e0f0a9f95827"
+      "c76361eaadde8fef3c8b7259ceb8c24f"
     ],
     [
       "Lib.IntTypes.shift_right_value_aux_3",
@@ -5261,7 +5263,7 @@
         "well-founded-ordering-on-nat"
       ],
       0,
-      "d359241db0f3d95affce68cd1d71d604"
+      "1ce641cba5b73434d0ab14f60b7d6ff9"
     ],
     [
       "Lib.IntTypes.shift_right_lemma",
@@ -5281,7 +5283,7 @@
         "typing_tok_Lib.IntTypes.U32@tok"
       ],
       0,
-      "2ec5ea5db4479412f99d59ecccebf2c2"
+      "a2e519fa1592972607ea2a36447c011a"
     ],
     [
       "Lib.IntTypes.shift_right_lemma",
@@ -5397,7 +5399,7 @@
         "typing_tok_Lib.IntTypes.U32@tok", "unit_inversion", "unit_typing"
       ],
       0,
-      "05a3bb40e8bf6a002ce63bd41797cd52"
+      "a02f3645772523d525af88b32a96c89a"
     ],
     [
       "Lib.IntTypes.shift_left",
@@ -5417,7 +5419,7 @@
         "typing_tok_Lib.IntTypes.U32@tok"
       ],
       0,
-      "98a134468eef5547b73a0b30e808a86d"
+      "d651106bea71e5b72abcfd4bb33ac4a6"
     ],
     [
       "Lib.IntTypes.shift_left",
@@ -5491,7 +5493,7 @@
         "typing_tok_Lib.IntTypes.PUB@tok", "typing_tok_Lib.IntTypes.U32@tok"
       ],
       0,
-      "17b9ce4e3dda91973084ecfaee435ae7"
+      "e6dc3add1efc4b20f5964ff4cd0e1876"
     ],
     [
       "Lib.IntTypes.shift_left_lemma",
@@ -5512,7 +5514,7 @@
         "typing_tok_Lib.IntTypes.U32@tok"
       ],
       0,
-      "fa06e3b492de44a086a57c43ec70f404"
+      "c6f37cbc812750d82b545aa804e3e25e"
     ],
     [
       "Lib.IntTypes.shift_left_lemma",
@@ -5525,7 +5527,7 @@
         "equation_Lib.IntTypes.range", "equation_Lib.IntTypes.unsigned"
       ],
       0,
-      "742dad42e853a125d49db8c59ae43c27"
+      "4163aede4a5fed6dad045d003365ba39"
     ],
     [
       "Lib.IntTypes.shift_left_lemma",
@@ -5615,7 +5617,7 @@
         "typing_tok_Lib.IntTypes.PUB@tok", "typing_tok_Lib.IntTypes.U32@tok"
       ],
       0,
-      "e112e64e810dd16fa9b6ab3b6a0f6948"
+      "e1cb87d35018f35a3992fbbe27b7be88"
     ],
     [
       "Lib.IntTypes.rotate_right",
@@ -5648,7 +5650,7 @@
         "typing_tok_Lib.IntTypes.U32@tok"
       ],
       0,
-      "574fe2503ee5633788290f7debfb39be"
+      "2c9630e830416af369c59f8791b90c61"
     ],
     [
       "Lib.IntTypes.rotate_left",
@@ -5681,7 +5683,7 @@
         "typing_tok_Lib.IntTypes.U32@tok"
       ],
       0,
-      "b00277b035e05efd44c1bcc68e8478f1"
+      "8be7840a0460c3f2b9cad9a38705dd57"
     ],
     [
       "Lib.IntTypes.shift_right_i",
@@ -5693,7 +5695,7 @@
         "refinement_interpretation_Tm_refine_33026181614126bf2f989b87912ad69b"
       ],
       0,
-      "e2503a6e2a8c8822a7fe64dea88f56fc"
+      "e3cbd817169c981f045a2736b027abba"
     ],
     [
       "Lib.IntTypes.shift_right_i",
@@ -5705,7 +5707,7 @@
         "refinement_interpretation_Tm_refine_33026181614126bf2f989b87912ad69b"
       ],
       0,
-      "96b0dbdf574a9c2a7ff47c235fa106ee"
+      "bfd525508f370e299477896193913869"
     ],
     [
       "Lib.IntTypes.shift_left_i",
@@ -5717,7 +5719,7 @@
         "refinement_interpretation_Tm_refine_33026181614126bf2f989b87912ad69b"
       ],
       0,
-      "c355339257f49845e819512f990fd8ec"
+      "cb38693577c74f6a33b81fcbdd7faf4f"
     ],
     [
       "Lib.IntTypes.shift_left_i",
@@ -5729,7 +5731,7 @@
         "refinement_interpretation_Tm_refine_33026181614126bf2f989b87912ad69b"
       ],
       0,
-      "32e24605f0bc1015fbda3e97eeb7a1a5"
+      "65d2240b48f6c386eccf9731fb770420"
     ],
     [
       "Lib.IntTypes.rotate_right_i",
@@ -5741,7 +5743,7 @@
         "refinement_interpretation_Tm_refine_fe1f2b0fb92318a15c076125042e53a3"
       ],
       0,
-      "f77b59c7886a0fdb7be81fbe297b645f"
+      "8d673936ccdd8668918c2c5d02bdbc4f"
     ],
     [
       "Lib.IntTypes.rotate_right_i",
@@ -5753,7 +5755,7 @@
         "refinement_interpretation_Tm_refine_fe1f2b0fb92318a15c076125042e53a3"
       ],
       0,
-      "ab2505bbdc39b01c5e1ca05885a9493e"
+      "432680fd9260125b6a0020623b1305c5"
     ],
     [
       "Lib.IntTypes.rotate_left_i",
@@ -5765,7 +5767,7 @@
         "refinement_interpretation_Tm_refine_fe1f2b0fb92318a15c076125042e53a3"
       ],
       0,
-      "db6f04dc0b324dbba7565e4c6edde751"
+      "f00074c252df03992728ce2a66eeea88"
     ],
     [
       "Lib.IntTypes.rotate_left_i",
@@ -5777,7 +5779,7 @@
         "refinement_interpretation_Tm_refine_fe1f2b0fb92318a15c076125042e53a3"
       ],
       0,
-      "e4763acc5e8fc3ad6520023f05abe860"
+      "4de34d3868c2ff4f9704491004acd938"
     ],
     [
       "Lib.IntTypes.ct_abs",
@@ -5829,7 +5831,7 @@
         "typing_tok_Lib.IntTypes.S64@tok", "typing_tok_Lib.IntTypes.S8@tok"
       ],
       0,
-      "58e93f23a562bbb5d19c03edcbe33f77"
+      "9d1b5c069a15e3864159cdabfd04f836"
     ],
     [
       "Lib.IntTypes.eq_mask",
@@ -5871,7 +5873,7 @@
         "refinement_interpretation_Tm_refine_d13c5132af51f62dfb7018a438f66ab7"
       ],
       0,
-      "4f81c6a8a8ae6689f906391373087e37"
+      "e1bdbbcb9b66a748e657de9c597fae30"
     ],
     [
       "Lib.IntTypes.eq_mask_lemma_unsigned",
@@ -5892,7 +5894,7 @@
         "refinement_interpretation_Tm_refine_387e6d282145573240ab7b8a4b94cce5"
       ],
       0,
-      "d9753a9a981d0bfb52a8b1ea11c37f1c"
+      "ac5d1dad64d51246d4cd4aef4e626dc1"
     ],
     [
       "Lib.IntTypes.eq_mask_lemma_unsigned",
@@ -5971,7 +5973,7 @@
         "typing_tok_Lib.IntTypes.SEC@tok", "typing_tok_Lib.IntTypes.U1@tok"
       ],
       0,
-      "22099163a4ad86bdffd98c4436a0be50"
+      "91b9bb8eddd03bf400dbd79065dcb890"
     ],
     [
       "Lib.IntTypes.eq_mask_lemma_signed",
@@ -5980,7 +5982,7 @@
       1,
       [ "@query" ],
       0,
-      "c43a2774d8d341286233cc1548ae6105"
+      "98df8d21b4e0c62d10e3737c119e58e0"
     ],
     [
       "Lib.IntTypes.eq_mask_lemma_signed",
@@ -6133,7 +6135,7 @@
         "typing_tok_Lib.IntTypes.U64@tok", "unit_inversion", "unit_typing"
       ],
       0,
-      "3aa90194834b7fe932eb17f76233ea4b"
+      "a1c8c3cc05faa7db5b78c9ed71c8f3ae"
     ],
     [
       "Lib.IntTypes.eq_mask_lemma",
@@ -6150,7 +6152,7 @@
         "typing_Lib.IntTypes.unsigned"
       ],
       0,
-      "75499ef8cddeebe7c21a1f1f4d53a124"
+      "89f82e2cf55ea78aa38cf957c36fabf2"
     ],
     [
       "Lib.IntTypes.eq_mask_logand_lemma",
@@ -6222,7 +6224,7 @@
         "typing_tok_Lib.IntTypes.U1@tok"
       ],
       0,
-      "c3dc20819a268b049b99b4148b6e0298"
+      "692792c8c5c39b866cb89cb508f760d9"
     ],
     [
       "Lib.IntTypes.neq_mask_lemma",
@@ -6374,7 +6376,7 @@
         "typing_tok_Lib.IntTypes.U1@tok"
       ],
       0,
-      "e583e02d4c788800461e0edaeee685d9"
+      "2b81954e16b4b6ca9c0e6552fc6b9c4a"
     ],
     [
       "Lib.IntTypes.gte_mask",
@@ -6401,7 +6403,7 @@
         "typing_Lib.IntTypes.unsigned"
       ],
       0,
-      "fee0e66529874fc3932574c8cc1a706a"
+      "81dbf2e9013ac228e2873c5806b346b1"
     ],
     [
       "Lib.IntTypes.gte_mask_lemma",
@@ -6472,7 +6474,7 @@
         "typing_tok_Lib.IntTypes.SEC@tok", "typing_tok_Lib.IntTypes.U1@tok"
       ],
       0,
-      "4e82838fcbfa1b19fde1e757d16dbbbc"
+      "f4dd76f58489839ba17535fe7b241998"
     ],
     [
       "Lib.IntTypes.gte_mask_logand_lemma",
@@ -6530,7 +6532,7 @@
         "typing_tok_Lib.IntTypes.U1@tok"
       ],
       0,
-      "227d7f9c7ecdc26c1515dd00ef94aea2"
+      "9b047ee982c7e5da8b08fe8ee686699f"
     ],
     [
       "Lib.IntTypes.lt_mask_lemma",
@@ -6601,7 +6603,7 @@
         "typing_tok_Lib.IntTypes.SEC@tok", "typing_tok_Lib.IntTypes.U1@tok"
       ],
       0,
-      "31c35eb012be51b4c575cd2e87b2db4a"
+      "87e92517ac4fdac87e19320921ed8ccb"
     ],
     [
       "Lib.IntTypes.gt_mask",
@@ -6616,7 +6618,7 @@
         "typing_Lib.IntTypes.unsigned"
       ],
       0,
-      "ceeb6bf99f5fc41b31bfc7107f4b3665"
+      "10b610a6195f0aefc22cc2e0f18a96cc"
     ],
     [
       "Lib.IntTypes.gt_mask_lemma",
@@ -6691,7 +6693,7 @@
         "typing_tok_Lib.IntTypes.U8@tok"
       ],
       0,
-      "03dc47ccbb1a9c6410157b845fd24109"
+      "d7106bd371951527fef611be3f562483"
     ],
     [
       "Lib.IntTypes.lte_mask",
@@ -6706,7 +6708,7 @@
         "typing_Lib.IntTypes.unsigned"
       ],
       0,
-      "83cccbb97372b0abbb2827cf4289c41a"
+      "711bb74524432bb13efe09accee6a8e8"
     ],
     [
       "Lib.IntTypes.lte_mask_lemma",
@@ -6799,7 +6801,7 @@
         "typing_tok_Lib.IntTypes.U8@tok", "unit_inversion", "unit_typing"
       ],
       0,
-      "2f7eb57ed79abc1d53d8e3a91a58a11d"
+      "226ee67e12bf0045815f3546da584f48"
     ],
     [
       "Lib.IntTypes.mod_mask",
@@ -6820,7 +6822,7 @@
         "typing_tok_Lib.IntTypes.U32@tok"
       ],
       0,
-      "a11bafdbd052f14e68c3219912629805"
+      "62e188db23cc7674a9fa1fe02f48670f"
     ],
     [
       "Lib.IntTypes.mod_mask",
@@ -6917,7 +6919,7 @@
         "typing_tok_Lib.IntTypes.U32@tok"
       ],
       0,
-      "b936157958d1c48eb132ecc2d0954ab3"
+      "075f08cd4e4aa2c97a73d7c51c0856a1"
     ],
     [
       "Lib.IntTypes.mod_mask_value",
@@ -6938,7 +6940,7 @@
         "typing_tok_Lib.IntTypes.U32@tok"
       ],
       0,
-      "40480a0e4c638fd8c0481c07b2e03ddf"
+      "12a8e6d501f4b05547b14e8b99e01315"
     ],
     [
       "Lib.IntTypes.mod_mask_value",
@@ -6959,7 +6961,7 @@
         "typing_tok_Lib.IntTypes.U32@tok"
       ],
       0,
-      "013fe692a19b89e08366d88194820187"
+      "da81406d5c9c46f76623f02be8f23925"
     ],
     [
       "Lib.IntTypes.mod_mask_value",
@@ -7011,7 +7013,7 @@
         "typing_tok_Lib.IntTypes.PUB@tok", "typing_tok_Lib.IntTypes.U32@tok"
       ],
       0,
-      "1f0b53aba7efc28331d7a8aff278c327"
+      "1f499230bdc5e122e984e5a367564872"
     ],
     [
       "Lib.IntTypes.mod_mask_lemma",
@@ -7040,7 +7042,7 @@
         "typing_tok_Lib.IntTypes.PUB@tok", "typing_tok_Lib.IntTypes.U32@tok"
       ],
       0,
-      "444ad35b267803002a7ae43c7a98e236"
+      "a4583416c0556fdc7460cba7ea812898"
     ],
     [
       "Lib.IntTypes.mod_mask_lemma",
@@ -7061,7 +7063,7 @@
         "typing_tok_Lib.IntTypes.U32@tok"
       ],
       0,
-      "029040a3bee288fb82dff9c48c81e0df"
+      "bdc570162221a672103d4b6d453e6828"
     ],
     [
       "Lib.IntTypes.mod_mask_lemma",
@@ -7166,7 +7168,7 @@
         "unit_inversion", "unit_typing"
       ],
       0,
-      "e93373a4be85624a78834ec8d2696411"
+      "98b606dc8e3125d65642ea8f579a458c"
     ],
     [
       "Lib.IntTypes.conditional_subtract",
@@ -7189,7 +7191,7 @@
         "refinement_interpretation_Tm_refine_e383ab97e1686e9ae6a07ba85505673a"
       ],
       0,
-      "ab86791521388b4f830cc7c2fb5bdf43"
+      "1cbea984e6909321ad63632f5e5e0349"
     ],
     [
       "Lib.IntTypes.conditional_subtract",
@@ -7212,7 +7214,7 @@
         "refinement_interpretation_Tm_refine_e383ab97e1686e9ae6a07ba85505673a"
       ],
       0,
-      "7632c97c86f94c37966ac3f9a78adba1"
+      "67b868d0081e0b848229913cb1147d41"
     ],
     [
       "Lib.IntTypes.conditional_subtract",
@@ -7335,7 +7337,7 @@
         "typing_tok_Lib.IntTypes.PUB@tok", "typing_tok_Lib.IntTypes.U32@tok"
       ],
       0,
-      "21485db5182e0f04734c450ed761ca5d"
+      "3a03f4d8619762a9d65e2277586dced8"
     ],
     [
       "Lib.IntTypes.cast_mod",
@@ -7450,7 +7452,7 @@
         "typing_tok_Lib.IntTypes.U32@tok"
       ],
       0,
-      "b7fe28d2c87598e1f5d6a0f7950105be"
+      "a53bf0f221d586b5f05464e5e9b724bb"
     ],
     [
       "Lib.IntTypes.div",
@@ -7459,7 +7461,7 @@
       1,
       [ "@query", "assumption_Lib.IntTypes.inttype__uu___haseq" ],
       0,
-      "e43b69908e7ed7d553d392a26349df3a"
+      "4cea398d328f1a9af84b8da8267a15f4"
     ],
     [
       "Lib.IntTypes.div",
@@ -7468,7 +7470,7 @@
       1,
       [ "@query", "assumption_Lib.IntTypes.inttype__uu___haseq" ],
       0,
-      "0d1467bce4c738d4b98063eb62c69d51"
+      "4bb08fb04a2734c27f8bf61d97d1776c"
     ],
     [
       "Lib.IntTypes.div",
@@ -7520,7 +7522,7 @@
         "typing_tok_Lib.IntTypes.PUB@tok"
       ],
       0,
-      "89dfb81ed98730df3728817764c50b2f"
+      "a404faaff2e9f066bff2d8830bbb8d97"
     ],
     [
       "Lib.IntTypes.div_lemma",
@@ -7532,7 +7534,7 @@
         "refinement_interpretation_Tm_refine_e450d0eda8ec6ce5c9eff42d01f0e81a"
       ],
       0,
-      "610428c0f2f86b22e1a46e4bb933220b"
+      "b7b07217908522e27545db28b0f776c4"
     ],
     [
       "Lib.IntTypes.div_lemma",
@@ -7541,7 +7543,7 @@
       1,
       [ "@query", "assumption_Lib.IntTypes.inttype__uu___haseq" ],
       0,
-      "a68c06dbaa668b4bafe4e9c77abefe61"
+      "7c1df69f914b235a01dd340e3e7fd350"
     ],
     [
       "Lib.IntTypes.div_lemma",
@@ -7643,7 +7645,7 @@
         "typing_tok_Lib.IntTypes.S8@tok"
       ],
       0,
-      "51625da97029636e786467a7b9336fbf"
+      "318c7bd2ab9efc1a63f0de383fff42eb"
     ],
     [
       "Lib.IntTypes.mod",
@@ -7652,7 +7654,7 @@
       1,
       [ "@query", "assumption_Lib.IntTypes.inttype__uu___haseq" ],
       0,
-      "0b45896789edd07f6a3064b4aa72b1a6"
+      "a92a0c3879440e675441664d994638ae"
     ],
     [
       "Lib.IntTypes.mod",
@@ -7661,7 +7663,7 @@
       1,
       [ "@query", "assumption_Lib.IntTypes.inttype__uu___haseq" ],
       0,
-      "f05e9bfa9ab8c1b1b5037feccf13e5bb"
+      "c8fbd7a8c0c1372c22a90a92885fa414"
     ],
     [
       "Lib.IntTypes.mod",
@@ -7714,7 +7716,7 @@
         "typing_tok_Lib.IntTypes.PUB@tok"
       ],
       0,
-      "247ffb683639194e01f833cd4bfbab34"
+      "c9101abde76f216d19bde4f59ece112b"
     ],
     [
       "Lib.IntTypes.mod_lemma",
@@ -7761,7 +7763,7 @@
         "typing_tok_Lib.IntTypes.PUB@tok"
       ],
       0,
-      "c9e9cbfe76143915065bdad7dfc6c783"
+      "feec1211f23ec0fe58b0e65013bba74a"
     ],
     [
       "Lib.IntTypes.mod_lemma",
@@ -7770,7 +7772,7 @@
       1,
       [ "@query", "assumption_Lib.IntTypes.inttype__uu___haseq" ],
       0,
-      "1e091bd50c683379e48be92f6a278d85"
+      "b09dd7e3a4bb96c2cea36c7d28d9d1c9"
     ],
     [
       "Lib.IntTypes.mod_lemma",
@@ -7859,7 +7861,7 @@
         "typing_tok_Lib.IntTypes.U32@tok", "typing_tok_Lib.IntTypes.U64@tok"
       ],
       0,
-      "b5744784fa638e378158b81676c5baf9"
+      "39ba09e594bb88f939340aa91650a3ac"
     ],
     [
       "Lib.IntTypes.eq",
@@ -7893,7 +7895,7 @@
         "refinement_interpretation_Tm_refine_e0b16d74ee3644bd585df5e7938934c6"
       ],
       0,
-      "7cce133bea33fa27a6ac848c5ef824a5"
+      "d13ad58df527b66648262a583a252ba4"
     ],
     [
       "Lib.IntTypes.eq_lemma",
@@ -7919,7 +7921,7 @@
         "typing_FStar.UInt128.eq"
       ],
       0,
-      "58fdfef365f38506a7cd523284962471"
+      "ff94db12af58fd9de64421bde895b0a8"
     ],
     [
       "Lib.IntTypes.ne_lemma",
@@ -7934,7 +7936,7 @@
         "projection_inverse_BoxBool_proj_0"
       ],
       0,
-      "43f8e7da4c4618d84cebdb0228b79b71"
+      "8b8ed4af13b732a8eb43cb5e78918c16"
     ],
     [
       "Lib.IntTypes.lt",
@@ -7968,7 +7970,7 @@
         "refinement_interpretation_Tm_refine_e0b16d74ee3644bd585df5e7938934c6"
       ],
       0,
-      "70a6ec192390247b3d3157b2b47411be"
+      "8abf27fa6d5d18569094ddcdae405495"
     ],
     [
       "Lib.IntTypes.lt_lemma",
@@ -7992,7 +7994,7 @@
         "typing_FStar.UInt128.lt"
       ],
       0,
-      "1247a9cbae55a3c5bf446dc07c0809f7"
+      "26d6adfa733969df4cc56b04e2481acb"
     ],
     [
       "Lib.IntTypes.lte",
@@ -8026,7 +8028,7 @@
         "refinement_interpretation_Tm_refine_e0b16d74ee3644bd585df5e7938934c6"
       ],
       0,
-      "480608c2f1ba4d59e86a1035632a2abc"
+      "97b3015813a21467d2cedf5bed4e5a99"
     ],
     [
       "Lib.IntTypes.lte_lemma",
@@ -8050,7 +8052,7 @@
         "typing_FStar.UInt128.lte"
       ],
       0,
-      "df7da08562f0f765c1a35cef855eae5e"
+      "6d66bc200f2ce4454d4ee3984e02b532"
     ],
     [
       "Lib.IntTypes.gt",
@@ -8084,7 +8086,7 @@
         "refinement_interpretation_Tm_refine_e0b16d74ee3644bd585df5e7938934c6"
       ],
       0,
-      "caf98db2fda188136aa0f263c1967e0e"
+      "c375db04218cafaaef0318d81b43cb64"
     ],
     [
       "Lib.IntTypes.gt_lemma",
@@ -8108,7 +8110,7 @@
         "typing_FStar.UInt128.gt"
       ],
       0,
-      "ade2ffff9340a35696a35765e13c0552"
+      "64aeec4f8620addc89c5cc5cf1dfa0b9"
     ],
     [
       "Lib.IntTypes.gte",
@@ -8142,7 +8144,7 @@
         "refinement_interpretation_Tm_refine_e0b16d74ee3644bd585df5e7938934c6"
       ],
       0,
-      "170f2fdc4fe67c3ecac4f5b5f2ba0a84"
+      "00182aaa68a3848a38b63616f110497f"
     ],
     [
       "Lib.IntTypes.gte_lemma",
@@ -8166,7 +8168,7 @@
         "typing_FStar.UInt128.gte"
       ],
       0,
-      "371652c715d3d84b4bb22d4832583e12"
+      "45c2cd3054b58b7a48d84dc9c612e594"
     ]
   ]
 ]

--- a/hints/Vale.Poly1305.Math.fst.hints
+++ b/hints/Vale.Poly1305.Math.fst.hints
@@ -1,5 +1,5 @@
 [
-  "Ó1xh¯Ü8(…\u0002Æ[û\u001e(s",
+  "hÄ)}|\t¡fß\u001d-è‹5\t7",
   [
     [
       "Vale.Poly1305.Math.lowerUpper128_def",
@@ -14,7 +14,7 @@
         "refinement_interpretation_Tm_refine_c1424615841f28cac7fc34e92b7ff33c"
       ],
       0,
-      "2e94869b0f660cfe60f12936576aa064"
+      "086ed20111273a9e0566bc229328f989"
     ],
     [
       "Vale.Poly1305.Math.lowerUpper128_reveal",
@@ -23,7 +23,7 @@
       0,
       [ "@query" ],
       0,
-      "2927fc23bd1c2786a3dd4924606c5c01"
+      "84dfd178530386b15665d797cace2cc6"
     ],
     [
       "Vale.Poly1305.Math.lowerUpper192_reveal",
@@ -32,7 +32,7 @@
       0,
       [ "@query" ],
       0,
-      "3d72d03c8be17d60107ee1ab0efd7e76"
+      "86d15ab78e4304084c502a693a0f73f3"
     ],
     [
       "Vale.Poly1305.Math.lemma_mul_div_comm",
@@ -44,7 +44,7 @@
         "refinement_interpretation_Tm_refine_774ba3f728d91ead8ef40be66c9802e5"
       ],
       0,
-      "1ff26fe40c2fb70fd91cfaace23694c6"
+      "db6e399e81baf2a12fd55d4b7de318fb"
     ],
     [
       "Vale.Poly1305.Math.lemma_mul_div_comm",
@@ -57,7 +57,7 @@
         "refinement_interpretation_Tm_refine_774ba3f728d91ead8ef40be66c9802e5"
       ],
       0,
-      "6cdc9b42a62d8eb8ee189708bc0f7526"
+      "e0940b919bc5edd7596dac73f67346d7"
     ],
     [
       "Vale.Poly1305.Math.lemma_exact_mul",
@@ -69,7 +69,7 @@
         "refinement_interpretation_Tm_refine_774ba3f728d91ead8ef40be66c9802e5"
       ],
       0,
-      "70bd7e9b57b9d9da53dfcdc303c312b4"
+      "846e5e29421c581a89a2f71a86ad7196"
     ],
     [
       "Vale.Poly1305.Math.lemma_exact_mul",
@@ -82,7 +82,7 @@
         "refinement_interpretation_Tm_refine_774ba3f728d91ead8ef40be66c9802e5"
       ],
       0,
-      "833014a025edefe850eb48aea990420f"
+      "7baa9751a2d8926bfff7857a2f0fd2ae"
     ],
     [
       "Vale.Poly1305.Math.lemma_mul_div_sep",
@@ -94,7 +94,7 @@
         "refinement_interpretation_Tm_refine_774ba3f728d91ead8ef40be66c9802e5"
       ],
       0,
-      "9fdfd3fe3d4a3a1346be246227630398"
+      "5ad880b66a65cfb18d60fe76373e5ff3"
     ],
     [
       "Vale.Poly1305.Math.lemma_mul_div_sep",
@@ -107,7 +107,7 @@
         "refinement_interpretation_Tm_refine_774ba3f728d91ead8ef40be66c9802e5"
       ],
       0,
-      "6bd5618cb834c4569f6208876b021af6"
+      "f7c7ea19d416683e74b5a26264f9b212"
     ],
     [
       "Vale.Poly1305.Math.swap_add",
@@ -116,7 +116,7 @@
       0,
       [ "@query" ],
       0,
-      "65a88dd7cfa52c64607ad342275c2d69"
+      "de575b61594c3cabbdd6056044352ada"
     ],
     [
       "Vale.Poly1305.Math.lemma_mul_increases",
@@ -129,7 +129,7 @@
         "refinement_interpretation_Tm_refine_774ba3f728d91ead8ef40be66c9802e5"
       ],
       0,
-      "7cf3148c55dbe363ff6afe18eeb65b7e"
+      "d10298bd03586d31663057300215f6b6"
     ],
     [
       "Vale.Poly1305.Math.multiplication_order_lemma_int",
@@ -142,7 +142,7 @@
         "refinement_interpretation_Tm_refine_774ba3f728d91ead8ef40be66c9802e5"
       ],
       0,
-      "56eabc74f0326d1a65e80cc9a536a3da"
+      "b3ad740ecb2276cc38305d6c38fc65d8"
     ],
     [
       "Vale.Poly1305.Math.multiplication_order_eq_lemma_int",
@@ -155,7 +155,7 @@
         "refinement_interpretation_Tm_refine_774ba3f728d91ead8ef40be66c9802e5"
       ],
       0,
-      "61ec4a3e5773c34b649dddd65ab1631c"
+      "5841db302f04e472bd377b3a0aa6f05b"
     ],
     [
       "Vale.Poly1305.Math.lemma_poly_multiply",
@@ -170,7 +170,7 @@
         "refinement_interpretation_Tm_refine_2de20c066034c13bf76e9c0b94f4806c"
       ],
       0,
-      "ffa000d057f85e50e7ee92eca52b25d8"
+      "7c785bd7112fd2f8712d521869df693f"
     ],
     [
       "Vale.Poly1305.Math.lemma_poly_multiply",
@@ -179,7 +179,7 @@
       0,
       [ "@query", "projection_inverse_BoxInt_proj_0", "true_interp" ],
       0,
-      "61425553143d40b7714373777368dbed"
+      "5bca9b94e21fc9d4519ed036b74ef097"
     ],
     [
       "Vale.Poly1305.Math.lemma_poly_reduce",
@@ -193,7 +193,7 @@
         "refinement_interpretation_Tm_refine_2de20c066034c13bf76e9c0b94f4806c"
       ],
       0,
-      "608de29eb0a3149afcddc8ea74d41e61"
+      "da70e7f386bb6382b5ef4719db57a27b"
     ],
     [
       "Vale.Poly1305.Math.lemma_poly_reduce",
@@ -202,7 +202,7 @@
       0,
       [ "@query", "projection_inverse_BoxInt_proj_0", "true_interp" ],
       0,
-      "96ee69ea85d74e8ebcefdb4478a626e4"
+      "cee82f671579dace817f6f41f904ccd0"
     ],
     [
       "Vale.Poly1305.Math.lemma_shr2_nat",
@@ -229,7 +229,7 @@
         "refinement_interpretation_Tm_refine_f13070840248fced9d9d60d77bdae3ec"
       ],
       0,
-      "ce9af412f39abd1f32cba3d230fa528a"
+      "49546208ae1f47c93f812c2713ff142a"
     ],
     [
       "Vale.Poly1305.Math.lemma_shr4_nat",
@@ -256,7 +256,7 @@
         "refinement_interpretation_Tm_refine_f13070840248fced9d9d60d77bdae3ec"
       ],
       0,
-      "1dca8a12315b03794f4cdc02e8ffbf7f"
+      "03e0c760fee500c71d739ecdd2d0d7a7"
     ],
     [
       "Vale.Poly1305.Math.lemma_and_mod_n_nat",
@@ -283,7 +283,7 @@
         "refinement_interpretation_Tm_refine_f13070840248fced9d9d60d77bdae3ec"
       ],
       0,
-      "4faeb7cfa8988c121fac3baa5a84891b"
+      "eed2301e30429bb62141dc5c83836e70"
     ],
     [
       "Vale.Poly1305.Math.lemma_and_constants_nat",
@@ -311,7 +311,7 @@
         "typing_Prims.pow2"
       ],
       0,
-      "4a8305a7b76d1fb3b4b31478a41f17d4"
+      "11e3fbdc0dfaef21e62d32753049741e"
     ],
     [
       "Vale.Poly1305.Math.lemma_clear_lower_2_nat",
@@ -345,7 +345,7 @@
         "typing_Vale.Def.Types_s.iand"
       ],
       0,
-      "3f6953d2b41efa5b30048f44af02a564"
+      "23c17faad801b44eedd7dae2a891b382"
     ],
     [
       "Vale.Poly1305.Math.lemma_poly_constants_nat",
@@ -372,7 +372,7 @@
         "refinement_interpretation_Tm_refine_f13070840248fced9d9d60d77bdae3ec"
       ],
       0,
-      "3daf19b88f4f76c87ba61a268ab13ce1"
+      "dd4ac448ffec44b9775affb715251575"
     ],
     [
       "Vale.Poly1305.Math.lemma_and_commutes_nat",
@@ -397,7 +397,7 @@
         "typing_Prims.pow2"
       ],
       0,
-      "af0d8fe9f2fb99d81216a85d62238e2a"
+      "8c2f15ac16d3fde51bae93b1b1244418"
     ],
     [
       "Vale.Poly1305.Math.lemma_poly_bits64",
@@ -406,7 +406,7 @@
       0,
       [ "@query" ],
       0,
-      "ff811338ed468228715f6c187f7521d4"
+      "f83a040775b3d018a6717482230b30c1"
     ],
     [
       "Vale.Poly1305.Math.lemma_mul_strict_upper_bound",
@@ -422,7 +422,7 @@
         "projection_inverse_BoxInt_proj_0", "unit_inversion", "unit_typing"
       ],
       0,
-      "4d4c51b1c702a2fc7a4f4f7e6d64e428"
+      "d2df7ec1433a42abfb0d12714afe3fa4"
     ],
     [
       "Vale.Poly1305.Math.lemma_bytes_shift_power2",
@@ -431,7 +431,7 @@
       0,
       [ "@query" ],
       0,
-      "0de2ec6c3021b606ed83637a5d806e19"
+      "e04ba63ea60cbaf0e4cfdeeaf16ae7fe"
     ],
     [
       "Vale.Poly1305.Math.lemma_bytes_shift_power2",
@@ -456,7 +456,7 @@
         "typing_Prims.pow2"
       ],
       0,
-      "1de2f4b10b1a4d63f576feb7f11e22f7"
+      "b238b38b0d148f3583d0c92d8360629e"
     ],
     [
       "Vale.Poly1305.Math.lemma_bytes_and_mod0",
@@ -473,7 +473,7 @@
         "refinement_interpretation_Tm_refine_f13070840248fced9d9d60d77bdae3ec"
       ],
       0,
-      "26b284a619eb0a50572f13319ed591cf"
+      "acffe329ea0336911cfa268bc06ce892"
     ],
     [
       "Vale.Poly1305.Math.lemma_bytes_and_mod1",
@@ -494,7 +494,7 @@
         "refinement_interpretation_Tm_refine_542f9d4f129664613f2483a6c88bc7c2"
       ],
       0,
-      "ea4e79df7cab41c68d863177a05e8f4c"
+      "aae88dfe85c54150295864d7f86e85ef"
     ],
     [
       "Vale.Poly1305.Math.lemma_bytes_and_mod2",
@@ -515,7 +515,7 @@
         "refinement_interpretation_Tm_refine_542f9d4f129664613f2483a6c88bc7c2"
       ],
       0,
-      "c498d9ed731bdcea1eefb160e832c03b"
+      "9e87205cd964c3c6278d964f09008e61"
     ],
     [
       "Vale.Poly1305.Math.lemma_bytes_and_mod3",
@@ -536,7 +536,7 @@
         "refinement_interpretation_Tm_refine_542f9d4f129664613f2483a6c88bc7c2"
       ],
       0,
-      "d325dbfb9df05a00fd6d6584a4d309c2"
+      "d34d948d1efd81ad0d0b15cafd710549"
     ],
     [
       "Vale.Poly1305.Math.lemma_bytes_and_mod4",
@@ -557,7 +557,7 @@
         "refinement_interpretation_Tm_refine_542f9d4f129664613f2483a6c88bc7c2"
       ],
       0,
-      "3944813a8cf2953e85a5e2e1fd59055a"
+      "c05e8cff44d569d348846f62e2d42eee"
     ],
     [
       "Vale.Poly1305.Math.lemma_bytes_and_mod5",
@@ -578,7 +578,7 @@
         "refinement_interpretation_Tm_refine_542f9d4f129664613f2483a6c88bc7c2"
       ],
       0,
-      "9e5bd755a40e86320ddea01110728bf4"
+      "b62c89017f24f9447afa55f3352d3b95"
     ],
     [
       "Vale.Poly1305.Math.lemma_bytes_and_mod6",
@@ -599,7 +599,7 @@
         "refinement_interpretation_Tm_refine_542f9d4f129664613f2483a6c88bc7c2"
       ],
       0,
-      "f75292989ab96f13d98ed5a9a801cfd1"
+      "abdca3c3ac6dc352387e42d6fa4204b1"
     ],
     [
       "Vale.Poly1305.Math.lemma_bytes_and_mod7",
@@ -620,7 +620,7 @@
         "refinement_interpretation_Tm_refine_542f9d4f129664613f2483a6c88bc7c2"
       ],
       0,
-      "30ad314014e8b01b6251ce30a8c0b9d6"
+      "47b24bba16c47b0cb06e6ffd4ec98e8d"
     ],
     [
       "Vale.Poly1305.Math.lemma_bytes_and_mod0",
@@ -652,7 +652,7 @@
         "typing_FStar.BitVector.logand_vec", "typing_FStar.UInt.to_vec"
       ],
       0,
-      "025aa403f75d4f33163a68800e551109"
+      "965ee296cad575ea420610bfa106a0c7"
     ],
     [
       "Vale.Poly1305.Math.lemma_bytes_and_mod0",
@@ -661,7 +661,7 @@
       0,
       [ "@query" ],
       0,
-      "1866d7f104fc0c0578d21ed4590d60d8"
+      "c688cfb940a222a40b73b8bd20707a65"
     ],
     [
       "Vale.Poly1305.Math.lemma_bytes_and_mod1",
@@ -696,7 +696,7 @@
         "typing_FStar.UInt.fits", "typing_FStar.UInt.to_vec"
       ],
       0,
-      "fbca0221d2d68f4b8846af6fb4fa3224"
+      "dc40821b7d5ce303e61315f71d7cbeff"
     ],
     [
       "Vale.Poly1305.Math.lemma_bytes_and_mod1",
@@ -705,7 +705,7 @@
       0,
       [ "@query" ],
       0,
-      "63783b4d04494e35bf8af7326d806a78"
+      "742523c580850160fb331a120a764dee"
     ],
     [
       "Vale.Poly1305.Math.lemma_bytes_and_mod2",
@@ -740,7 +740,7 @@
         "typing_FStar.UInt.fits", "typing_FStar.UInt.to_vec"
       ],
       0,
-      "39b55240ca6bf7d7bfe6957e8d8ccd35"
+      "b121e121d87ad29762e1613476bb19b9"
     ],
     [
       "Vale.Poly1305.Math.lemma_bytes_and_mod2",
@@ -749,7 +749,7 @@
       0,
       [ "@query" ],
       0,
-      "8abd1388a8cef371bd8f217ff3255e43"
+      "58e85e72bf30cd293cd7f2b60a571b8c"
     ],
     [
       "Vale.Poly1305.Math.lemma_bytes_and_mod3",
@@ -784,7 +784,7 @@
         "typing_FStar.UInt.fits", "typing_FStar.UInt.to_vec"
       ],
       0,
-      "f44cf6c6fc8c0dd5b08d8ff934896d89"
+      "1faa12febea15d76ee840fb5fb15381b"
     ],
     [
       "Vale.Poly1305.Math.lemma_bytes_and_mod3",
@@ -793,7 +793,7 @@
       0,
       [ "@query" ],
       0,
-      "75fd24754b205e87d57c76c0a87bebc9"
+      "95b335ded1b814bb64c81579aae4a1bc"
     ],
     [
       "Vale.Poly1305.Math.lemma_bytes_and_mod4",
@@ -828,7 +828,7 @@
         "typing_FStar.UInt.fits", "typing_FStar.UInt.to_vec"
       ],
       0,
-      "e1e2505b615ec86636185415a0571863"
+      "698a0d6f3169cb6d81699205458b5f3f"
     ],
     [
       "Vale.Poly1305.Math.lemma_bytes_and_mod4",
@@ -837,7 +837,7 @@
       0,
       [ "@query" ],
       0,
-      "fd44ed8dc68fd9f6a62aa3aede5495b5"
+      "29612b9c0a6933f39bce26ae412d6239"
     ],
     [
       "Vale.Poly1305.Math.lemma_bytes_and_mod5",
@@ -872,7 +872,7 @@
         "typing_FStar.UInt.fits", "typing_FStar.UInt.to_vec"
       ],
       0,
-      "0b8a41fbafe900721842ba743059b147"
+      "b1010e9aaf9fc7b251324aee1ec5829c"
     ],
     [
       "Vale.Poly1305.Math.lemma_bytes_and_mod5",
@@ -881,7 +881,7 @@
       0,
       [ "@query" ],
       0,
-      "cae0f5c2b212748ae592d0b23d98e9d8"
+      "5280f4c4a084d1239c86ac839fbc7591"
     ],
     [
       "Vale.Poly1305.Math.lemma_bytes_and_mod6",
@@ -916,7 +916,7 @@
         "typing_FStar.UInt.fits", "typing_FStar.UInt.to_vec"
       ],
       0,
-      "850c83fdf7ae3acfa6df235600708823"
+      "012009cef6978ea82a73c10ddf6f76f1"
     ],
     [
       "Vale.Poly1305.Math.lemma_bytes_and_mod6",
@@ -925,7 +925,7 @@
       0,
       [ "@query" ],
       0,
-      "9cfd0bad257659500de59bc923d8f02f"
+      "20b7d4a8bdf2dca7e4e774f6c507816f"
     ],
     [
       "Vale.Poly1305.Math.lemma_bytes_and_mod7",
@@ -960,7 +960,7 @@
         "typing_FStar.UInt.fits", "typing_FStar.UInt.to_vec"
       ],
       0,
-      "2c277481cfb900a565975eef95e527fd"
+      "34bf86b4a3262f63722a0c0846b85103"
     ],
     [
       "Vale.Poly1305.Math.lemma_bytes_and_mod7",
@@ -969,7 +969,7 @@
       0,
       [ "@query" ],
       0,
-      "4bf69f765f2de5daa23b4a8c0162639e"
+      "b787e96c69b4de9212ba45a7b09013ae"
     ],
     [
       "Vale.Poly1305.Math.lemma_bytes_and_mod",
@@ -985,7 +985,7 @@
         "typing_Vale.Def.Types_s.ishl"
       ],
       0,
-      "929be6d677c1b70bf5af94cf00ea9d40"
+      "2fdc1a921e16601fbe78b185551d5612"
     ],
     [
       "Vale.Poly1305.Math.lemma_bytes_and_mod",
@@ -1021,7 +1021,7 @@
         "typing_Prims.pow2"
       ],
       0,
-      "85cc84f48099b59c35dd293fef359275"
+      "3fa57cbc417cff2b2e4db0b450f3fa72"
     ],
     [
       "Vale.Poly1305.Math.lemma_mod_factors",
@@ -1034,7 +1034,7 @@
         "true_interp"
       ],
       0,
-      "7127ea7c2023f05a9c75146f434ce63d"
+      "f3a08ddf56d5102bd16e6414d053ea44"
     ],
     [
       "Vale.Poly1305.Math.lemma_mul_pos_pos_is_pos_inverse",
@@ -1053,7 +1053,7 @@
         "unit_inversion", "unit_typing"
       ],
       0,
-      "f8d4b48d9bae01eeb18fbf065463383d"
+      "c76398603c28f729040fffb8b575bec5"
     ],
     [
       "Vale.Poly1305.Math.lemma_mod_factor_lo",
@@ -1066,7 +1066,7 @@
         "refinement_interpretation_Tm_refine_774ba3f728d91ead8ef40be66c9802e5"
       ],
       0,
-      "344c40a80ee5e068a770432d40fd9d71"
+      "5e04cb64be59bb3d6c4aeb0c3b6490db"
     ],
     [
       "Vale.Poly1305.Math.lemma_mod_power2_lo",
@@ -1082,7 +1082,7 @@
         "refinement_interpretation_Tm_refine_2de20c066034c13bf76e9c0b94f4806c"
       ],
       0,
-      "14e0bb30b60b5569f0b096b5561b0fda"
+      "ffe67d8fc015f8219b3096eabb3d4d24"
     ],
     [
       "Vale.Poly1305.Math.lemma_mod_power2_lo",
@@ -1105,7 +1105,7 @@
         "typing_Prims.pow2"
       ],
       0,
-      "642dc6c615e9d87efd0404b59d777b81"
+      "39a3d095e4ba9a6fecd11255bfbb3f20"
     ],
     [
       "Vale.Poly1305.Math.lemma_power2_add64",
@@ -1118,7 +1118,7 @@
         "refinement_interpretation_Tm_refine_542f9d4f129664613f2483a6c88bc7c2"
       ],
       0,
-      "5e873ea68cd66a64bf35e402c38f7961"
+      "2f40b86d0d95ea5538d2c41c00a31b57"
     ],
     [
       "Vale.Poly1305.Math.lemma_power2_add64",
@@ -1127,7 +1127,7 @@
       0,
       [ "@query", "projection_inverse_BoxInt_proj_0" ],
       0,
-      "a4ba261c92a5c8c195f56e5fd1174727"
+      "57a9f56d23a160ff10cba99f238cd1d5"
     ],
     [
       "Vale.Poly1305.Math.lemma_part_bound1",
@@ -1140,7 +1140,7 @@
         "true_interp"
       ],
       0,
-      "c67d203484662cd0523ba4b23d6cfebb"
+      "2fdd108af87a6586d014600c2966d0cf"
     ],
     [
       "Vale.Poly1305.Math.lemma_lt_le_trans",
@@ -1149,7 +1149,7 @@
       0,
       [ "@query" ],
       0,
-      "4bee98af13562e89e9755e960f965ffb"
+      "396721f6d5834808bebbbc0d6bdf0d53"
     ],
     [
       "Vale.Poly1305.Math.lemma_part_bound2",
@@ -1161,7 +1161,7 @@
         "refinement_interpretation_Tm_refine_774ba3f728d91ead8ef40be66c9802e5"
       ],
       0,
-      "c0d09f0b651fece7f50d1ae77e7cbe03"
+      "05702983cd3c62dae7a41a5293ac3671"
     ],
     [
       "Vale.Poly1305.Math.lemma_truncate_middle",
@@ -1174,7 +1174,7 @@
         "refinement_interpretation_Tm_refine_774ba3f728d91ead8ef40be66c9802e5"
       ],
       0,
-      "e631377c293cf2bb3ef6e3b7efe6c7c0"
+      "9d23f2c0f2a2236e62ca905636c390dc"
     ],
     [
       "Vale.Poly1305.Math.lemma_mod_breakdown",
@@ -1188,7 +1188,7 @@
         "true_interp"
       ],
       0,
-      "674a1b55dd8e53c2bbdf614a7961ea1a"
+      "ce5fad5b4eff15f5ca26c187daa1d456"
     ],
     [
       "Vale.Poly1305.Math.lemma_mod_breakdown",
@@ -1197,7 +1197,7 @@
       0,
       [ "@query" ],
       0,
-      "a2a8213b6ac37beed1d6a6dce1cc0d7d"
+      "ec40ccfacbec0a682a1a184c6cc50dd0"
     ],
     [
       "Vale.Poly1305.Math.lemma_mod_hi",
@@ -1212,7 +1212,7 @@
         "refinement_interpretation_Tm_refine_c1424615841f28cac7fc34e92b7ff33c"
       ],
       0,
-      "779662259a2eb4e9700d617d6f67647d"
+      "166f52e57e8fcb54b8b9a535deed7d5d"
     ],
     [
       "Vale.Poly1305.Math.lemma_mod_hi",
@@ -1232,7 +1232,7 @@
         "token_correspondence_Vale.Poly1305.Math.lowerUpper128_def"
       ],
       0,
-      "72c9b0cb4a2ae0eaa76f1c303531ae44"
+      "68e4c9bc61d6379e813ab3aacaea4803"
     ],
     [
       "Vale.Poly1305.Math.lemma_poly_demod",
@@ -1244,7 +1244,7 @@
         "refinement_interpretation_Tm_refine_774ba3f728d91ead8ef40be66c9802e5"
       ],
       0,
-      "4d0ad8aaed57ede9a2aa61a0b5e06496"
+      "343b358ea938abdc03b1b3c6f8fa6468"
     ],
     [
       "Vale.Poly1305.Math.lemma_poly_demod",
@@ -1257,7 +1257,7 @@
         "refinement_interpretation_Tm_refine_774ba3f728d91ead8ef40be66c9802e5"
       ],
       0,
-      "65df0fb5f5c8a104f4b9c436590c37a4"
+      "61f250ffb07565db03769eb74f45b9b7"
     ],
     [
       "Vale.Poly1305.Math.lemma_reduce128",
@@ -1285,7 +1285,7 @@
         "typing_Vale.Poly1305.Math.lowerUpper128"
       ],
       0,
-      "fedba5ea68e51ba63eace940805aee9a"
+      "8c5525b2734b8070aaa18b9b347756af"
     ],
     [
       "Vale.Poly1305.Math.lemma_add_key",
@@ -1312,7 +1312,7 @@
         "typing_Vale.Poly1305.Math.lowerUpper128"
       ],
       0,
-      "0835a49844d7982917f00b6a769dfd5a"
+      "0a0806964f847e48327362769e9bc2f4"
     ],
     [
       "Vale.Poly1305.Math.lemma_lowerUpper128_and",
@@ -1345,7 +1345,7 @@
         "typing_FStar.UInt.fits", "typing_FStar.UInt.logand"
       ],
       0,
-      "cd27e3e49495c123a6090a51cdf717b7"
+      "f2bc67aa40cab6b58b6ee27023ba3f84"
     ],
     [
       "Vale.Poly1305.Math.lemma_add_mod128",
@@ -1360,7 +1360,7 @@
         "projection_inverse_BoxInt_proj_0"
       ],
       0,
-      "8137efb1814d3806d0facdb1368d35c4"
+      "9b76341d0e73fd4c7f125a21ca79c1e2"
     ]
   ]
 ]

--- a/lib/Lib.IntTypes.fst
+++ b/lib/Lib.IntTypes.fst
@@ -110,7 +110,7 @@ let int64_to_uint128 a = int128_to_uint128 (int64_to_int128 a)
 val int128_to_uint64: a:Int128.t -> b:UInt64.t{UInt64.v b == Int128.v a % pow2 64}
 let int128_to_uint64 a = Int.Cast.Full.uint128_to_uint64 (int128_to_uint128 a)
 
-#push-options "--z3rlimit 700"
+#push-options "--z3rlimit 800"
 
 [@(strict_on_arguments [0;2])]
 let cast #t #l t' l' u =

--- a/vale/code/crypto/poly1305/x64/Vale.Poly1305.Math.fst
+++ b/vale/code/crypto/poly1305/x64/Vale.Poly1305.Math.fst
@@ -172,6 +172,7 @@ val lemma_bytes_and_mod6: x: uint_t 64 ->
 val lemma_bytes_and_mod7: x: uint_t 64 ->
   Lemma (logand #64 x  (0x100000000000000 - 1) == x % 0x100000000000000)
 
+#push-options "--z3cliopt smt.arith.nl=true"
 let lemma_bytes_and_mod0 x =
   assert_by_tactic (logand #64 x (0x1 - 1) == mod #64 x 0x1) bv_tac
 
@@ -194,6 +195,7 @@ let lemma_bytes_and_mod6 x =
 
 let lemma_bytes_and_mod7 x =
   assert_by_tactic (logand #64 x (0x100000000000000 - 1) == mod #64 x 0x100000000000000) bv_tac
+#pop-options
 
 let lemma_bytes_and_mod (x:nat64) (y:nat64) =
   reveal_iand_all 64;


### PR DESCRIPTION
I made some changes to the VC generation code in F*: https://github.com/FStarLang/FStar/issues/2018 which resulted in some regressions. This PR fixes them.

`code/ed25519/Hacl.Bignum25519.fst`: just explaining the proof a bit more.

`code/ed25519/Hacl.Spec.BignumQ.Lemmas.fst`: the assertion that I removed seems tricky to prove, seems like Z3 can find a proof without it (but fails with it).

`code/poly1305/Hacl.Spec.Poly1305.Field32xN.Lemmas.fst`: this one don't know much about. The rlimit is large, but the proof is stable and hint replays.

`lib/Lib.IntTypes.fst`: rlimit increase 700 -> 800

`vale/code/crypto/poly1305/x64/Vale.Poly1305.Math.fst`: this was the most interesting one. The proofs that broke, seems like they were relying on the non-linear arithmetic but were setting `smt.nl.arith` to `false`, here is an example proof obligation from the smt file:

```
(or label_39

;; def=<input>(56,47-56,83); use=<input>(57,2-57,67)
(= (FStar.UInt.logand (BoxInt 64)
@x0
(BoxInt 0))
(BoxInt (_mod (BoxInt_proj_0 @x0)
1)))
)
)
```

With my changes the diff in the queries is just some gensym changes, but the proof broke. Enabling non-linear arithmetic for these proofs works fine. Why they were working earlier, not sure. Here is the queries diff in case.

```
469321a469322,469324
> ; <Skipped />
>
>
469336,469338d469338
< ; <Skipped />
<
<
469343a469344
> (push)
469348d469348
< (push)
469352,469357c469352,469357
< (declare-fun label_10 () Bool)
< (declare-fun label_9 () Bool)
< (declare-fun label_8 () Bool)
< (declare-fun label_7 () Bool)
< (declare-fun label_6 () Bool)
< (declare-fun label_5 () Bool)
---
> (declare-fun label_42 () Bool)
> (declare-fun label_41 () Bool)
> (declare-fun label_40 () Bool)
> (declare-fun label_39 () Bool)
> (declare-fun label_38 () Bool)
> (declare-fun label_37 () Bool)
469370,469371c469370,469371
< ;               (forall (return_val: Prims.int).
< ;                   return_val == 0x1 ==>
---
> ;               (forall (any_result: Prims.int).
> ;                   0x1 == any_result ==>
469406c469406
< (or label_5
---
> (or label_37
469428c469428
<  (! (implies (and (or label_6
---
>  (! (implies (and (or label_38
469433c469433
< (or label_7
---
> (or label_39
469467c469467
< (or label_8
---
> (or label_40
469503c469503
< (or label_9
---
> (or label_41
469514c469514
< ;; def=/workspace/everest/FStar/bin/../ulib/prims.fst(296,2-296,58); use=<input>(57,2-57,67)
---
> ;; def=/workspace/everest/FStar/bin/../ulib/prims.fst(364,46-364,82); use=<input>(57,2-57,67)
469519,469521c469519,469521
< ;; def=/workspace/everest/FStar/bin/../ulib/prims.fst(296,26-296,41); use=<input>(57,2-57,67)
< (= @x4
< (BoxInt 1))
---
> ;; def=/workspace/everest/FStar/bin/../ulib/FStar.UInt.fsti(161,31-161,32); use=<input>(57,2-57,67)
> (= (BoxInt 1)
> @x4)
469555c469555
< (or label_10
---
> (or label_42
469634,469645c469634,469645
< (echo "label_10")
< (eval label_10)
< (echo "label_9")
< (eval label_9)
< (echo "label_8")
< (eval label_8)
< (echo "label_7")
< (eval label_7)
< (echo "label_6")
< (eval label_6)
< (echo "label_5")
< (eval label_5)
---
> (echo "label_42")
> (eval label_42)
> (echo "label_41")
> (eval label_41)
> (echo "label_40")
> (eval label_40)
> (echo "label_39")
> (eval label_39)
> (echo "label_38")
> (eval label_38)
> (echo "label_37")
> (eval label_37)
469657c469657
< (declare-fun label_11 () Bool)
---
> (declare-fun label_43 () Bool)
469848c469848
< (declare-fun Tm_refine_493726b0caab6179254e314147227b49 (Term) Term)
---
> (declare-fun Tm_refine_e9fd75cceaaeb3c4516e200cfb4bee15 (Term) Term)
469852c469852
< ;; def=/workspace/everest/FStar/bin/../ulib/prims.fst(296,26-296,41); use=<input>(57,2-57,67)
---
> ;; def=/workspace/everest/FStar/bin/../ulib/FStar.UInt.fsti(161,31-161,32); use=<input>(57,2-57,67)
469854c469854
<  (! (HasType (Tm_refine_493726b0caab6179254e314147227b49 @x0)
---
>  (! (HasType (Tm_refine_e9fd75cceaaeb3c4516e200cfb4bee15 @x0)
469858c469858
< :pattern ((HasType (Tm_refine_493726b0caab6179254e314147227b49 @x0)
---
> :pattern ((HasType (Tm_refine_e9fd75cceaaeb3c4516e200cfb4bee15 @x0)
469860c469860
< :qid refinement_kinding_Tm_refine_493726b0caab6179254e314147227b49))
---
> :qid refinement_kinding_Tm_refine_e9fd75cceaaeb3c4516e200cfb4bee15))
469862c469862
< :named refinement_kinding_Tm_refine_493726b0caab6179254e314147227b49))
---
> :named refinement_kinding_Tm_refine_e9fd75cceaaeb3c4516e200cfb4bee15))
469866c469866
< ;; def=/workspace/everest/FStar/bin/../ulib/prims.fst(296,26-296,41); use=<input>(57,2-57,67)
---
> ;; def=/workspace/everest/FStar/bin/../ulib/FStar.UInt.fsti(161,31-161,32); use=<input>(57,2-57,67)
469870c469870
< (Tm_refine_493726b0caab6179254e314147227b49 @x2))
---
> (Tm_refine_e9fd75cceaaeb3c4516e200cfb4bee15 @x2))
469875,469877c469875,469877
< ;; def=/workspace/everest/FStar/bin/../ulib/prims.fst(296,26-296,41); use=<input>(57,2-57,67)
< (= @x2
< (BoxInt 1))
---
> ;; def=/workspace/everest/FStar/bin/../ulib/FStar.UInt.fsti(161,31-161,32); use=<input>(57,2-57,67)
> (= (BoxInt 1)
> @x2)
469883,469884c469883,469884
< (Tm_refine_493726b0caab6179254e314147227b49 @x2)))
< :qid refinement_interpretation_Tm_refine_493726b0caab6179254e314147227b49))
---
> (Tm_refine_e9fd75cceaaeb3c4516e200cfb4bee15 @x2)))
> :qid refinement_interpretation_Tm_refine_e9fd75cceaaeb3c4516e200cfb4bee15))
469886,469887c469886,469887
< :named refinement_interpretation_Tm_refine_493726b0caab6179254e314147227b49))
< ;;;;;;;;;;;;;;;;haseq for Tm_refine_493726b0caab6179254e314147227b49
---
> :named refinement_interpretation_Tm_refine_e9fd75cceaaeb3c4516e200cfb4bee15))
> ;;;;;;;;;;;;;;;;haseq for Tm_refine_e9fd75cceaaeb3c4516e200cfb4bee15
469890c469890
< ;; def=/workspace/everest/FStar/bin/../ulib/prims.fst(296,26-296,41); use=<input>(57,2-57,67)
---
> ;; def=/workspace/everest/FStar/bin/../ulib/FStar.UInt.fsti(161,31-161,32); use=<input>(57,2-57,67)
469892c469892
<  (! (iff (Valid (Prims.hasEq (Tm_refine_493726b0caab6179254e314147227b49 @x0)))
---
>  (! (iff (Valid (Prims.hasEq (Tm_refine_e9fd75cceaaeb3c4516e200cfb4bee15 @x0)))
469896,469897c469896,469897
< :pattern ((Valid (Prims.hasEq (Tm_refine_493726b0caab6179254e314147227b49 @x0))))
< :qid haseqTm_refine_493726b0caab6179254e314147227b49))
---
> :pattern ((Valid (Prims.hasEq (Tm_refine_e9fd75cceaaeb3c4516e200cfb4bee15 @x0))))
> :qid haseqTm_refine_e9fd75cceaaeb3c4516e200cfb4bee15))
469899c469899
< :named haseqTm_refine_493726b0caab6179254e314147227b49))
---
> :named haseqTm_refine_e9fd75cceaaeb3c4516e200cfb4bee15))
470071c470071
< ;   (return_val: Prims.int) (_: _: Prims.unit{return_val == 0x1}) (any_result: FStar.UInt.uint_t 64)
---
> ;   (any_result: Prims.int) (_: _: Prims.unit{0x1 == any_result}) (any_result: FStar.UInt.uint_t 64)
470111c470111
< (Tm_refine_493726b0caab6179254e314147227b49 @x7))
---
> (Tm_refine_e9fd75cceaaeb3c4516e200cfb4bee15 @x7))
470124c470124
< (or label_11
---
> (or label_43
470149,470150c470149,470150
< (echo "label_11")
< (eval label_11)
---
> (echo "label_43")
> (eval label_43)
```