### PR TITLE
Removing the use_extracted_interfaces option

### DIFF
--- a/Makefile.common
+++ b/Makefile.common
@@ -29,7 +29,6 @@ INCLUDES = \
 
 VALE_FSTAR_FLAGS=--z3cliopt smt.arith.nl=false \
   --z3cliopt smt.QI.EAGER_THRESHOLD=100 --z3cliopt smt.CASE_SPLIT=3 \
-  --use_extracted_interfaces true \
   --max_fuel 1 --max_ifuel 1 --initial_ifuel 0 \
   --smtencoding.elim_box true --smtencoding.l_arith_repr native \
   --smtencoding.nl_arith_repr wrapped


### PR DESCRIPTION
This option is not necessary and will soon be removed from F*.