### PR TITLE
Fix docs (again)

### DIFF
--- a/.docker/build/build.sh
+++ b/.docker/build/build.sh
@@ -171,10 +171,10 @@ function refresh_doc() {
 function refresh_hacl_hints_dist() {
     # We should not generate hints when building on Windows
     if [[ "$OS" != "Windows_NT" ]]; then
-        refresh_hints_dist "git@github.com:mitls/hacl-star.git" "true" "regenerate hints and dist" "."
         if [[ $branchname == "master" ]] ; then
           refresh_doc
         fi
+        refresh_hints_dist "git@github.com:mitls/hacl-star.git" "true" "regenerate hints and dist" "."
     fi
 }
 


### PR DESCRIPTION
Sorry folks, I had to merge to master *then* trigger a nightly build because documentation refresh is only enabled on master... so it took me a first attempt to figure out the issue.

I'm fairly confident this is it. For some reason, refresh_dist blasts everything in dist/, *then* refreshes the C code, then git-adds everything. So, we need to do the website refresh first because otherwise wasm/doc is gone.

Probably worth tidying this up eventually but that'll do for now.