### PR TITLE
CI: do not hardcode gcc-7

### DIFF
--- a/.docker/build/build.sh
+++ b/.docker/build/build.sh
@@ -290,10 +290,6 @@ function exec_build() {
 export OCAMLRUNPARAM=b
 export OTHERFLAGS="--use_hints --query_stats"
 export MAKEFLAGS="$MAKEFLAGS -Otarget"
-if [[ "$OS" != "Windows_NT" ]]; then
-    export CC=gcc-7
-    export CXX=g++-7
-fi
 
 export_home FSTAR "$(pwd)/FStar"
 cd hacl-star


### PR DESCRIPTION
No longer useful now with the base Linux CI container using gcc-9. This change was suggested by @msprotz 

I claim that this is the only change needed to make HACL* Linux CI work with the new Linux CI base image based on Ubuntu 20.04, where the default gcc is now gcc-9
