### PR TITLE
ocaml bindings: fix some misquoted path

### DIFF
--- a/bindings/ocaml/dune
+++ b/bindings/ocaml/dune
@@ -9,4 +9,4 @@
 
 (rule (targets config.h) (deps)
  (action
-  (copy %{lib:hacl-star-raw:config.h} .)))
+  (bash "cp %{lib:hacl-star-raw:config.h} .")))

--- a/bindings/ocaml/dune
+++ b/bindings/ocaml/dune
@@ -9,4 +9,4 @@
 
 (rule (targets config.h) (deps)
  (action
-  (bash "cp $(ocamlfind printconf destdir)/hacl-star-raw/config.h .")))
+  (bash "cp $(ocamlfind query hacl-star-raw)/config.h .")))

--- a/bindings/ocaml/dune
+++ b/bindings/ocaml/dune
@@ -9,4 +9,4 @@
 
 (rule (targets config.h) (deps)
  (action
-  (bash "cp %{lib:hacl-star-raw:config.h} .")))
+  (bash "cp '%{lib:hacl-star-raw:config.h}' .")))

--- a/bindings/ocaml/dune
+++ b/bindings/ocaml/dune
@@ -9,4 +9,4 @@
 
 (rule (targets config.h) (deps)
  (action
-  (bash "cp %{lib:hacl-star-raw:config.h} .")))
+  (copy %{lib:hacl-star-raw:config.h} .)))

--- a/bindings/ocaml/dune
+++ b/bindings/ocaml/dune
@@ -9,4 +9,4 @@
 
 (rule (targets config.h) (deps)
  (action
-  (bash "cp '%{lib:hacl-star-raw:config.h}' .")))
+  (bash "cp $(ocamlfind printconf destdir)/hacl-star-raw/config.h .")))

--- a/bindings/ocaml/tests/dune
+++ b/bindings/ocaml/tests/dune
@@ -17,4 +17,4 @@
 
 (rule (targets config.h) (deps)
  (action
-  (bash "cp %{lib:hacl-star-raw:config.h} .")))
+  (bash "cp $(ocamlfind printconf destdir)/hacl-star-raw/config.h .")))

--- a/bindings/ocaml/tests/dune
+++ b/bindings/ocaml/tests/dune
@@ -17,4 +17,4 @@
 
 (rule (targets config.h) (deps)
  (action
-  (bash "cp $(ocamlfind printconf destdir)/hacl-star-raw/config.h .")))
+  (bash "cp $(ocamlfind query hacl-star-raw)/config.h .")))


### PR DESCRIPTION
The ocamlfind package destination directory processed by dune is passed as an argument to bash. On Windows (Cygwin), that path may be a Windows path with backslashes (\), thus we are caught into a quoting pitfall.
This pull request tries to solve this issue by having bash process the path instead of dune.
(A clean solution in the future would be to use the dune `copy` rule, but it currently does not support paths outside of the current building directory.)