### PR TITLE
Fix hint regeneration

### DIFF
--- a/.docker/build/build.sh
+++ b/.docker/build/build.sh
@@ -174,7 +174,7 @@ function refresh_hacl_hints_dist() {
         if [[ $branchname == "master" ]] ; then
           refresh_doc
         fi
-        refresh_hints_dist "git@github.com:mitls/hacl-star.git" "true" "regenerate hints and dist" "."
+        refresh_hints_dist "git@github.com:mitls/hacl-star.git" "true" "regenerate hints and dist" "hints"
     fi
 }
 

--- a/Makefile
+++ b/Makefile
@@ -1022,6 +1022,7 @@ dist/%/Makefile.basic: $(ALL_KRML_FILES) dist/LICENSE.txt \
 dist/evercrypt-external-headers/Makefile.basic: $(ALL_KRML_FILES)
 	$(KRML) -silent \
 	  -minimal \
+	  -header $(HACL_HOME)/dist/LICENSE.txt \
 	  -bundle EverCrypt+EverCrypt.AEAD+EverCrypt.AutoConfig2+EverCrypt.HKDF+EverCrypt.HMAC+EverCrypt.Hash+EverCrypt.Hash.Incremental+EverCrypt.Cipher+EverCrypt.Poly1305+EverCrypt.Chacha20Poly1305+EverCrypt.Curve25519=*[rename=EverCrypt] \
 	  -library EverCrypt,EverCrypt.* \
 	  -add-include '<inttypes.h>' \

--- a/hints/Lib.Buffer.fst.hints
+++ b/hints/Lib.Buffer.fst.hints
@@ -12,7 +12,7 @@
         "fuel_guarded_inversion_Lib.Buffer.buftype"
       ],
       0,
-      "09565084da5ad71ed2d92f1e033e27f0"
+      "4ef3d69b2aa90479cacb9b3a74fae44a"
     ],
     [
       "Lib.Buffer.length",
@@ -31,7 +31,7 @@
         "fuel_guarded_inversion_Lib.Buffer.buftype"
       ],
       0,
-      "de46d0a2fdba4a547a3fcf299c954841"
+      "156d321cb79b28e79350cb5ee62b5ea8"
     ],
     [
       "Lib.Buffer.to_const",
@@ -61,7 +61,7 @@
         "fuel_guarded_inversion_Lib.Buffer.buftype"
       ],
       0,
-      "dc14e3cfcda1594a0f8cf29de64952bd"
+      "e58aa0a278c2dc4ffbd77fc07c4248fe"
     ],
     [
       "Lib.Buffer.const_to_buffer",
@@ -84,7 +84,7 @@
         "refinement_interpretation_Tm_refine_cff67ae72a32a26eda52be5cb0ae9c68"
       ],
       0,
-      "75f6ce80495c07e7fec3464404636b39"
+      "dcd9f3e0699d8289b8b99f31c5049ce2"
     ],
     [
       "Lib.Buffer.const_to_ibuffer",
@@ -109,7 +109,7 @@
         "refinement_interpretation_Tm_refine_7492783be123ac02826f6e0e703dc48c"
       ],
       0,
-      "a6d1a595da191c62a2a9d18d5b1d3825"
+      "e156adff51334c17cf95c80396aefa38"
     ],
     [
       "Lib.Buffer.lbuffer_t",
@@ -118,7 +118,7 @@
       1,
       [ "@query" ],
       0,
-      "020094e6c66789b74cf49efc36f8d084"
+      "714b94e88a47caed810b66e71b4617f2"
     ],
     [
       "Lib.Buffer.glbuffer",
@@ -133,7 +133,7 @@
         "refinement_interpretation_Tm_refine_9d89bf7b57667578cd0e1f4470daef3b"
       ],
       0,
-      "a54ea3f6545d3d5623814bd75895c451"
+      "47b3b40790d739465ea2aaf53600e48b"
     ],
     [
       "Lib.Buffer.const_to_lbuffer",
@@ -146,7 +146,7 @@
         "refinement_interpretation_Tm_refine_9d89bf7b57667578cd0e1f4470daef3b"
       ],
       0,
-      "1109f330c186ce95dbab24eb3efaa8d4"
+      "40600706f51cbe0325a755ddf9e0a49b"
     ],
     [
       "Lib.Buffer.const_to_lbuffer",
@@ -162,7 +162,7 @@
         "refinement_interpretation_Tm_refine_9d89bf7b57667578cd0e1f4470daef3b"
       ],
       0,
-      "b41a472cf2c4dec9aebe9eef9a3c94e3"
+      "a65ea1821268cfa1755f32988d745bd8"
     ],
     [
       "Lib.Buffer.const_to_ilbuffer",
@@ -178,7 +178,7 @@
         "refinement_interpretation_Tm_refine_d3262d59947c8e9af0ea1a5449396c22"
       ],
       0,
-      "835938fa932196217beb2d6bcd66fc27"
+      "f15f2836143676b063c80d9127b25dff"
     ],
     [
       "Lib.Buffer.live",
@@ -197,7 +197,7 @@
         "fuel_guarded_inversion_Lib.Buffer.buftype"
       ],
       0,
-      "f3fcd75582a71a20ea9240c194ef89b8"
+      "b6dfd46887aa1263e2159857b29ec3f2"
     ],
     [
       "Lib.Buffer.loc",
@@ -216,7 +216,7 @@
         "fuel_guarded_inversion_Lib.Buffer.buftype"
       ],
       0,
-      "9f9d3f81c3ec343929fd0905a56e6ee2"
+      "f6e94b12120ee0d7084803073b91fa8f"
     ],
     [
       "Lib.Buffer.mut_immut_disjoint",
@@ -232,7 +232,7 @@
         "equation_LowStar.Monotonic.Buffer.disjoint"
       ],
       0,
-      "b55bab2bc22ed64d420cdfaa2a45d8f2"
+      "bcadbd835e20047b2d1872086051c60f"
     ],
     [
       "Lib.Buffer.mut_const_immut_disjoint",
@@ -258,7 +258,7 @@
         "equation_LowStar.Monotonic.Buffer.disjoint"
       ],
       0,
-      "e8bb9c54382f8d622c2a488f77c45727"
+      "da8372624810136f8dac9a072af25848"
     ],
     [
       "Lib.Buffer.as_seq",
@@ -296,7 +296,7 @@
         "typing_tok_Lib.IntTypes.PUB@tok", "typing_tok_Lib.IntTypes.U32@tok"
       ],
       0,
-      "bca832b44026aa8ecac95683bb44c3a0"
+      "9ec9b0da77902456bb0a6b89b00e709e"
     ],
     [
       "Lib.Buffer.gsub",
@@ -346,7 +346,7 @@
         "typing_LowStar.Monotonic.Buffer.mgsub"
       ],
       0,
-      "e9d7716ed2617d5f8ec85a00f22d9ec4"
+      "f5567b4247a72720e8b99cf56882f75a"
     ],
     [
       "Lib.Buffer.live_sub",
@@ -439,7 +439,7 @@
         "unit_typing"
       ],
       0,
-      "5b3b7598b912655ae1e64b33f61ca894"
+      "e668c89a9418cfdac4d591d41bde4da3"
     ],
     [
       "Lib.Buffer.modifies_sub",
@@ -483,7 +483,7 @@
         "typing_tok_Lib.IntTypes.PUB@tok", "typing_tok_Lib.IntTypes.U32@tok"
       ],
       0,
-      "41023a8fca331227c4e0a344370066ad"
+      "043997539f531e366f8f3adfd7e0965e"
     ],
     [
       "Lib.Buffer.as_seq_gsub",
@@ -507,7 +507,7 @@
         "typing_tok_Lib.IntTypes.PUB@tok", "typing_tok_Lib.IntTypes.U32@tok"
       ],
       0,
-      "3694d3e3585a377235050143dfd6b7c5"
+      "cc97f80d5d7d01cfbc6a7da125150018"
     ],
     [
       "Lib.Buffer.as_seq_gsub",
@@ -550,7 +550,7 @@
         "typing_tok_Lib.IntTypes.PUB@tok", "typing_tok_Lib.IntTypes.U32@tok"
       ],
       0,
-      "3440a75176ae0c43a3741367ff33cb18"
+      "c2df44c0dd587236ef998e3d119e8b69"
     ],
     [
       "Lib.Buffer.sub",
@@ -653,7 +653,7 @@
         "typing_tok_Lib.IntTypes.U32@tok"
       ],
       0,
-      "97721ea8f1d4aa243990d19ae9a5e60b"
+      "40adae4bab2496d293f07a9bc32b8ab5"
     ],
     [
       "Lib.Buffer.index",
@@ -674,7 +674,7 @@
         "typing_tok_Lib.IntTypes.U32@tok"
       ],
       0,
-      "df9d1e49f09fb1c58a0453d4a57e4bf4"
+      "936c0f778df612e0a45701554a550ac8"
     ],
     [
       "Lib.Buffer.index",
@@ -717,7 +717,7 @@
         "typing_Lib.Buffer.length"
       ],
       0,
-      "6d10600025e61582af8ac27f2084c562"
+      "991a7b9663337baf44945d3ed967b796"
     ],
     [
       "Lib.Buffer.upd",
@@ -738,7 +738,7 @@
         "typing_tok_Lib.IntTypes.U32@tok"
       ],
       0,
-      "5331217bc85f759d59165f4203195825"
+      "51157ea74b5e03d58532b28027805579"
     ],
     [
       "Lib.Buffer.upd",
@@ -773,7 +773,7 @@
         "typing_LowStar.Monotonic.Buffer.len"
       ],
       0,
-      "107c71c1954e4fb087c423da8624ff57"
+      "27b460826eed743944abeb4e83d80e6f"
     ],
     [
       "Lib.Buffer.bget",
@@ -805,7 +805,7 @@
         "typing_tok_Lib.IntTypes.PUB@tok", "typing_tok_Lib.IntTypes.U32@tok"
       ],
       0,
-      "7dd647530e5221d4d6f97708106e03ae"
+      "2ab316c57db95bb9c07e353bb865bb6f"
     ],
     [
       "Lib.Buffer.bget_as_seq",
@@ -829,7 +829,7 @@
         "typing_tok_Lib.IntTypes.U32@tok"
       ],
       0,
-      "f99e1cd58b983dabc385dcb0891bb281"
+      "732d36b23185aecd04564f8f73ddc26d"
     ],
     [
       "Lib.Buffer.bget_as_seq",
@@ -853,7 +853,7 @@
         "typing_tok_Lib.IntTypes.U32@tok"
       ],
       0,
-      "47054ed9cedcfbf587361194512d7c3b"
+      "3b12e11f4bd6841933c67eac6b319679"
     ],
     [
       "Lib.Buffer.stack_allocated",
@@ -871,7 +871,7 @@
         "typing_Lib.Buffer.length", "typing_tok_Lib.Buffer.MUT@tok"
       ],
       0,
-      "344d4342ce2de179e14abe6b4c7c0db1"
+      "7368d7ad5ec45a9f6b14fe1912fffc25"
     ],
     [
       "Lib.Buffer.stack_allocated",
@@ -886,7 +886,7 @@
         "refinement_interpretation_Tm_refine_9d89bf7b57667578cd0e1f4470daef3b"
       ],
       0,
-      "224d215695803755be915434c07725de"
+      "f046a9507a6ce868628c2e96798bdb3b"
     ],
     [
       "Lib.Buffer.global_allocated",
@@ -906,7 +906,7 @@
         "typing_Lib.Buffer.length", "typing_tok_Lib.Buffer.CONST@tok"
       ],
       0,
-      "0e9898754d865c0917111a18659bcbd4"
+      "8a015e877494b227f7800dca9593337d"
     ],
     [
       "Lib.Buffer.global_allocated",
@@ -930,7 +930,7 @@
         "refinement_interpretation_Tm_refine_acc162e7169e6aa7bd29398a6c3dea04"
       ],
       0,
-      "4536c8326e38c1096bf249b9f3a13584"
+      "abbe2924f8bd0a54043680a1d6a7542c"
     ],
     [
       "Lib.Buffer.recallable",
@@ -955,7 +955,7 @@
         "typing_tok_Lib.IntTypes.U32@tok"
       ],
       0,
-      "19533ab817e761beea631dde10b9de4d"
+      "46258bfd87b525b58e2e99f74e05c3ec"
     ],
     [
       "Lib.Buffer.recall",
@@ -995,7 +995,7 @@
         "typing_tok_Lib.IntTypes.PUB@tok", "typing_tok_Lib.IntTypes.U32@tok"
       ],
       0,
-      "b9e35ec4bf0310d4893b2bb6e8c1a7de"
+      "b8a1d1989c0161e27f4521b725714330"
     ],
     [
       "Lib.Buffer.witnessed",
@@ -1015,7 +1015,7 @@
         "typing_Lib.Buffer.length", "typing_tok_Lib.Buffer.CONST@tok"
       ],
       0,
-      "e431346ad11fe2b30d19763b3577a6d4"
+      "2d2edfd04e131fbbbac492a28b9881ab"
     ],
     [
       "Lib.Buffer.witnessed",
@@ -1031,7 +1031,7 @@
         "refinement_interpretation_Tm_refine_acc162e7169e6aa7bd29398a6c3dea04"
       ],
       0,
-      "2b9bf986ea5a284b15d42ec9fee23be5"
+      "5666ad5c9db961e67f67fc5be0cdecc4"
     ],
     [
       "Lib.Buffer.create",
@@ -1045,7 +1045,7 @@
         "refinement_interpretation_Tm_refine_f5d52bcf1a847ba3702dfbd3e5477a14"
       ],
       0,
-      "f9c72510af9610346682758f7fe9d50d"
+      "6348bf4343e8d25ef03fbe8923676c1b"
     ],
     [
       "Lib.Buffer.create",
@@ -1078,7 +1078,7 @@
         "typing_FStar.Monotonic.HyperHeap.root"
       ],
       0,
-      "89babab82f8d9f6142968c24aa51ae0f"
+      "40b2e20843a27f403b075d00cf0c85ed"
     ],
     [
       "Lib.Buffer.createL",
@@ -1118,7 +1118,7 @@
         "typing_tok_Lib.IntTypes.U32@tok"
       ],
       0,
-      "3db1fa6dad89d51ed00a759ab20e24e1"
+      "a891ff795849426130777269980a5c34"
     ],
     [
       "Lib.Buffer.createL",
@@ -1174,7 +1174,7 @@
         "typing_tok_Lib.IntTypes.PUB@tok", "typing_tok_Lib.IntTypes.U32@tok"
       ],
       0,
-      "55a202a94dd0a66f01d8c3b7b66444e5"
+      "b1c87e17027f54dc091da6e312bb58fa"
     ],
     [
       "Lib.Buffer.createL_global",
@@ -1218,7 +1218,7 @@
         "typing_tok_Lib.IntTypes.PUB@tok", "typing_tok_Lib.IntTypes.U32@tok"
       ],
       0,
-      "6854ffaa38e0ba593f16b3bb76a86922"
+      "ad8409f3fba34ca46a567627286d9545"
     ],
     [
       "Lib.Buffer.createL_global",
@@ -1283,7 +1283,7 @@
         "typing_tok_Lib.IntTypes.PUB@tok", "typing_tok_Lib.IntTypes.U32@tok"
       ],
       0,
-      "966edb7c5e170fd4b5e759001b8d73e5"
+      "82dbec182a51876562180384c19d002c"
     ],
     [
       "Lib.Buffer.recall_contents",
@@ -1306,7 +1306,7 @@
         "typing_tok_Lib.Buffer.CONST@tok"
       ],
       0,
-      "e417cc3f2d4eb520793bd3bbd057c46e"
+      "56984c9b57f78492c232af764b42348e"
     ],
     [
       "Lib.Buffer.recall_contents",
@@ -1326,7 +1326,7 @@
         "typing_Lib.Buffer.length", "typing_tok_Lib.Buffer.CONST@tok"
       ],
       0,
-      "f37dc7ad644c083fe7942fe309423b47"
+      "6da0a42d4bed29ea02ab710ea97f7a50"
     ],
     [
       "Lib.Buffer.recall_contents",
@@ -1373,7 +1373,7 @@
         "typing_tok_LowStar.ConstBuffer.IMMUTABLE@tok"
       ],
       0,
-      "126ec5afab8414eb3eda31b9c7a8b893"
+      "fddbcaccc3ec1c6b6ab558e64fa824c4"
     ],
     [
       "Lib.Buffer.copy",
@@ -1391,7 +1391,7 @@
         "typing_Lib.Buffer.length"
       ],
       0,
-      "cd0b59fbc6be1fa15b541fa75d159941"
+      "9a5cefca0ceb7f54d2ee30ea87a7c1e1"
     ],
     [
       "Lib.Buffer.copy",
@@ -1479,7 +1479,7 @@
         "unit_inversion", "unit_typing"
       ],
       0,
-      "a2f3732425c3318fb90c500cd352a8e9"
+      "cad0032986bd90898188796fb6e3f6fe"
     ],
     [
       "Lib.Buffer.memset",
@@ -1536,7 +1536,7 @@
         "typing_tok_Lib.IntTypes.U32@tok"
       ],
       0,
-      "cb3c71ee548d27d640176f4916137230"
+      "8152c190b1ec65c7993931857723cfa4"
     ],
     [
       "Lib.Buffer.memset",
@@ -1609,7 +1609,7 @@
         "typing_tok_Lib.IntTypes.U32@tok"
       ],
       0,
-      "0aaaff38d5049134a91e998c4b39ff4b"
+      "fb5aca9b2173fe6657bdf8828c04e0b5"
     ],
     [
       "Lib.Buffer.update_sub",
@@ -1635,7 +1635,7 @@
         "typing_tok_Lib.IntTypes.U32@tok"
       ],
       0,
-      "b5eaebb5fc956386f47ffe825c4624c2"
+      "b6ed774280b8829a0619844c063680b2"
     ],
     [
       "Lib.Buffer.update_sub",
@@ -1745,7 +1745,7 @@
         "typing_tok_Lib.IntTypes.U32@tok", "unit_inversion", "unit_typing"
       ],
       0,
-      "c09f947f02880105418f58325f95ca74"
+      "63a33dee1613bb9ee188471ecfeeba24"
     ],
     [
       "Lib.Buffer.update_sub_f",
@@ -1771,7 +1771,7 @@
         "typing_tok_Lib.IntTypes.U32@tok"
       ],
       0,
-      "9ba473b9479539c3f80d2e95d3ac8e4f"
+      "55d1f41a432fd02e0ad06abbd2fd8b5e"
     ],
     [
       "Lib.Buffer.update_sub_f",
@@ -1791,7 +1791,7 @@
         "typing_tok_Lib.IntTypes.U32@tok"
       ],
       0,
-      "2877fafaa415d3bfc9fe97c06f20ca54"
+      "69931486f080fede7ac998afa73296dd"
     ],
     [
       "Lib.Buffer.update_sub_f",
@@ -1860,7 +1860,7 @@
         "typing_tok_Lib.IntTypes.U32@tok"
       ],
       0,
-      "09b2eacf970e37b73c602e4705768e02"
+      "416b50a4fb92917f0b35e8125136ba4f"
     ],
     [
       "Lib.Buffer.concat2",
@@ -1887,7 +1887,7 @@
         "typing_tok_Lib.IntTypes.U32@tok"
       ],
       0,
-      "d2ed69920a828ec01675abfd3a7b6198"
+      "c83e5166cc04dbed7140673072e5e193"
     ],
     [
       "Lib.Buffer.concat2",
@@ -1910,7 +1910,7 @@
         "typing_tok_Lib.IntTypes.PUB@tok", "typing_tok_Lib.IntTypes.U32@tok"
       ],
       0,
-      "92acc441ff1d39a03680fe4dccd023d5"
+      "a1b737ef6c3df66f9eac121d9b6de7da"
     ],
     [
       "Lib.Buffer.concat2",
@@ -1978,7 +1978,7 @@
         "typing_tok_Lib.IntTypes.U32@tok"
       ],
       0,
-      "9a8af06735f77a3bffdff7d062ac5841"
+      "525868c68fa816be1ebe212995923d55"
     ],
     [
       "Lib.Buffer.concat3",
@@ -2007,7 +2007,7 @@
         "typing_tok_Lib.IntTypes.PUB@tok", "typing_tok_Lib.IntTypes.U32@tok"
       ],
       0,
-      "ce0b6e38437dcd5ffbe9f19b0c76fc95"
+      "c3bae56a97dd8d44b41d9f53844a70f3"
     ],
     [
       "Lib.Buffer.concat3",
@@ -2034,7 +2034,7 @@
         "typing_tok_Lib.IntTypes.PUB@tok", "typing_tok_Lib.IntTypes.U32@tok"
       ],
       0,
-      "b522b351c5b4be31010bf5925a7c041c"
+      "253a4e4d1ef50e4878b6b88a896220d1"
     ],
     [
       "Lib.Buffer.concat3",
@@ -2113,7 +2113,7 @@
         "typing_tok_Lib.IntTypes.U32@tok"
       ],
       0,
-      "09176fe01a0b84cbb3f7522f96ad51c6"
+      "17cb96bef5a3d1bdc7e9c88bdf71cf25"
     ],
     [
       "Lib.Buffer.loop_nospec",
@@ -2145,7 +2145,7 @@
         "typing_tok_Lib.IntTypes.PUB@tok", "typing_tok_Lib.IntTypes.U32@tok"
       ],
       0,
-      "2eb8d1f012e6521d221afb653054b6f5"
+      "4f9040e268dc78d25fc9bc58ba61fb5a"
     ],
     [
       "Lib.Buffer.loop_nospec2",
@@ -2180,7 +2180,7 @@
         "typing_tok_Lib.IntTypes.U32@tok"
       ],
       0,
-      "ce02b812f5f2ff1050b3cc2fc9fab34a"
+      "a6275931ca0e33f6313866e29be0859b"
     ],
     [
       "Lib.Buffer.loop_nospec3",
@@ -2217,7 +2217,7 @@
         "typing_tok_Lib.IntTypes.U32@tok"
       ],
       0,
-      "e9ddbdc45f511515fffe4f5fcf324404"
+      "70a6e261ed8563cf0d2636dab67584a5"
     ],
     [
       "Lib.Buffer.loop_range_nospec",
@@ -2264,7 +2264,7 @@
         "typing_tok_Lib.IntTypes.PUB@tok", "typing_tok_Lib.IntTypes.U32@tok"
       ],
       0,
-      "54e57f87d94301665415c700bc461891"
+      "050319cd6d0fd5fdb5b75f32c7fa8d87"
     ],
     [
       "Lib.Buffer.loop_inv",
@@ -2285,7 +2285,7 @@
         "typing_tok_Lib.IntTypes.U32@tok"
       ],
       0,
-      "ab9c6cf4904c14e7d7730ac253ab6e89"
+      "93d65f8eb842c4afcc42a15098d23a98"
     ],
     [
       "Lib.Buffer.loop_inv",
@@ -2298,7 +2298,7 @@
         "refinement_interpretation_Tm_refine_542f9d4f129664613f2483a6c88bc7c2"
       ],
       0,
-      "9dd990f2229706e98e0128b7cb1add2f"
+      "b652aee5ee47cb23223cd0ca151013ff"
     ],
     [
       "Lib.Buffer.loop",
@@ -2322,7 +2322,7 @@
         "typing_tok_Lib.IntTypes.U32@tok"
       ],
       0,
-      "805794fb56b04b9d7ff3a38c96458fc9"
+      "ac1ed221c8869b67641ef4702c84c7ca"
     ],
     [
       "Lib.Buffer.loop",
@@ -2346,7 +2346,7 @@
         "typing_tok_Lib.IntTypes.U32@tok"
       ],
       0,
-      "99c96e36ff36f9edf6312bbb762d99fd"
+      "a1fae9f4df3d0619bea69db6350c54b5"
     ],
     [
       "Lib.Buffer.loop",
@@ -2402,7 +2402,7 @@
         "typing_tok_Lib.IntTypes.PUB@tok", "typing_tok_Lib.IntTypes.U32@tok"
       ],
       0,
-      "52ad19af1635c58967f876bcc11bb1f8"
+      "19a8da14c3d6fc7fe160fa99a9b603b3"
     ],
     [
       "Lib.Buffer.loop_refl_inv",
@@ -2414,7 +2414,7 @@
         "refinement_interpretation_Tm_refine_288fffd419394f450ebf29a6cb5759d8"
       ],
       0,
-      "c92f47d433db457eedb846df7dfcdaaa"
+      "981d7216248d038cd46a5cd21fd0f4b3"
     ],
     [
       "Lib.Buffer.loop_refl",
@@ -2435,7 +2435,7 @@
         "typing_tok_Lib.IntTypes.U32@tok"
       ],
       0,
-      "3cfb6bc3627d73d338efa7cac41b3b66"
+      "d79673ca8c62709f194012e260d4bec1"
     ],
     [
       "Lib.Buffer.loop_refl",
@@ -2456,7 +2456,7 @@
         "typing_tok_Lib.IntTypes.U32@tok"
       ],
       0,
-      "e2a10006320494fa12fab7916d6ea67a"
+      "e0d72a4edd56beee604478127062dbf3"
     ],
     [
       "Lib.Buffer.loop_refl",
@@ -2516,7 +2516,7 @@
         "typing_tok_Lib.IntTypes.U32@tok"
       ],
       0,
-      "c5da31f001f88cd3726187a2030c3bc9"
+      "bdfd8737939812b7dab48df947605253"
     ],
     [
       "Lib.Buffer.loop1_inv",
@@ -2537,7 +2537,7 @@
         "typing_tok_Lib.IntTypes.U32@tok"
       ],
       0,
-      "9c9abbc02bb35c0ddf2c06784cbfa603"
+      "c82c684873770036c3a992459f347cab"
     ],
     [
       "Lib.Buffer.loop1_inv",
@@ -2559,7 +2559,7 @@
         "typing_tok_Lib.IntTypes.U32@tok"
       ],
       0,
-      "c665a774356b4d0939ab1d53eef64132"
+      "5717e852535efad26558d8a99143abfc"
     ],
     [
       "Lib.Buffer.loop1",
@@ -2585,7 +2585,7 @@
         "typing_tok_Lib.IntTypes.U32@tok"
       ],
       0,
-      "4ed65943ea4a22bff603d02897fffd5d"
+      "80ac21f89414c6fb56cf32bad3bc8e22"
     ],
     [
       "Lib.Buffer.loop1",
@@ -2611,7 +2611,7 @@
         "typing_tok_Lib.IntTypes.U32@tok"
       ],
       0,
-      "e929f3a72081336f81b30752e01b8708"
+      "2bef34055457bd824ffb14a14647d7ed"
     ],
     [
       "Lib.Buffer.loop1",
@@ -2671,7 +2671,7 @@
         "typing_tok_Lib.IntTypes.U32@tok"
       ],
       0,
-      "652f6c58398529f49be1c07f3c0da628"
+      "8cf3c580bbfe47200e6bf971525e7632"
     ],
     [
       "Lib.Buffer.loop2_inv",
@@ -2694,7 +2694,7 @@
         "typing_tok_Lib.IntTypes.U32@tok"
       ],
       0,
-      "e971d18c6409927e14f503c9d847c533"
+      "d642473f5bfea1d5989e8ae362d0beb1"
     ],
     [
       "Lib.Buffer.loop2_inv",
@@ -2716,7 +2716,7 @@
         "typing_tok_Lib.IntTypes.U32@tok"
       ],
       0,
-      "1d13266017f95413852665ab18c1ebf6"
+      "2be831ebfa08056b513106f04b7da37a"
     ],
     [
       "Lib.Buffer.loop2",
@@ -2742,7 +2742,7 @@
         "typing_tok_Lib.IntTypes.U32@tok"
       ],
       0,
-      "a4f982b7c8684ad60d69de8fc76b7b8e"
+      "ab07c3858a8870c50246f0fc2048fcf3"
     ],
     [
       "Lib.Buffer.loop2",
@@ -2768,7 +2768,7 @@
         "typing_tok_Lib.IntTypes.U32@tok"
       ],
       0,
-      "6b2640509f6f4289e07cc199930f27be"
+      "0613132737a87e5bace5a421727d99f5"
     ],
     [
       "Lib.Buffer.loop2",
@@ -2832,7 +2832,7 @@
         "typing_tok_Lib.IntTypes.U32@tok"
       ],
       0,
-      "9225a173dbb4c29f7c5446e360500e61"
+      "330d032d7cba59a8505b20c2997d86af"
     ],
     [
       "Lib.Buffer.salloc1_with_inv",
@@ -2850,7 +2850,7 @@
         "typing_tok_Lib.IntTypes.U32@tok"
       ],
       0,
-      "9aac6aa8e0057b40a3895e6529afc8bd"
+      "9f3906cc297235c5d7ed7dce536d0b37"
     ],
     [
       "Lib.Buffer.salloc1_with_inv",
@@ -2868,7 +2868,7 @@
         "typing_tok_Lib.IntTypes.U32@tok"
       ],
       0,
-      "7f486e27bb5df8616f1b5ae69c7e9041"
+      "4f5589a1125af8913c5d2874b2ddc329"
     ],
     [
       "Lib.Buffer.salloc1_with_inv",
@@ -2970,7 +2970,7 @@
         "typing_tok_Lib.Buffer.MUT@tok"
       ],
       0,
-      "8e8fc6d6db34ce2e320c351a72016745"
+      "acbd05cf0312952ccd3f8b91ec60b70e"
     ],
     [
       "Lib.Buffer.salloc1",
@@ -2988,7 +2988,7 @@
         "typing_tok_Lib.IntTypes.U32@tok"
       ],
       0,
-      "229fb83dc68454cdae0985bbf0cb9817"
+      "dadd0872dd0ff2811085c438d9184288"
     ],
     [
       "Lib.Buffer.salloc1",
@@ -3006,7 +3006,7 @@
         "typing_tok_Lib.IntTypes.U32@tok"
       ],
       0,
-      "9a7b083c2756b2d6dd2d83c6a2d6b6cd"
+      "5a0847876360f7be525c5ef26c25300d"
     ],
     [
       "Lib.Buffer.salloc1",
@@ -3019,7 +3019,7 @@
         "refinement_interpretation_Tm_refine_d9b9c8cceed03da1f9d311b8aa3b197b"
       ],
       0,
-      "3a1bcbcc4c1af9bcdc06a13ac142a22e"
+      "04a791344ac2afb194b214072e69aded"
     ],
     [
       "Lib.Buffer.salloc_nospec",
@@ -3037,7 +3037,7 @@
         "typing_tok_Lib.IntTypes.U32@tok"
       ],
       0,
-      "fc8a176e3154bdc4a8dd064d7ea62b3f"
+      "f42d02d86230a2879683688def407350"
     ],
     [
       "Lib.Buffer.salloc_nospec",
@@ -3055,7 +3055,7 @@
         "typing_tok_Lib.IntTypes.U32@tok"
       ],
       0,
-      "c0bcbd55ab91a0b58951ab6b8f322c9c"
+      "b0009b195cf5308a277b9cd0cd178a14"
     ],
     [
       "Lib.Buffer.loopi_blocks_f",
@@ -3085,7 +3085,7 @@
         "typing_tok_Lib.IntTypes.PUB@tok", "typing_tok_Lib.IntTypes.U32@tok"
       ],
       0,
-      "cce2ada843e4cc4a076b161419cdf4b8"
+      "916bbb84db41f6046ae374720d72bfc2"
     ],
     [
       "Lib.Buffer.loopi_blocks_f",
@@ -3111,7 +3111,7 @@
         "typing_tok_Lib.IntTypes.U32@tok"
       ],
       0,
-      "0858ba45ea9c2e69a6e7edce37644ad5"
+      "0fce927f6385cfcd79fc30ef3906fc04"
     ],
     [
       "Lib.Buffer.loopi_blocks_f",
@@ -3170,7 +3170,7 @@
         "typing_tok_Lib.IntTypes.U32@tok"
       ],
       0,
-      "98e0497d794070a48053e250d7efb1e9"
+      "e0e7ae7ff676ffef7c3e194742b72292"
     ],
     [
       "Lib.Buffer.loopi_blocks_f_nospec",
@@ -3182,7 +3182,7 @@
         "refinement_interpretation_Tm_refine_cfc41488cee641ca406ae764563b3947"
       ],
       0,
-      "dd1fc5475444a6c7df0b29faa09f9792"
+      "022e696ac8e5ba58b952b3759135d7c8"
     ],
     [
       "Lib.Buffer.loopi_blocks_f_nospec",
@@ -3194,7 +3194,7 @@
         "refinement_interpretation_Tm_refine_cfc41488cee641ca406ae764563b3947"
       ],
       0,
-      "f4f40a9fec9dadb578c8bd80a97a5cbb"
+      "e21c9d11a6586d012cb93905b1846624"
     ],
     [
       "Lib.Buffer.loopi_blocks_f_nospec",
@@ -3249,7 +3249,7 @@
         "typing_tok_Lib.IntTypes.U32@tok"
       ],
       0,
-      "ce0f6835149a6bca99c8bd77f44bb5f3"
+      "a981a1d63a4bf339355e4e74812afd57"
     ],
     [
       "Lib.Buffer.loopi_blocks",
@@ -3280,7 +3280,7 @@
         "typing_tok_Lib.IntTypes.PUB@tok", "typing_tok_Lib.IntTypes.U32@tok"
       ],
       0,
-      "2c98cf787abc831ebbaea7a77e72cd70"
+      "97268041181bf24d8c9e9ea3ccaa6b2a"
     ],
     [
       "Lib.Buffer.loopi_blocks",
@@ -3309,7 +3309,7 @@
         "typing_tok_Lib.IntTypes.U32@tok"
       ],
       0,
-      "bf076971924ba8e0bdcad88bfe367fc8"
+      "d017670cbaf395c6e4de258b581a8a05"
     ],
     [
       "Lib.Buffer.loopi_blocks",
@@ -3397,7 +3397,7 @@
         "typing_tok_Lib.IntTypes.U32@tok"
       ],
       0,
-      "020972b40ea0acc35fe58bd1130e24ba"
+      "5e3d9ebd05cb7ffada68256a0abfe5f0"
     ],
     [
       "Lib.Buffer.loopi_blocks_nospec",
@@ -3409,7 +3409,7 @@
         "refinement_interpretation_Tm_refine_cfc41488cee641ca406ae764563b3947"
       ],
       0,
-      "4d041e3765f83b548e045a2946d80df9"
+      "f99d912bf7b2cd396e2e6ce512ded86b"
     ],
     [
       "Lib.Buffer.loopi_blocks_nospec",
@@ -3421,7 +3421,7 @@
         "refinement_interpretation_Tm_refine_cfc41488cee641ca406ae764563b3947"
       ],
       0,
-      "ecd1dfcbcf6d6f74304b61bbd929e05a"
+      "66ffc0fa39414420ffa73842cbe4a76c"
     ],
     [
       "Lib.Buffer.loopi_blocks_nospec",
@@ -3502,7 +3502,7 @@
         "typing_tok_Lib.IntTypes.U32@tok"
       ],
       0,
-      "7493cb2b33e5d4f30db5e90315d30098"
+      "afc2c66db84a6ed169a9f72a3385ed6b"
     ],
     [
       "Lib.Buffer.loop_blocks_f",
@@ -3531,7 +3531,7 @@
         "typing_tok_Lib.IntTypes.PUB@tok", "typing_tok_Lib.IntTypes.U32@tok"
       ],
       0,
-      "86534e9ad826b160e7b448b7d1c7b3f4"
+      "9865d6596f92286bb1988872f9b7b987"
     ],
     [
       "Lib.Buffer.loop_blocks_f",
@@ -3551,7 +3551,7 @@
         "typing_tok_Lib.IntTypes.U32@tok"
       ],
       0,
-      "8f9ce8e9bc5ac5e8e7c5037ede2befb3"
+      "f2061fd231fcffa88a67a752006347cf"
     ],
     [
       "Lib.Buffer.loop_blocks_f",
@@ -3614,7 +3614,7 @@
         "typing_tok_Lib.IntTypes.U32@tok"
       ],
       0,
-      "5ccb10bf91d4abc3daa47c5489ffafd1"
+      "d5701109a6bfa9481f56ef8edaecf533"
     ],
     [
       "Lib.Buffer.loop_blocks",
@@ -3643,7 +3643,7 @@
         "typing_tok_Lib.IntTypes.PUB@tok", "typing_tok_Lib.IntTypes.U32@tok"
       ],
       0,
-      "3332922942a19b9c0d43a2cbe7ed14d5"
+      "3dffe4c611447e0df47d6f3567ea0cd6"
     ],
     [
       "Lib.Buffer.loop_blocks",
@@ -3670,7 +3670,7 @@
         "typing_tok_Lib.IntTypes.U32@tok"
       ],
       0,
-      "f720b761144b177cd358d38e8fa12706"
+      "f7a149f2b5ef9df9c967053c055f4f6d"
     ],
     [
       "Lib.Buffer.loop_blocks",
@@ -3760,7 +3760,7 @@
         "typing_tok_Lib.IntTypes.U32@tok"
       ],
       0,
-      "379863624cbee5fb13dc759e10a4ec1a"
+      "6a474543197791a6c8f651ef2500a403"
     ],
     [
       "Lib.Buffer.fill_blocks",
@@ -3815,7 +3815,7 @@
         "typing_tok_Lib.IntTypes.U32@tok"
       ],
       0,
-      "4f32e5f74137b9ae5cd6df31c65300e4"
+      "40f30c48a1401a4ac2c51cad628ee222"
     ],
     [
       "Lib.Buffer.fill_blocks",
@@ -3871,7 +3871,7 @@
         "typing_tok_Lib.IntTypes.PUB@tok", "typing_tok_Lib.IntTypes.U32@tok"
       ],
       0,
-      "00bd42686abcdb1f730625cda0959d89"
+      "484a626af2c9dde2303e46fc2d66d88d"
     ],
     [
       "Lib.Buffer.fill_blocks",
@@ -4009,7 +4009,7 @@
         "typing_tok_Lib.IntTypes.U32@tok"
       ],
       0,
-      "ba84a9c928db93947a6d376445fb3c4a"
+      "9e91d3c3d91dc2f7d0d7a4ef424a48a9"
     ],
     [
       "Lib.Buffer.fill_blocks_simple",
@@ -4063,7 +4063,7 @@
         "typing_tok_Lib.IntTypes.U32@tok"
       ],
       0,
-      "810caf337d42a4d4874f17df29027b32"
+      "13619e3a9cd6f1dd65070127fd061f08"
     ],
     [
       "Lib.Buffer.fill_blocks_simple",
@@ -4119,7 +4119,7 @@
         "typing_tok_Lib.IntTypes.PUB@tok", "typing_tok_Lib.IntTypes.U32@tok"
       ],
       0,
-      "3ac13c003cd3d3c6dde8aaa0cc7fd925"
+      "7da8e727b18a49414267f00b47bce3fd"
     ],
     [
       "Lib.Buffer.fill_blocks_simple",
@@ -4130,7 +4130,6 @@
         "@MaxFuel_assumption", "@MaxIFuel_assumption",
         "@fuel_correspondence_Lib.LoopCombinators.repeat_right.fuel_instrumented",
         "@fuel_correspondence_Prims.pow2.fuel_instrumented", "@query",
-        "FStar.Seq.Base_pretyping_7efa52b424e80c83ad68a652aa3561e4",
         "Lib.Buffer_interpretation_Tm_arrow_8cfc883af73dcf8257c36bc7d1380e01",
         "Lib.Buffer_interpretation_Tm_arrow_ad9685ec4c1340a135ce09610697a5f3",
         "Lib.Buffer_interpretation_Tm_arrow_cba57468f225404c3162be7bd2db736f",
@@ -4138,6 +4137,7 @@
         "Lib.Buffer_interpretation_Tm_ghost_arrow_142f4722c3d152c2125deb7d5120df83",
         "Lib.Buffer_interpretation_Tm_ghost_arrow_2d7e19da835d05e7c6aa1335402dc81e",
         "Lib.Buffer_interpretation_Tm_ghost_arrow_7d6bc7e6fba840a72dc9db3935698d51",
+        "Lib.Buffer_interpretation_Tm_ghost_arrow_8738df21a2a363c5559308029e5c4748",
         "Lib.Buffer_interpretation_Tm_ghost_arrow_920957e3e1f8835cccfc24b34a219265",
         "Lib.Buffer_interpretation_Tm_ghost_arrow_be9e7f37c07509853142cd8a6ab48455",
         "Lib.LoopCombinators_interpretation_Tm_arrow_2bf7345966baadb5d8656724dcf7cee8",
@@ -4191,6 +4191,7 @@
         "interpretation_Tm_abs_e9373a9ce27284093ddc86a320905ffa",
         "lemma_FStar.Map.lemma_ContainsDom",
         "lemma_FStar.Seq.Base.lemma_len_append",
+        "lemma_FStar.Seq.Base.lemma_len_slice",
         "lemma_FStar.Seq.Properties.slice_is_empty",
         "lemma_FStar.Seq.Properties.slice_length",
         "lemma_FStar.Seq.Properties.slice_slice",
@@ -4219,6 +4220,7 @@
         "projection_inverse_FStar.Pervasives.Native.Mktuple2__1",
         "projection_inverse_FStar.Pervasives.Native.Mktuple2__2",
         "refinement_interpretation_Tm_refine_05e15190c946858f68c69156f585f95a",
+        "refinement_interpretation_Tm_refine_0ea1fba779ad5718e28476faeef94d56",
         "refinement_interpretation_Tm_refine_198934f9ebf7e718b739cb483e272175",
         "refinement_interpretation_Tm_refine_1ba8fd8bb363097813064c67740b2de5",
         "refinement_interpretation_Tm_refine_1c4c894037978a46f04bad691f583c43",
@@ -4233,6 +4235,7 @@
         "refinement_interpretation_Tm_refine_774ba3f728d91ead8ef40be66c9802e5",
         "refinement_interpretation_Tm_refine_7990a1a36dbd0eb1e5462722ebac1239",
         "refinement_interpretation_Tm_refine_7e0b9b2dbca36eab00de093c1b701c6d",
+        "refinement_interpretation_Tm_refine_81407705a0828c2c1b1976675443f647",
         "refinement_interpretation_Tm_refine_83845a86f2550cdf941eeb1d9b59602b",
         "refinement_interpretation_Tm_refine_9d3fd79fd314167f1a9c213a188da3ec",
         "refinement_interpretation_Tm_refine_9d89bf7b57667578cd0e1f4470daef3b",
@@ -4261,9 +4264,9 @@
         "typing_FStar.Monotonic.HyperHeap.root",
         "typing_FStar.Monotonic.HyperStack.get_hmap",
         "typing_FStar.Monotonic.HyperStack.get_tip",
-        "typing_FStar.UInt.fits", "typing_FStar.UInt32.v",
-        "typing_Lib.Buffer.as_seq", "typing_Lib.Buffer.length",
-        "typing_Lib.Buffer.loc", "typing_Lib.IntTypes.minint",
+        "typing_FStar.UInt.fits", "typing_FStar.UInt32.uint_to_t",
+        "typing_FStar.UInt32.v", "typing_Lib.Buffer.as_seq",
+        "typing_Lib.Buffer.length", "typing_Lib.IntTypes.minint",
         "typing_Lib.IntTypes.mk_int", "typing_Lib.IntTypes.mul",
         "typing_Lib.IntTypes.pub_int_v", "typing_Lib.IntTypes.v",
         "typing_Lib.LoopCombinators.repeat_right",
@@ -4277,7 +4280,7 @@
         "typing_tok_Lib.IntTypes.U32@tok"
       ],
       0,
-      "0b6e60728ead493f96cc194546dca7b7"
+      "b9bde0e740ef0dce6dad4cceb53aa5f0"
     ],
     [
       "Lib.Buffer.fillT",
@@ -4302,7 +4305,7 @@
         "typing_tok_Lib.IntTypes.U32@tok"
       ],
       0,
-      "e6f100261488e07f9cacccb4dc8652f3"
+      "4121441099be1b31d91845d8af646af7"
     ],
     [
       "Lib.Buffer.fillT",
@@ -4322,7 +4325,7 @@
         "typing_tok_Lib.IntTypes.U32@tok"
       ],
       0,
-      "7cbdb1d0d00f42614c662e4521409ce2"
+      "282f2b08c964880ba1eea90b0cbd4e48"
     ],
     [
       "Lib.Buffer.fillT",
@@ -4452,7 +4455,7 @@
         "typing_tok_Lib.IntTypes.U32@tok"
       ],
       0,
-      "061628210beff8ecad803e6b571ef7a0"
+      "eb7547f91410eefe80fc5845b257fe83"
     ],
     [
       "Lib.Buffer.fill",
@@ -4499,7 +4502,7 @@
         "typing_tok_Lib.IntTypes.PUB@tok", "typing_tok_Lib.IntTypes.U32@tok"
       ],
       0,
-      "16aed365a9ef8121463cc5b0d3b4d0d0"
+      "706415ee13303add57f68f7068985910"
     ],
     [
       "Lib.Buffer.fill",
@@ -4543,7 +4546,7 @@
         "typing_tok_Lib.IntTypes.PUB@tok", "typing_tok_Lib.IntTypes.U32@tok"
       ],
       0,
-      "b5640108379ff78d73a2bcac9f8bfcbb"
+      "2a2ce2faafb839d96a3e2f649d123a50"
     ],
     [
       "Lib.Buffer.fill",
@@ -4722,7 +4725,7 @@
         "typing_tok_Lib.IntTypes.U32@tok"
       ],
       0,
-      "5abaf5bf87bee31e45b9225185cd85ae"
+      "9011d220c5c39f7013a76f4a933747e7"
     ],
     [
       "Lib.Buffer.eq_or_disjoint",
@@ -4736,7 +4739,7 @@
         "refinement_interpretation_Tm_refine_9d89bf7b57667578cd0e1f4470daef3b"
       ],
       0,
-      "83dd3d12c991ae9e7548a4f08ec0ccf4"
+      "79467a0b198fa28d42b4c5460612953a"
     ],
     [
       "Lib.Buffer.lemma_eq_disjoint",
@@ -4779,7 +4782,7 @@
         "typing_tok_Lib.IntTypes.U32@tok"
       ],
       0,
-      "cef625938c9d7d13a711d9f0e5698ed5"
+      "cfd32c03f368abb60d13605a24fd16bc"
     ],
     [
       "Lib.Buffer.lemma_eq_disjoint",
@@ -4883,7 +4886,7 @@
         "typing_tok_Lib.IntTypes.U32@tok"
       ],
       0,
-      "bbea7bfb489d2c79776c312aa92e6d70"
+      "3410781ad574eaddd9c58f4dcf5228cc"
     ],
     [
       "Lib.Buffer.mapT",
@@ -4903,7 +4906,7 @@
         "typing_tok_Lib.IntTypes.PUB@tok", "typing_tok_Lib.IntTypes.U32@tok"
       ],
       0,
-      "e1252f2655c29567c396e87e78d8300c"
+      "65560a5eac1037e9587f97b6a4926b74"
     ],
     [
       "Lib.Buffer.mapT",
@@ -4973,7 +4976,7 @@
         "typing_tok_Lib.IntTypes.U32@tok"
       ],
       0,
-      "88f752d14c4c7ead2d96ed9f9c11172b"
+      "ce896e81c4eb4bbaf76746b41987fd7d"
     ],
     [
       "Lib.Buffer.map2T",
@@ -4993,7 +4996,7 @@
         "typing_tok_Lib.IntTypes.PUB@tok", "typing_tok_Lib.IntTypes.U32@tok"
       ],
       0,
-      "8fc88c639f49dcf270c2b606f34f8f48"
+      "7296d10724671fbc87cb0a40b4e4ae1f"
     ],
     [
       "Lib.Buffer.map2T",
@@ -5068,7 +5071,7 @@
         "typing_tok_Lib.IntTypes.PUB@tok", "typing_tok_Lib.IntTypes.U32@tok"
       ],
       0,
-      "cc6fcbbc6ccca4bd34dffd368c8f229e"
+      "2661bf0b9fbf75ed299835893e69594f"
     ],
     [
       "Lib.Buffer.mapiT",
@@ -5091,7 +5094,7 @@
         "typing_tok_Lib.IntTypes.PUB@tok", "typing_tok_Lib.IntTypes.U32@tok"
       ],
       0,
-      "5a936b427bfaa286c430b90bbfacdb36"
+      "db8f5240bc0f44aed0427f2a49d37ff0"
     ],
     [
       "Lib.Buffer.mapiT",
@@ -5175,7 +5178,7 @@
         "typing_tok_Lib.IntTypes.U32@tok"
       ],
       0,
-      "91714547fe37b029d986e998a0e4ef1e"
+      "8504743d7133cf1ae29d3094bffef9f5"
     ],
     [
       "Lib.Buffer.mapi",
@@ -5200,7 +5203,7 @@
         "typing_tok_Lib.IntTypes.U32@tok"
       ],
       0,
-      "0a1d2cd327dd60fcce82ec84ecb2fce8"
+      "e6ecaffa28f05d63001b24d2d2cbe9e0"
     ],
     [
       "Lib.Buffer.mapi",
@@ -5220,7 +5223,7 @@
         "typing_tok_Lib.IntTypes.U32@tok"
       ],
       0,
-      "4a63e0875d36e0bca3bdcb5950598166"
+      "245e18812663b792dd6169f698310934"
     ],
     [
       "Lib.Buffer.mapi",
@@ -5283,7 +5286,7 @@
         "typing_tok_Lib.IntTypes.U32@tok"
       ],
       0,
-      "f8283a91f79a79869a40400fe3b2289d"
+      "cd3475a7ddb031814ed35ee0a16dc166"
     ],
     [
       "Lib.Buffer.map_blocks_multi",
@@ -5335,7 +5338,7 @@
         "typing_tok_Lib.IntTypes.U32@tok"
       ],
       0,
-      "93421d6d5f53bf05c3439fa43773c782"
+      "8fcd03ecb90973f52fe0d8b7a21e1fee"
     ],
     [
       "Lib.Buffer.map_blocks_multi",
@@ -5395,7 +5398,7 @@
         "typing_tok_Lib.IntTypes.U32@tok"
       ],
       0,
-      "98af9776d24cf29346c8af3126748717"
+      "946f173b97801b6824699a35da58479b"
     ],
     [
       "Lib.Buffer.map_blocks_multi",
@@ -5571,7 +5574,7 @@
         "typing_tok_Lib.IntTypes.U32@tok"
       ],
       0,
-      "4156ea06d4aa772568e884904541c339"
+      "247b448790fdfd2549393e4cb527b9c7"
     ],
     [
       "Lib.Buffer.div_mul_le",
@@ -5580,7 +5583,7 @@
       1,
       [ "@query" ],
       0,
-      "5fc95cf76161fbe021fc1f4d3d868dcc"
+      "827989cd890e247d9ed373baf8046d92"
     ],
     [
       "Lib.Buffer.div_mul_le",
@@ -5594,7 +5597,7 @@
         "refinement_interpretation_Tm_refine_774ba3f728d91ead8ef40be66c9802e5"
       ],
       0,
-      "8c6a3e8f33322e1efece10800835cd8f"
+      "135804f56c7b8710257e7b58200aa7af"
     ],
     [
       "Lib.Buffer.map_blocks",
@@ -5662,7 +5665,7 @@
         "typing_tok_Lib.IntTypes.U32@tok"
       ],
       0,
-      "f1bdfcbe5d59b0763217f4ec5b654284"
+      "76b2f26d12cb8d3babbf8f237b731bf0"
     ],
     [
       "Lib.Buffer.map_blocks",
@@ -5694,6 +5697,7 @@
         "equation_Lib.IntTypes.pub_int_t", "equation_Lib.IntTypes.pub_int_v",
         "equation_Lib.IntTypes.range", "equation_Lib.IntTypes.signed",
         "equation_Lib.IntTypes.unsigned", "equation_Lib.IntTypes.v",
+        "equation_LowStar.Buffer.trivial_preorder",
         "equation_LowStar.Monotonic.Buffer.length", "equation_Prims.nat",
         "function_token_typing_FStar.Monotonic.Heap.heap", "int_inversion",
         "int_typing", "lemma_FStar.Map.lemma_ContainsDom",
@@ -5702,10 +5706,9 @@
         "primitive_Prims.op_Addition", "primitive_Prims.op_AmpAmp",
         "primitive_Prims.op_Division", "primitive_Prims.op_LessThanOrEqual",
         "primitive_Prims.op_Modulus", "primitive_Prims.op_Multiply",
-        "primitive_Prims.op_Subtraction",
-        "projection_inverse_BoxBool_proj_0",
-        "projection_inverse_BoxInt_proj_0",
+        "primitive_Prims.op_Subtraction", "projection_inverse_BoxInt_proj_0",
         "refinement_interpretation_Tm_refine_05e15190c946858f68c69156f585f95a",
+        "refinement_interpretation_Tm_refine_365abba901205a01d0ef28ebf2198c47",
         "refinement_interpretation_Tm_refine_542f9d4f129664613f2483a6c88bc7c2",
         "refinement_interpretation_Tm_refine_67cf88b78b5e63b7b55064c486881669",
         "refinement_interpretation_Tm_refine_83845a86f2550cdf941eeb1d9b59602b",
@@ -5718,6 +5721,8 @@
         "refinement_interpretation_Tm_refine_f13070840248fced9d9d60d77bdae3ec",
         "refinement_interpretation_Tm_refine_fe4791f4d4a569257ab146b82811864c",
         "typing_FStar.Map.contains", "typing_FStar.Monotonic.HyperHeap.rid",
+        "typing_FStar.Monotonic.HyperHeap.rid_freeable",
+        "typing_FStar.Monotonic.HyperHeap.root",
         "typing_FStar.Monotonic.HyperStack.get_hmap",
         "typing_FStar.Monotonic.HyperStack.get_tip",
         "typing_FStar.UInt.fits", "typing_FStar.UInt32.v",
@@ -5726,7 +5731,7 @@
         "typing_tok_Lib.IntTypes.PUB@tok", "typing_tok_Lib.IntTypes.U32@tok"
       ],
       0,
-      "f85bcfbe72ae9a8ddec034bdfa348d37"
+      "bf9508492fc7936dc768543c0aba8d71"
     ],
     [
       "Lib.Buffer.map_blocks",
@@ -5894,7 +5899,7 @@
         "unit_inversion", "unit_typing"
       ],
       0,
-      "932e44d2af668309f22fee4fb17147dc"
+      "2962487d0c277eed85bb64b2934b6cf7"
     ]
   ]
 ]

--- a/lib/Lib.Buffer.fst
+++ b/lib/Lib.Buffer.fst
@@ -402,6 +402,7 @@ let fill_blocks #t h0 len n output a_spec refl footprint spec impl =
   assert(B.loc_includes (B.loc_union (footprint (v n)) (loc output)) (B.loc_union (footprint (v n)) (loc (gsub output 0ul (n *! len)))));
   assert(B.modifies (B.loc_union (footprint (v n)) (loc output)) h0 h1)
 
+#restart-solver
 #reset-options "--z3rlimit 300 --max_fuel 1"
 
 let fill_blocks_simple #a h0 bs n output spec_f impl_f =


### PR DESCRIPTION
For some reason this allowed hint regeneration to add under version control hints from mitls-fstar and kremlin.