### PR TITLE
OCaml API: Placeholders for unsupported primitives in Hacl

### DIFF
--- a/bindings/ocaml/CHANGES.md
+++ b/bindings/ocaml/CHANGES.md
@@ -1,0 +1,5 @@
+## 0.1.1
+- Support for ARM
+
+## 0.1
+The first release of the OCaml API for HACL*

--- a/bindings/ocaml/Hacl.ml
+++ b/bindings/ocaml/Hacl.ml
@@ -2,6 +2,7 @@
 
 open Unsigned
 
+open AutoConfig2
 open SharedDefs
 open SharedFunctors
 module C = CBytes
@@ -303,7 +304,6 @@ module ECDSA = struct
 end
 
 #if not (defined IS_NOT_X64) || defined IS_ARM_8
-open AutoConfig2
 module Chacha20_Poly1305_128 : Chacha20_Poly1305 =
   Make_Chacha20_Poly1305 (struct
     let reqs = [AVX]
@@ -322,10 +322,28 @@ module Blake2s_128 : Blake2 =
     let reqs = [AVX]
     let blake2s = Hacl_Blake2s_128.hacl_Blake2s_128_blake2s
   end)
+#else
+module Chacha20_Poly1305_128 : Chacha20_Poly1305 =
+  Make_Chacha20_Poly1305 (struct
+    let reqs = [AVX]
+    let encrypt _ _ _ _ _ _ = failwith "Not implemented on this platform"
+    let decrypt _ _ _ _ _ _ = failwith "Not implemented on this platform"
+  end)
+
+module Poly1305_128 : MAC =
+  Make_Poly1305 (struct
+    let reqs = [AVX]
+    let mac _ _ _ = failwith "Not implemented on this platform"
+end)
+
+module Blake2s_128 : Blake2 =
+  Make_Blake2s (struct
+    let reqs = [AVX]
+    let blake2s _ _ _ = failwith "Not implemented on this platform"
+  end)
 #endif
 
 #ifndef IS_NOT_X64
-open AutoConfig2
 module Chacha20_Poly1305_256 : Chacha20_Poly1305 =
   Make_Chacha20_Poly1305 (struct
     let reqs = [AVX2]
@@ -351,5 +369,32 @@ module Curve25519_64 : Curve25519 =
     let secret_to_public = Hacl_Curve25519_64.hacl_Curve25519_64_secret_to_public
     let scalarmult = Hacl_Curve25519_64.hacl_Curve25519_64_scalarmult
     let ecdh = Hacl_Curve25519_64.hacl_Curve25519_64_ecdh
+  end)
+#else
+module Chacha20_Poly1305_256 : Chacha20_Poly1305 =
+  Make_Chacha20_Poly1305 (struct
+     let reqs = [AVX2]
+    let encrypt _ _ _ _ _ _ = failwith "Not implemented on this platform"
+    let decrypt _ _ _ _ _ _ = failwith "Not implemented on this platform"
+  end)
+
+module Poly1305_256 : MAC =
+  Make_Poly1305 (struct
+      let reqs = [AVX2]
+    let mac _ _ _ = failwith "Not implemented on this platform"
+end)
+
+module Blake2b_256 : Blake2 =
+  Make_Blake2b (struct
+    let reqs = [AVX2]
+    let blake2b _ _ _ = failwith "Not implemented on this platform"
+  end)
+
+module Curve25519_64 : Curve25519 =
+  Make_Curve25519 (struct
+    let reqs = [BMI2; ADX]
+    let secret_to_public _ _ = failwith "Not implemented on this platform"
+    let scalarmult _ _ _ = failwith "Not implemented on this platform"
+    let ecdh _ _ _ = failwith "Not implemented on this platform"
   end)
 #endif

--- a/bindings/ocaml/Hacl.mli
+++ b/bindings/ocaml/Hacl.mli
@@ -1,5 +1,3 @@
-#include "config.h"
-
 open SharedDefs
 
 module C = CBytes
@@ -9,8 +7,11 @@ module RandomBuffer : sig
 end
 
 module Chacha20_Poly1305_32 : Chacha20_Poly1305
+module Chacha20_Poly1305_128 : Chacha20_Poly1305
+module Chacha20_Poly1305_256 : Chacha20_Poly1305
 
 module Curve25519_51 : Curve25519
+module Curve25519_64 : Curve25519
 
 module Ed25519 : EdDSA
 
@@ -37,6 +38,8 @@ module HMAC_SHA2_384 : MAC
 module HMAC_SHA2_512 : MAC
 
 module Poly1305_32 : MAC
+module Poly1305_128 : MAC
+module Poly1305_256 : MAC
 
 module HKDF_SHA2_256 : HKDF
 module HKDF_SHA2_512 : HKDF
@@ -62,23 +65,12 @@ module NaCl : sig
 end
 
 module Blake2b_32 : Blake2
+module Blake2b_256 : Blake2
 
 module Blake2s_32 : Blake2
+module Blake2s_128 : Blake2
 
 module ECDSA : sig
   val sign : C.t -> C.t -> C.t -> C.t -> bool
   val verify : C.t -> C.t -> C.t -> bool
 end
-
-#if not (defined IS_NOT_X64) || defined IS_ARM_8
-module Chacha20_Poly1305_128 : Chacha20_Poly1305
-module Poly1305_128 : MAC
-module Blake2s_128 : Blake2
-#endif
-
-#ifndef IS_NOT_X64
-module Chacha20_Poly1305_256 : Chacha20_Poly1305
-module Poly1305_256 : MAC
-module Blake2b_256 : Blake2
-module Curve25519_64 : Curve25519
-#endif

--- a/bindings/ocaml/tests/aead_test.ml
+++ b/bindings/ocaml/tests/aead_test.ml
@@ -1,5 +1,3 @@
-#include "config.h"
-
 open EverCrypt.Error
 open AutoConfig2
 
@@ -107,15 +105,8 @@ let _ =
 
   test_agile chacha20poly1305_test;
   test_nonagile chacha20poly1305_test "Hacl.Chacha20_Poly1305_32" Hacl.Chacha20_Poly1305_32.encrypt Hacl.Chacha20_Poly1305_32.decrypt [];
-
-  #if not (defined IS_NOT_X64) || defined IS_ARM_8
   test_nonagile chacha20poly1305_test "Hacl.Chacha20_Poly1305_128" Hacl.Chacha20_Poly1305_128.encrypt Hacl.Chacha20_Poly1305_128.decrypt [AVX];
-  #endif
-
-  #ifndef IS_NOT_X64
   test_nonagile chacha20poly1305_test "Hacl.Chacha20_Poly1305_256" Hacl.Chacha20_Poly1305_256.encrypt Hacl.Chacha20_Poly1305_256.decrypt [AVX2];
-  #endif
-
-  test_nonagile chacha20poly1305_test "EverCrypt.Chacha20_Poly1305" EverCrypt.Chacha20_Poly1305.encrypt EverCrypt.Chacha20_Poly1305.decrypt [];
+  test_nonagile chacha20poly1305_test "EverCrypt.Chacha20_Poly1305_256" EverCrypt.Chacha20_Poly1305.encrypt EverCrypt.Chacha20_Poly1305.decrypt [];
 
   test_random ()

--- a/bindings/ocaml/tests/blake2_test.ml
+++ b/bindings/ocaml/tests/blake2_test.ml
@@ -1,5 +1,3 @@
-#include "config.h"
-
 open Test_utils
 open AutoConfig2
 
@@ -40,13 +38,6 @@ let test (v: Bytes.t blake2_test) n hash reqs =
 
 let _ =
   List.iter (fun v -> test v "Blake2b_32" Hacl.Blake2b_32.hash []) blake2b_tests;
+  List.iter (fun v -> test v "Blake2b_256" Hacl.Blake2b_256.hash [AVX2]) blake2b_tests;
   List.iter (fun v -> test v "Blake2s_32" Hacl.Blake2s_32.hash []) blake2s_tests;
-
-  #if not (defined IS_NOT_X64) || defined IS_ARM_8
-  List.iter (fun v -> test v "Blake2s_128" Hacl.Blake2s_128.hash [AVX]) blake2s_tests;
-  #endif
-
-  #ifndef IS_NOT_X64
-  List.iter (fun v -> test v "Blake2b_256" Hacl.Blake2b_256.hash [AVX2]) blake2b_tests
-  #endif
-
+  List.iter (fun v -> test v "Blake2s_128" Hacl.Blake2s_128.hash [AVX]) blake2s_tests

--- a/bindings/ocaml/tests/curve25519_test.ml
+++ b/bindings/ocaml/tests/curve25519_test.ml
@@ -1,5 +1,3 @@
-#include "config.h"
-
 open Test_utils
 open AutoConfig2
 
@@ -42,6 +40,4 @@ let test (v: Bytes.t curve25519_test) t scalarmult ecdh reqs =
 let _ =
   List.iter (fun v -> test v "EverCrypt.Curve25519" EverCrypt.Curve25519.scalarmult EverCrypt.Curve25519.ecdh []) tests;
   List.iter (fun v -> test v "Hacl.Curve25519_51" Hacl.Curve25519_51.scalarmult Hacl.Curve25519_51.ecdh []) tests;
-  #ifndef IS_NOT_X64
   List.iter (fun v -> test v "Hacl.Curve25519_64" Hacl.Curve25519_64.scalarmult Hacl.Curve25519_64.ecdh [BMI2; ADX]) tests
-  #endif

--- a/bindings/ocaml/tests/dune
+++ b/bindings/ocaml/tests/dune
@@ -13,7 +13,7 @@
  (libraries hacl-star)
  (preprocessor_deps config.h)
  (preprocess (action (run %{bin:cppo} %{input-file})))
- (flags (:standard -open Hacl_star -warn-error -3-33)))
+ (flags (:standard -open Hacl_star -warn-error -3)))
 
 (rule (targets config.h) (deps)
  (action

--- a/bindings/ocaml/tests/poly1305_test.ml
+++ b/bindings/ocaml/tests/poly1305_test.ml
@@ -1,5 +1,3 @@
-#include "config.h"
-
 open Test_utils
 
 type 'a poly1305_test =
@@ -37,12 +35,6 @@ let test (v: Bytes.t poly1305_test) t mac reqs =
 let _ =
   List.iter validate_test tests;
   List.iter (fun v -> test v "Hacl.Poly1305_32" Hacl.Poly1305_32.mac []) tests;
-  List.iter (fun v -> test v "EverCrypt.Poly1305" EverCrypt.Poly1305.mac []) tests;
-
-  #if not (defined IS_NOT_X64) || defined IS_ARM_8
   List.iter (fun v -> test v "Hacl.Poly1305_128" Hacl.Poly1305_128.mac [AVX]) tests;
-  #endif
-
-  #ifndef IS_NOT_X64
-  List.iter (fun v -> test v "Hacl.Poly1305_256" Hacl.Poly1305_256.mac [AVX2]) tests
-  #endif
+  List.iter (fun v -> test v "Hacl.Poly1305_256" Hacl.Poly1305_256.mac [AVX2]) tests;
+  List.iter (fun v -> test v "EverCrypt.Poly1305" EverCrypt.Poly1305.mac []) tests


### PR DESCRIPTION
In order for Hacl.mli to be the same on every platform (and thus spare clients of the need to preprocess / have different code on different platforms) unsupported primitives are now replaced with placeholders rather than completely eliminated.