### PR TITLE
OCaml API: Minor build fix, new release

### DIFF
--- a/bindings/ocaml/hacl-star.opam
+++ b/bindings/ocaml/hacl-star.opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
 name: "hacl-star"
-version: "0.2.0"
+version: "0.2.1"
 maintainer: "Victor Dumitrescu <victor.dumitrescu@nomadic-labs.com>"
 authors: [ "Victor Dumitrescu <victor.dumitrescu@nomadic-labs.com>" ]
 homepage: "https://hacl-star.github.io/"

--- a/dist/META
+++ b/dist/META
@@ -1,5 +1,5 @@
 name="hacl-star-raw"
-version="0.2.0"
+version="0.2.1"
 description="EverCrypt with Ctypes bindings"
 requires="ctypes,ctypes.foreign"
 archive(native)="ocamlevercrypt.cmxa"

--- a/dist/Makefile.tmpl
+++ b/dist/Makefile.tmpl
@@ -191,7 +191,7 @@ ocamlevercrypt.cma: $(ALL_BINDINGS) $(ALL_ML_STUBS_CMO) $(CTYPES_CMO) $(ALL_C_ST
 	ocamlfind mklib -o ocamlevercrypt $(CTYPES_CMO) $(ALL_C_STUBS) -ccopt -L. -cclib -levercrypt
 
 install-hacl-star-raw: ocamlevercrypt.cmxa ocamlevercrypt.cma libevercrypt.a
-	ocamlfind install hacl-star-raw META $(CTYPES_ML) $(CTYPES_CMX) $(CTYPES_CMO) $(CTYPES_CMI) ocamlevercrypt.cma ocamlevercrypt.cmxa $(wildcard *.a *.so *.dll) config.h
+	ocamlfind install hacl-star-raw META $(CTYPES_ML) $(CTYPES_CMX) $(CTYPES_CMO) $(CTYPES_CMI) ocamlevercrypt.cma ocamlevercrypt.cmxa *.a *.$(SO) config.h
 
 endif
 endif

--- a/dist/Makefile.tmpl
+++ b/dist/Makefile.tmpl
@@ -191,7 +191,7 @@ ocamlevercrypt.cma: $(ALL_BINDINGS) $(ALL_ML_STUBS_CMO) $(CTYPES_CMO) $(ALL_C_ST
 	ocamlfind mklib -o ocamlevercrypt $(CTYPES_CMO) $(ALL_C_STUBS) -ccopt -L. -cclib -levercrypt
 
 install-hacl-star-raw: ocamlevercrypt.cmxa ocamlevercrypt.cma libevercrypt.a
-	ocamlfind install hacl-star-raw META $(CTYPES_ML) $(CTYPES_CMX) $(CTYPES_CMO) $(CTYPES_CMI) $(wildcard *.cmxa *.cma *.a *.so *.dll) config.h
+	ocamlfind install hacl-star-raw META $(CTYPES_ML) $(CTYPES_CMX) $(CTYPES_CMO) $(CTYPES_CMI) ocamlevercrypt.cma ocamlevercrypt.cmxa $(wildcard *.a *.so *.dll) config.h
 
 endif
 endif

--- a/dist/gcc-compatible/META
+++ b/dist/gcc-compatible/META
@@ -1,5 +1,5 @@
 name="hacl-star-raw"
-version="0.2.0"
+version="0.2.1"
 description="EverCrypt with Ctypes bindings"
 requires="ctypes,ctypes.foreign"
 archive(native)="ocamlevercrypt.cmxa"

--- a/dist/gcc-compatible/Makefile
+++ b/dist/gcc-compatible/Makefile
@@ -191,7 +191,7 @@ ocamlevercrypt.cma: $(ALL_BINDINGS) $(ALL_ML_STUBS_CMO) $(CTYPES_CMO) $(ALL_C_ST
 	ocamlfind mklib -o ocamlevercrypt $(CTYPES_CMO) $(ALL_C_STUBS) -ccopt -L. -cclib -levercrypt
 
 install-hacl-star-raw: ocamlevercrypt.cmxa ocamlevercrypt.cma libevercrypt.a
-	ocamlfind install hacl-star-raw META $(CTYPES_ML) $(CTYPES_CMX) $(CTYPES_CMO) $(CTYPES_CMI) ocamlevercrypt.cma ocamlevercrypt.cmxa $(wildcard *.a *.so *.dll) config.h
+	ocamlfind install hacl-star-raw META $(CTYPES_ML) $(CTYPES_CMX) $(CTYPES_CMO) $(CTYPES_CMI) ocamlevercrypt.cma ocamlevercrypt.cmxa *.a *.$(SO) config.h
 
 endif
 endif

--- a/dist/gcc-compatible/Makefile
+++ b/dist/gcc-compatible/Makefile
@@ -191,7 +191,7 @@ ocamlevercrypt.cma: $(ALL_BINDINGS) $(ALL_ML_STUBS_CMO) $(CTYPES_CMO) $(ALL_C_ST
 	ocamlfind mklib -o ocamlevercrypt $(CTYPES_CMO) $(ALL_C_STUBS) -ccopt -L. -cclib -levercrypt
 
 install-hacl-star-raw: ocamlevercrypt.cmxa ocamlevercrypt.cma libevercrypt.a
-	ocamlfind install hacl-star-raw META $(CTYPES_ML) $(CTYPES_CMX) $(CTYPES_CMO) $(CTYPES_CMI) $(wildcard *.cmxa *.cma *.a *.so *.dll) config.h
+	ocamlfind install hacl-star-raw META $(CTYPES_ML) $(CTYPES_CMX) $(CTYPES_CMO) $(CTYPES_CMI) ocamlevercrypt.cma ocamlevercrypt.cmxa $(wildcard *.a *.so *.dll) config.h
 
 endif
 endif

--- a/dist/gcc-compatible/hacl-star-raw.opam
+++ b/dist/gcc-compatible/hacl-star-raw.opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
 name: "hacl-star-raw"
-version: "0.2.0"
+version: "0.2.1"
 maintainer: "Victor Dumitrescu <victor.dumitrescu@nomadic-labs.com>"
 authors: [ "Victor Dumitrescu <victor.dumitrescu@nomadic-labs.com>" ]
 homepage: "https://hacl-star.github.io/"

--- a/dist/hacl-star-raw.opam
+++ b/dist/hacl-star-raw.opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
 name: "hacl-star-raw"
-version: "0.2.0"
+version: "0.2.1"
 maintainer: "Victor Dumitrescu <victor.dumitrescu@nomadic-labs.com>"
 authors: [ "Victor Dumitrescu <victor.dumitrescu@nomadic-labs.com>" ]
 homepage: "https://hacl-star.github.io/"

--- a/tools/Makefile.opam
+++ b/tools/Makefile.opam
@@ -23,7 +23,7 @@ prepare-raw:
 	cp -r ../dist/kremlin raw
 	sed -i 's/KREMLIN_HOME ?= ..\/kremlin/KREMLIN_HOME=kremlin/g' raw/Makefile
 	make -C raw clean
-	cd raw && rm -rf lib/*.cmx lib/*.cmi lib/*.o lib_gen/*.exe lib_gen/*.cmx lib_gen/*.cmi lib_gen/*.o libevercrypt.so ocamlevercrypt.* dllocamlevercrypt.so
+	cd raw && rm -rf lib/*.cmx lib/*.cmi lib/*.cmo lib/*.o lib_gen/*.exe lib_gen/*.cmx lib_gen/*.cmi lib_gen/*.o libocamlevercrypt.a libevercrypt.so ocamlevercrypt.* dllocamlevercrypt.so
 
 release-hacl-star: prepare-raw
 	rm -rf hacl-star && mkdir -p hacl-star


### PR DESCRIPTION
This PR fixes a small bug in the Makefile in dist/gcc-compatible which resulted in the bytecode archive not being picked up when installing `hacl-star-raw`.