### PR TITLE
Have Vale use 32-bit encoding for "xor64 r, r"

### DIFF
--- a/dist/c89-compatible/curve25519-inline.h
+++ b/dist/c89-compatible/curve25519-inline.h
@@ -10,11 +10,11 @@ static inline uint64_t add_scalar (uint64_t *out, uint64_t *f1, uint64_t f2)
 
   asm volatile(
     // Clear registers to propagate the carry bit
-    "  xor %%r8, %%r8;"
-    "  xor %%r9, %%r9;"
-    "  xor %%r10, %%r10;"
-    "  xor %%r11, %%r11;"
-    "  xor %1, %1;"
+    "  xor %%r8d, %%r8d;"
+    "  xor %%r9d, %%r9d;"
+    "  xor %%r10d, %%r10d;"
+    "  xor %%r11d, %%r11d;"
+    "  xor %k1, %k1;"
 
     // Begin addition chain
     "  addq 0(%3), %0;"
@@ -58,7 +58,7 @@ static inline void fadd (uint64_t *out, uint64_t *f1, uint64_t *f2)
     "  cmovc %0, %%rax;"
 
     // Step 2: Add carry*38 to the original sum
-    "  xor %%rcx, %%rcx;"
+    "  xor %%ecx, %%ecx;"
     "  add %%rax, %%r8;"
     "  adcx %%rcx, %%r9;"
     "  movq %%r9, 8(%1);"
@@ -131,7 +131,7 @@ static inline void fmul (uint64_t *out, uint64_t *f1, uint64_t *f2, uint64_t *tm
 
     // Compute src1[0] * src2
     "  movq 0(%1), %%rdx;"
-    "  mulxq 0(%2), %%r8, %%r9;"       "  xor %%r10, %%r10;"     "  movq %%r8, 0(%3);"
+    "  mulxq 0(%2), %%r8, %%r9;"       "  xor %%r10d, %%r10d;"     "  movq %%r8, 0(%3);"
     "  mulxq 8(%2), %%r10, %%r11;"     "  adox %%r9, %%r10;"     "  movq %%r10, 8(%3);"
     "  mulxq 16(%2), %%rbx, %%r13;"    "  adox %%r11, %%rbx;"
     "  mulxq 24(%2), %%r14, %%rdx;"    "  adox %%r13, %%r14;"    "  mov $0, %%rax;"
@@ -139,7 +139,7 @@ static inline void fmul (uint64_t *out, uint64_t *f1, uint64_t *f2, uint64_t *tm
 
     // Compute src1[1] * src2
     "  movq 8(%1), %%rdx;"
-    "  mulxq 0(%2), %%r8, %%r9;"       "  xor %%r10, %%r10;"     "  adcxq 8(%3), %%r8;"    "  movq %%r8, 8(%3);"
+    "  mulxq 0(%2), %%r8, %%r9;"       "  xor %%r10d, %%r10d;"     "  adcxq 8(%3), %%r8;"    "  movq %%r8, 8(%3);"
     "  mulxq 8(%2), %%r10, %%r11;"     "  adox %%r9, %%r10;"     "  adcx %%rbx, %%r10;"    "  movq %%r10, 16(%3);"
     "  mulxq 16(%2), %%rbx, %%r13;"    "  adox %%r11, %%rbx;"    "  adcx %%r14, %%rbx;"    "  mov $0, %%r8;"
     "  mulxq 24(%2), %%r14, %%rdx;"    "  adox %%r13, %%r14;"    "  adcx %%rax, %%r14;"    "  mov $0, %%rax;"
@@ -148,7 +148,7 @@ static inline void fmul (uint64_t *out, uint64_t *f1, uint64_t *f2, uint64_t *tm
 
     // Compute src1[2] * src2
     "  movq 16(%1), %%rdx;"
-    "  mulxq 0(%2), %%r8, %%r9;"       "  xor %%r10, %%r10;"    "  adcxq 16(%3), %%r8;"    "  movq %%r8, 16(%3);"
+    "  mulxq 0(%2), %%r8, %%r9;"       "  xor %%r10d, %%r10d;"    "  adcxq 16(%3), %%r8;"    "  movq %%r8, 16(%3);"
     "  mulxq 8(%2), %%r10, %%r11;"     "  adox %%r9, %%r10;"     "  adcx %%rbx, %%r10;"    "  movq %%r10, 24(%3);"
     "  mulxq 16(%2), %%rbx, %%r13;"    "  adox %%r11, %%rbx;"    "  adcx %%r14, %%rbx;"    "  mov $0, %%r8;"
     "  mulxq 24(%2), %%r14, %%rdx;"    "  adox %%r13, %%r14;"    "  adcx %%rax, %%r14;"    "  mov $0, %%rax;"
@@ -157,7 +157,7 @@ static inline void fmul (uint64_t *out, uint64_t *f1, uint64_t *f2, uint64_t *tm
 
     // Compute src1[3] * src2
     "  movq 24(%1), %%rdx;"
-    "  mulxq 0(%2), %%r8, %%r9;"       "  xor %%r10, %%r10;"    "  adcxq 24(%3), %%r8;"    "  movq %%r8, 24(%3);"
+    "  mulxq 0(%2), %%r8, %%r9;"       "  xor %%r10d, %%r10d;"    "  adcxq 24(%3), %%r8;"    "  movq %%r8, 24(%3);"
     "  mulxq 8(%2), %%r10, %%r11;"     "  adox %%r9, %%r10;"     "  adcx %%rbx, %%r10;"    "  movq %%r10, 32(%3);"
     "  mulxq 16(%2), %%rbx, %%r13;"    "  adox %%r11, %%rbx;"    "  adcx %%r14, %%rbx;"    "  movq %%rbx, 40(%3);"    "  mov $0, %%r8;"
     "  mulxq 24(%2), %%r14, %%rdx;"    "  adox %%r13, %%r14;"    "  adcx %%rax, %%r14;"    "  movq %%r14, 48(%3);"    "  mov $0, %%rax;"
@@ -172,7 +172,7 @@ static inline void fmul (uint64_t *out, uint64_t *f1, uint64_t *f2, uint64_t *tm
     // Step 1: Compute dst + carry == tmp_hi * 38 + tmp_lo
     "  mov $38, %%rdx;"
     "  mulxq 32(%1), %%r8, %%r13;"
-    "  xor %2, %2;"
+    "  xor %k2, %k2;"
     "  adoxq 0(%1), %%r8;"
     "  mulxq 40(%1), %%r9, %%rbx;"
     "  adcx %%r13, %%r9;"
@@ -219,7 +219,7 @@ static inline void fmul2 (uint64_t *out, uint64_t *f1, uint64_t *f2, uint64_t *t
 
     // Compute src1[0] * src2
     "  movq 0(%1), %%rdx;"
-    "  mulxq 0(%2), %%r8, %%r9;"       "  xor %%r10, %%r10;"     "  movq %%r8, 0(%3);"
+    "  mulxq 0(%2), %%r8, %%r9;"       "  xor %%r10d, %%r10d;"     "  movq %%r8, 0(%3);"
     "  mulxq 8(%2), %%r10, %%r11;"     "  adox %%r9, %%r10;"     "  movq %%r10, 8(%3);"
     "  mulxq 16(%2), %%rbx, %%r13;"    "  adox %%r11, %%rbx;"
     "  mulxq 24(%2), %%r14, %%rdx;"    "  adox %%r13, %%r14;"    "  mov $0, %%rax;"
@@ -227,7 +227,7 @@ static inline void fmul2 (uint64_t *out, uint64_t *f1, uint64_t *f2, uint64_t *t
 
     // Compute src1[1] * src2
     "  movq 8(%1), %%rdx;"
-    "  mulxq 0(%2), %%r8, %%r9;"       "  xor %%r10, %%r10;"     "  adcxq 8(%3), %%r8;"    "  movq %%r8, 8(%3);"
+    "  mulxq 0(%2), %%r8, %%r9;"       "  xor %%r10d, %%r10d;"     "  adcxq 8(%3), %%r8;"    "  movq %%r8, 8(%3);"
     "  mulxq 8(%2), %%r10, %%r11;"     "  adox %%r9, %%r10;"     "  adcx %%rbx, %%r10;"    "  movq %%r10, 16(%3);"
     "  mulxq 16(%2), %%rbx, %%r13;"    "  adox %%r11, %%rbx;"    "  adcx %%r14, %%rbx;"    "  mov $0, %%r8;"
     "  mulxq 24(%2), %%r14, %%rdx;"    "  adox %%r13, %%r14;"    "  adcx %%rax, %%r14;"    "  mov $0, %%rax;"
@@ -236,7 +236,7 @@ static inline void fmul2 (uint64_t *out, uint64_t *f1, uint64_t *f2, uint64_t *t
 
     // Compute src1[2] * src2
     "  movq 16(%1), %%rdx;"
-    "  mulxq 0(%2), %%r8, %%r9;"       "  xor %%r10, %%r10;"    "  adcxq 16(%3), %%r8;"    "  movq %%r8, 16(%3);"
+    "  mulxq 0(%2), %%r8, %%r9;"       "  xor %%r10d, %%r10d;"    "  adcxq 16(%3), %%r8;"    "  movq %%r8, 16(%3);"
     "  mulxq 8(%2), %%r10, %%r11;"     "  adox %%r9, %%r10;"     "  adcx %%rbx, %%r10;"    "  movq %%r10, 24(%3);"
     "  mulxq 16(%2), %%rbx, %%r13;"    "  adox %%r11, %%rbx;"    "  adcx %%r14, %%rbx;"    "  mov $0, %%r8;"
     "  mulxq 24(%2), %%r14, %%rdx;"    "  adox %%r13, %%r14;"    "  adcx %%rax, %%r14;"    "  mov $0, %%rax;"
@@ -245,7 +245,7 @@ static inline void fmul2 (uint64_t *out, uint64_t *f1, uint64_t *f2, uint64_t *t
 
     // Compute src1[3] * src2
     "  movq 24(%1), %%rdx;"
-    "  mulxq 0(%2), %%r8, %%r9;"       "  xor %%r10, %%r10;"    "  adcxq 24(%3), %%r8;"    "  movq %%r8, 24(%3);"
+    "  mulxq 0(%2), %%r8, %%r9;"       "  xor %%r10d, %%r10d;"    "  adcxq 24(%3), %%r8;"    "  movq %%r8, 24(%3);"
     "  mulxq 8(%2), %%r10, %%r11;"     "  adox %%r9, %%r10;"     "  adcx %%rbx, %%r10;"    "  movq %%r10, 32(%3);"
     "  mulxq 16(%2), %%rbx, %%r13;"    "  adox %%r11, %%rbx;"    "  adcx %%r14, %%rbx;"    "  movq %%rbx, 40(%3);"    "  mov $0, %%r8;"
     "  mulxq 24(%2), %%r14, %%rdx;"    "  adox %%r13, %%r14;"    "  adcx %%rax, %%r14;"    "  movq %%r14, 48(%3);"    "  mov $0, %%rax;"
@@ -255,7 +255,7 @@ static inline void fmul2 (uint64_t *out, uint64_t *f1, uint64_t *f2, uint64_t *t
 
     // Compute src1[0] * src2
     "  movq 32(%1), %%rdx;"
-    "  mulxq 32(%2), %%r8, %%r9;"       "  xor %%r10, %%r10;"     "  movq %%r8, 64(%3);"
+    "  mulxq 32(%2), %%r8, %%r9;"       "  xor %%r10d, %%r10d;"     "  movq %%r8, 64(%3);"
     "  mulxq 40(%2), %%r10, %%r11;"     "  adox %%r9, %%r10;"     "  movq %%r10, 72(%3);"
     "  mulxq 48(%2), %%rbx, %%r13;"    "  adox %%r11, %%rbx;"
     "  mulxq 56(%2), %%r14, %%rdx;"    "  adox %%r13, %%r14;"    "  mov $0, %%rax;"
@@ -263,7 +263,7 @@ static inline void fmul2 (uint64_t *out, uint64_t *f1, uint64_t *f2, uint64_t *t
 
     // Compute src1[1] * src2
     "  movq 40(%1), %%rdx;"
-    "  mulxq 32(%2), %%r8, %%r9;"       "  xor %%r10, %%r10;"     "  adcxq 72(%3), %%r8;"    "  movq %%r8, 72(%3);"
+    "  mulxq 32(%2), %%r8, %%r9;"       "  xor %%r10d, %%r10d;"     "  adcxq 72(%3), %%r8;"    "  movq %%r8, 72(%3);"
     "  mulxq 40(%2), %%r10, %%r11;"     "  adox %%r9, %%r10;"     "  adcx %%rbx, %%r10;"    "  movq %%r10, 80(%3);"
     "  mulxq 48(%2), %%rbx, %%r13;"    "  adox %%r11, %%rbx;"    "  adcx %%r14, %%rbx;"    "  mov $0, %%r8;"
     "  mulxq 56(%2), %%r14, %%rdx;"    "  adox %%r13, %%r14;"    "  adcx %%rax, %%r14;"    "  mov $0, %%rax;"
@@ -272,7 +272,7 @@ static inline void fmul2 (uint64_t *out, uint64_t *f1, uint64_t *f2, uint64_t *t
 
     // Compute src1[2] * src2
     "  movq 48(%1), %%rdx;"
-    "  mulxq 32(%2), %%r8, %%r9;"       "  xor %%r10, %%r10;"    "  adcxq 80(%3), %%r8;"    "  movq %%r8, 80(%3);"
+    "  mulxq 32(%2), %%r8, %%r9;"       "  xor %%r10d, %%r10d;"    "  adcxq 80(%3), %%r8;"    "  movq %%r8, 80(%3);"
     "  mulxq 40(%2), %%r10, %%r11;"     "  adox %%r9, %%r10;"     "  adcx %%rbx, %%r10;"    "  movq %%r10, 88(%3);"
     "  mulxq 48(%2), %%rbx, %%r13;"    "  adox %%r11, %%rbx;"    "  adcx %%r14, %%rbx;"    "  mov $0, %%r8;"
     "  mulxq 56(%2), %%r14, %%rdx;"    "  adox %%r13, %%r14;"    "  adcx %%rax, %%r14;"    "  mov $0, %%rax;"
@@ -281,7 +281,7 @@ static inline void fmul2 (uint64_t *out, uint64_t *f1, uint64_t *f2, uint64_t *t
 
     // Compute src1[3] * src2
     "  movq 56(%1), %%rdx;"
-    "  mulxq 32(%2), %%r8, %%r9;"       "  xor %%r10, %%r10;"    "  adcxq 88(%3), %%r8;"    "  movq %%r8, 88(%3);"
+    "  mulxq 32(%2), %%r8, %%r9;"       "  xor %%r10d, %%r10d;"    "  adcxq 88(%3), %%r8;"    "  movq %%r8, 88(%3);"
     "  mulxq 40(%2), %%r10, %%r11;"     "  adox %%r9, %%r10;"     "  adcx %%rbx, %%r10;"    "  movq %%r10, 96(%3);"
     "  mulxq 48(%2), %%rbx, %%r13;"    "  adox %%r11, %%rbx;"    "  adcx %%r14, %%rbx;"    "  movq %%rbx, 104(%3);"    "  mov $0, %%r8;"
     "  mulxq 56(%2), %%r14, %%rdx;"    "  adox %%r13, %%r14;"    "  adcx %%rax, %%r14;"    "  movq %%r14, 112(%3);"    "  mov $0, %%rax;"
@@ -296,7 +296,7 @@ static inline void fmul2 (uint64_t *out, uint64_t *f1, uint64_t *f2, uint64_t *t
     // Step 1: Compute dst + carry == tmp_hi * 38 + tmp_lo
     "  mov $38, %%rdx;"
     "  mulxq 32(%1), %%r8, %%r13;"
-    "  xor %2, %2;"
+    "  xor %k2, %k2;"
     "  adoxq 0(%1), %%r8;"
     "  mulxq 40(%1), %%r9, %%rbx;"
     "  adcx %%r13, %%r9;"
@@ -329,7 +329,7 @@ static inline void fmul2 (uint64_t *out, uint64_t *f1, uint64_t *f2, uint64_t *t
     // Step 1: Compute dst + carry == tmp_hi * 38 + tmp_lo
     "  mov $38, %%rdx;"
     "  mulxq 96(%1), %%r8, %%r13;"
-    "  xor %2, %2;"
+    "  xor %k2, %k2;"
     "  adoxq 64(%1), %%r8;"
     "  mulxq 104(%1), %%r9, %%rbx;"
     "  adcx %%r13, %%r9;"
@@ -502,7 +502,7 @@ static inline void fsqr (uint64_t *out, uint64_t *f, uint64_t *tmp)
 
     // Step 1: Compute all partial products
     "  movq 0(%1), %%rdx;"                                       // f[0]
-    "  mulxq 8(%1), %%r8, %%r14;"      "  xor %%r15, %%r15;"     // f[1]*f[0]
+    "  mulxq 8(%1), %%r8, %%r14;"      "  xor %%r15d, %%r15d;"     // f[1]*f[0]
     "  mulxq 16(%1), %%r9, %%r10;"     "  adcx %%r14, %%r9;"     // f[2]*f[0]
     "  mulxq 24(%1), %%rax, %%rcx;"    "  adcx %%rax, %%r10;"    // f[3]*f[0]
     "  movq 24(%1), %%rdx;"                                      // f[3]
@@ -512,7 +512,7 @@ static inline void fsqr (uint64_t *out, uint64_t *f, uint64_t *tmp)
     "  mulxq 16(%1), %%rax, %%rcx;"    "  mov $0, %%r14;"        // f[2]*f[1]
 
     // Step 2: Compute two parallel carry chains
-    "  xor %%r15, %%r15;"
+    "  xor %%r15d, %%r15d;"
     "  adox %%rax, %%r10;"
     "  adcx %%r8, %%r8;"
     "  adox %%rcx, %%r11;"
@@ -549,7 +549,7 @@ static inline void fsqr (uint64_t *out, uint64_t *f, uint64_t *tmp)
     // Step 1: Compute dst + carry == tmp_hi * 38 + tmp_lo
     "  mov $38, %%rdx;"
     "  mulxq 32(%1), %%r8, %%r13;"
-    "  xor %%rcx, %%rcx;"
+    "  xor %%ecx, %%ecx;"
     "  adoxq 0(%1), %%r8;"
     "  mulxq 40(%1), %%r9, %%rbx;"
     "  adcx %%r13, %%r9;"
@@ -593,7 +593,7 @@ static inline void fsqr2 (uint64_t *out, uint64_t *f, uint64_t *tmp)
   asm volatile(
     // Step 1: Compute all partial products
     "  movq 0(%1), %%rdx;"                                       // f[0]
-    "  mulxq 8(%1), %%r8, %%r14;"      "  xor %%r15, %%r15;"     // f[1]*f[0]
+    "  mulxq 8(%1), %%r8, %%r14;"      "  xor %%r15d, %%r15d;"     // f[1]*f[0]
     "  mulxq 16(%1), %%r9, %%r10;"     "  adcx %%r14, %%r9;"     // f[2]*f[0]
     "  mulxq 24(%1), %%rax, %%rcx;"    "  adcx %%rax, %%r10;"    // f[3]*f[0]
     "  movq 24(%1), %%rdx;"                                      // f[3]
@@ -603,7 +603,7 @@ static inline void fsqr2 (uint64_t *out, uint64_t *f, uint64_t *tmp)
     "  mulxq 16(%1), %%rax, %%rcx;"    "  mov $0, %%r14;"        // f[2]*f[1]
 
     // Step 2: Compute two parallel carry chains
-    "  xor %%r15, %%r15;"
+    "  xor %%r15d, %%r15d;"
     "  adox %%rax, %%r10;"
     "  adcx %%r8, %%r8;"
     "  adox %%rcx, %%r11;"
@@ -633,7 +633,7 @@ static inline void fsqr2 (uint64_t *out, uint64_t *f, uint64_t *tmp)
 
     // Step 1: Compute all partial products
     "  movq 32(%1), %%rdx;"                                       // f[0]
-    "  mulxq 40(%1), %%r8, %%r14;"      "  xor %%r15, %%r15;"     // f[1]*f[0]
+    "  mulxq 40(%1), %%r8, %%r14;"      "  xor %%r15d, %%r15d;"     // f[1]*f[0]
     "  mulxq 48(%1), %%r9, %%r10;"     "  adcx %%r14, %%r9;"     // f[2]*f[0]
     "  mulxq 56(%1), %%rax, %%rcx;"    "  adcx %%rax, %%r10;"    // f[3]*f[0]
     "  movq 56(%1), %%rdx;"                                      // f[3]
@@ -643,7 +643,7 @@ static inline void fsqr2 (uint64_t *out, uint64_t *f, uint64_t *tmp)
     "  mulxq 48(%1), %%rax, %%rcx;"    "  mov $0, %%r14;"        // f[2]*f[1]
 
     // Step 2: Compute two parallel carry chains
-    "  xor %%r15, %%r15;"
+    "  xor %%r15d, %%r15d;"
     "  adox %%rax, %%r10;"
     "  adcx %%r8, %%r8;"
     "  adox %%rcx, %%r11;"
@@ -678,7 +678,7 @@ static inline void fsqr2 (uint64_t *out, uint64_t *f, uint64_t *tmp)
     // Step 1: Compute dst + carry == tmp_hi * 38 + tmp_lo
     "  mov $38, %%rdx;"
     "  mulxq 32(%1), %%r8, %%r13;"
-    "  xor %%rcx, %%rcx;"
+    "  xor %%ecx, %%ecx;"
     "  adoxq 0(%1), %%r8;"
     "  mulxq 40(%1), %%r9, %%rbx;"
     "  adcx %%r13, %%r9;"
@@ -711,7 +711,7 @@ static inline void fsqr2 (uint64_t *out, uint64_t *f, uint64_t *tmp)
     // Step 1: Compute dst + carry == tmp_hi * 38 + tmp_lo
     "  mov $38, %%rdx;"
     "  mulxq 96(%1), %%r8, %%r13;"
-    "  xor %%rcx, %%rcx;"
+    "  xor %%ecx, %%ecx;"
     "  adoxq 64(%1), %%r8;"
     "  mulxq 104(%1), %%r9, %%rbx;"
     "  adcx %%r13, %%r9;"

--- a/dist/c89-compatible/curve25519-x86_64-darwin.S
+++ b/dist/c89-compatible/curve25519-x86_64-darwin.S
@@ -4,11 +4,11 @@ _add_scalar_e:
   push %rdi
   push %rsi
   ;# Clear registers to propagate the carry bit
-  xor %r8, %r8
-  xor %r9, %r9
-  xor %r10, %r10
-  xor %r11, %r11
-  xor %rax, %rax
+  xor %r8d, %r8d
+  xor %r9d, %r9d
+  xor %r10d, %r10d
+  xor %r11d, %r11d
+  xor %eax, %eax
   
   ;# Begin addition chain
   addq 0(%rsi), %rdx
@@ -44,7 +44,7 @@ _fadd_e:
   cmovc %rdx, %rax
   
   ;# Step 2: Add carry*38 to the original sum
-  xor %rcx, %rcx
+  xor %ecx, %ecx
   add %rax, %r8
   adcx %rcx, %r9
   movq %r9, 8(%rdi)
@@ -149,7 +149,7 @@ _fmul_e:
   ;# Compute src1[0] * src2
   movq 0(%rsi), %rdx
   mulxq 0(%rcx), %r8, %r9
-  xor %r10, %r10
+  xor %r10d, %r10d
   movq %r8, 0(%rdi)
   
   mulxq 8(%rcx), %r10, %r11
@@ -167,7 +167,7 @@ _fmul_e:
   ;# Compute src1[1] * src2
   movq 8(%rsi), %rdx
   mulxq 0(%rcx), %r8, %r9
-  xor %r10, %r10
+  xor %r10d, %r10d
   adcxq 8(%rdi), %r8
   movq %r8, 8(%rdi)
   mulxq 8(%rcx), %r10, %r11
@@ -189,7 +189,7 @@ _fmul_e:
   ;# Compute src1[2] * src2
   movq 16(%rsi), %rdx
   mulxq 0(%rcx), %r8, %r9
-  xor %r10, %r10
+  xor %r10d, %r10d
   adcxq 16(%rdi), %r8
   movq %r8, 16(%rdi)
   mulxq 8(%rcx), %r10, %r11
@@ -211,7 +211,7 @@ _fmul_e:
   ;# Compute src1[3] * src2
   movq 24(%rsi), %rdx
   mulxq 0(%rcx), %r8, %r9
-  xor %r10, %r10
+  xor %r10d, %r10d
   adcxq 24(%rdi), %r8
   movq %r8, 24(%rdi)
   mulxq 8(%rcx), %r10, %r11
@@ -240,7 +240,7 @@ _fmul_e:
   ;# Step 1: Compute dst + carry == tmp_hi * 38 + tmp_lo
   mov $38, %rdx
   mulxq 32(%rsi), %r8, %r13
-  xor %rcx, %rcx
+  xor %ecx, %ecx
   adoxq 0(%rsi), %r8
   mulxq 40(%rsi), %r9, %rbx
   adcx %r13, %r9
@@ -286,7 +286,7 @@ _fmul2_e:
   ;# Compute src1[0] * src2
   movq 0(%rsi), %rdx
   mulxq 0(%rcx), %r8, %r9
-  xor %r10, %r10
+  xor %r10d, %r10d
   movq %r8, 0(%rdi)
   
   mulxq 8(%rcx), %r10, %r11
@@ -304,7 +304,7 @@ _fmul2_e:
   ;# Compute src1[1] * src2
   movq 8(%rsi), %rdx
   mulxq 0(%rcx), %r8, %r9
-  xor %r10, %r10
+  xor %r10d, %r10d
   adcxq 8(%rdi), %r8
   movq %r8, 8(%rdi)
   mulxq 8(%rcx), %r10, %r11
@@ -326,7 +326,7 @@ _fmul2_e:
   ;# Compute src1[2] * src2
   movq 16(%rsi), %rdx
   mulxq 0(%rcx), %r8, %r9
-  xor %r10, %r10
+  xor %r10d, %r10d
   adcxq 16(%rdi), %r8
   movq %r8, 16(%rdi)
   mulxq 8(%rcx), %r10, %r11
@@ -348,7 +348,7 @@ _fmul2_e:
   ;# Compute src1[3] * src2
   movq 24(%rsi), %rdx
   mulxq 0(%rcx), %r8, %r9
-  xor %r10, %r10
+  xor %r10d, %r10d
   adcxq 24(%rdi), %r8
   movq %r8, 24(%rdi)
   mulxq 8(%rcx), %r10, %r11
@@ -373,7 +373,7 @@ _fmul2_e:
   ;# Compute src1[0] * src2
   movq 32(%rsi), %rdx
   mulxq 32(%rcx), %r8, %r9
-  xor %r10, %r10
+  xor %r10d, %r10d
   movq %r8, 64(%rdi)
   
   mulxq 40(%rcx), %r10, %r11
@@ -391,7 +391,7 @@ _fmul2_e:
   ;# Compute src1[1] * src2
   movq 40(%rsi), %rdx
   mulxq 32(%rcx), %r8, %r9
-  xor %r10, %r10
+  xor %r10d, %r10d
   adcxq 72(%rdi), %r8
   movq %r8, 72(%rdi)
   mulxq 40(%rcx), %r10, %r11
@@ -413,7 +413,7 @@ _fmul2_e:
   ;# Compute src1[2] * src2
   movq 48(%rsi), %rdx
   mulxq 32(%rcx), %r8, %r9
-  xor %r10, %r10
+  xor %r10d, %r10d
   adcxq 80(%rdi), %r8
   movq %r8, 80(%rdi)
   mulxq 40(%rcx), %r10, %r11
@@ -435,7 +435,7 @@ _fmul2_e:
   ;# Compute src1[3] * src2
   movq 56(%rsi), %rdx
   mulxq 32(%rcx), %r8, %r9
-  xor %r10, %r10
+  xor %r10d, %r10d
   adcxq 88(%rdi), %r8
   movq %r8, 88(%rdi)
   mulxq 40(%rcx), %r10, %r11
@@ -464,7 +464,7 @@ _fmul2_e:
   ;# Step 1: Compute dst + carry == tmp_hi * 38 + tmp_lo
   mov $38, %rdx
   mulxq 32(%rsi), %r8, %r13
-  xor %rcx, %rcx
+  xor %ecx, %ecx
   adoxq 0(%rsi), %r8
   mulxq 40(%rsi), %r9, %rbx
   adcx %r13, %r9
@@ -497,7 +497,7 @@ _fmul2_e:
   ;# Step 1: Compute dst + carry == tmp_hi * 38 + tmp_lo
   mov $38, %rdx
   mulxq 96(%rsi), %r8, %r13
-  xor %rcx, %rcx
+  xor %ecx, %ecx
   adoxq 64(%rsi), %r8
   mulxq 104(%rsi), %r9, %rbx
   adcx %r13, %r9
@@ -545,7 +545,7 @@ _fsqr_e:
   movq 0(%rsi), %rdx
   ;# f[0]
   mulxq 8(%rsi), %r8, %r14
-  xor %r15, %r15
+  xor %r15d, %r15d
   ;# f[1]*f[0]
   mulxq 16(%rsi), %r9, %r10
   adcx %r14, %r9
@@ -569,7 +569,7 @@ _fsqr_e:
   ;# f[2]*f[1]
   
   ;# Step 2: Compute two parallel carry chains
-  xor %r15, %r15
+  xor %r15d, %r15d
   adox %rax, %r10
   adcx %r8, %r8
   adox %rcx, %r11
@@ -627,7 +627,7 @@ _fsqr_e:
   ;# Step 1: Compute dst + carry == tmp_hi * 38 + tmp_lo
   mov $38, %rdx
   mulxq 32(%rsi), %r8, %r13
-  xor %rcx, %rcx
+  xor %ecx, %ecx
   adoxq 0(%rsi), %r8
   mulxq 40(%rsi), %r9, %rbx
   adcx %r13, %r9
@@ -675,7 +675,7 @@ _fsqr2_e:
   movq 0(%rsi), %rdx
   ;# f[0]
   mulxq 8(%rsi), %r8, %r14
-  xor %r15, %r15
+  xor %r15d, %r15d
   ;# f[1]*f[0]
   mulxq 16(%rsi), %r9, %r10
   adcx %r14, %r9
@@ -699,7 +699,7 @@ _fsqr2_e:
   ;# f[2]*f[1]
   
   ;# Step 2: Compute two parallel carry chains
-  xor %r15, %r15
+  xor %r15d, %r15d
   adox %rax, %r10
   adcx %r8, %r8
   adox %rcx, %r11
@@ -754,7 +754,7 @@ _fsqr2_e:
   movq 32(%rsi), %rdx
   ;# f[0]
   mulxq 40(%rsi), %r8, %r14
-  xor %r15, %r15
+  xor %r15d, %r15d
   ;# f[1]*f[0]
   mulxq 48(%rsi), %r9, %r10
   adcx %r14, %r9
@@ -778,7 +778,7 @@ _fsqr2_e:
   ;# f[2]*f[1]
   
   ;# Step 2: Compute two parallel carry chains
-  xor %r15, %r15
+  xor %r15d, %r15d
   adox %rax, %r10
   adcx %r8, %r8
   adox %rcx, %r11
@@ -836,7 +836,7 @@ _fsqr2_e:
   ;# Step 1: Compute dst + carry == tmp_hi * 38 + tmp_lo
   mov $38, %rdx
   mulxq 32(%rsi), %r8, %r13
-  xor %rcx, %rcx
+  xor %ecx, %ecx
   adoxq 0(%rsi), %r8
   mulxq 40(%rsi), %r9, %rbx
   adcx %r13, %r9
@@ -869,7 +869,7 @@ _fsqr2_e:
   ;# Step 1: Compute dst + carry == tmp_hi * 38 + tmp_lo
   mov $38, %rdx
   mulxq 96(%rsi), %r8, %r13
-  xor %rcx, %rcx
+  xor %ecx, %ecx
   adoxq 64(%rsi), %r8
   mulxq 104(%rsi), %r9, %rbx
   adcx %r13, %r9

--- a/dist/c89-compatible/curve25519-x86_64-linux.S
+++ b/dist/c89-compatible/curve25519-x86_64-linux.S
@@ -4,11 +4,11 @@ add_scalar_e:
   push %rdi
   push %rsi
   ;# Clear registers to propagate the carry bit
-  xor %r8, %r8
-  xor %r9, %r9
-  xor %r10, %r10
-  xor %r11, %r11
-  xor %rax, %rax
+  xor %r8d, %r8d
+  xor %r9d, %r9d
+  xor %r10d, %r10d
+  xor %r11d, %r11d
+  xor %eax, %eax
   
   ;# Begin addition chain
   addq 0(%rsi), %rdx
@@ -44,7 +44,7 @@ fadd_e:
   cmovc %rdx, %rax
   
   ;# Step 2: Add carry*38 to the original sum
-  xor %rcx, %rcx
+  xor %ecx, %ecx
   add %rax, %r8
   adcx %rcx, %r9
   movq %r9, 8(%rdi)
@@ -149,7 +149,7 @@ fmul_e:
   ;# Compute src1[0] * src2
   movq 0(%rsi), %rdx
   mulxq 0(%rcx), %r8, %r9
-  xor %r10, %r10
+  xor %r10d, %r10d
   movq %r8, 0(%rdi)
   
   mulxq 8(%rcx), %r10, %r11
@@ -167,7 +167,7 @@ fmul_e:
   ;# Compute src1[1] * src2
   movq 8(%rsi), %rdx
   mulxq 0(%rcx), %r8, %r9
-  xor %r10, %r10
+  xor %r10d, %r10d
   adcxq 8(%rdi), %r8
   movq %r8, 8(%rdi)
   mulxq 8(%rcx), %r10, %r11
@@ -189,7 +189,7 @@ fmul_e:
   ;# Compute src1[2] * src2
   movq 16(%rsi), %rdx
   mulxq 0(%rcx), %r8, %r9
-  xor %r10, %r10
+  xor %r10d, %r10d
   adcxq 16(%rdi), %r8
   movq %r8, 16(%rdi)
   mulxq 8(%rcx), %r10, %r11
@@ -211,7 +211,7 @@ fmul_e:
   ;# Compute src1[3] * src2
   movq 24(%rsi), %rdx
   mulxq 0(%rcx), %r8, %r9
-  xor %r10, %r10
+  xor %r10d, %r10d
   adcxq 24(%rdi), %r8
   movq %r8, 24(%rdi)
   mulxq 8(%rcx), %r10, %r11
@@ -240,7 +240,7 @@ fmul_e:
   ;# Step 1: Compute dst + carry == tmp_hi * 38 + tmp_lo
   mov $38, %rdx
   mulxq 32(%rsi), %r8, %r13
-  xor %rcx, %rcx
+  xor %ecx, %ecx
   adoxq 0(%rsi), %r8
   mulxq 40(%rsi), %r9, %rbx
   adcx %r13, %r9
@@ -286,7 +286,7 @@ fmul2_e:
   ;# Compute src1[0] * src2
   movq 0(%rsi), %rdx
   mulxq 0(%rcx), %r8, %r9
-  xor %r10, %r10
+  xor %r10d, %r10d
   movq %r8, 0(%rdi)
   
   mulxq 8(%rcx), %r10, %r11
@@ -304,7 +304,7 @@ fmul2_e:
   ;# Compute src1[1] * src2
   movq 8(%rsi), %rdx
   mulxq 0(%rcx), %r8, %r9
-  xor %r10, %r10
+  xor %r10d, %r10d
   adcxq 8(%rdi), %r8
   movq %r8, 8(%rdi)
   mulxq 8(%rcx), %r10, %r11
@@ -326,7 +326,7 @@ fmul2_e:
   ;# Compute src1[2] * src2
   movq 16(%rsi), %rdx
   mulxq 0(%rcx), %r8, %r9
-  xor %r10, %r10
+  xor %r10d, %r10d
   adcxq 16(%rdi), %r8
   movq %r8, 16(%rdi)
   mulxq 8(%rcx), %r10, %r11
@@ -348,7 +348,7 @@ fmul2_e:
   ;# Compute src1[3] * src2
   movq 24(%rsi), %rdx
   mulxq 0(%rcx), %r8, %r9
-  xor %r10, %r10
+  xor %r10d, %r10d
   adcxq 24(%rdi), %r8
   movq %r8, 24(%rdi)
   mulxq 8(%rcx), %r10, %r11
@@ -373,7 +373,7 @@ fmul2_e:
   ;# Compute src1[0] * src2
   movq 32(%rsi), %rdx
   mulxq 32(%rcx), %r8, %r9
-  xor %r10, %r10
+  xor %r10d, %r10d
   movq %r8, 64(%rdi)
   
   mulxq 40(%rcx), %r10, %r11
@@ -391,7 +391,7 @@ fmul2_e:
   ;# Compute src1[1] * src2
   movq 40(%rsi), %rdx
   mulxq 32(%rcx), %r8, %r9
-  xor %r10, %r10
+  xor %r10d, %r10d
   adcxq 72(%rdi), %r8
   movq %r8, 72(%rdi)
   mulxq 40(%rcx), %r10, %r11
@@ -413,7 +413,7 @@ fmul2_e:
   ;# Compute src1[2] * src2
   movq 48(%rsi), %rdx
   mulxq 32(%rcx), %r8, %r9
-  xor %r10, %r10
+  xor %r10d, %r10d
   adcxq 80(%rdi), %r8
   movq %r8, 80(%rdi)
   mulxq 40(%rcx), %r10, %r11
@@ -435,7 +435,7 @@ fmul2_e:
   ;# Compute src1[3] * src2
   movq 56(%rsi), %rdx
   mulxq 32(%rcx), %r8, %r9
-  xor %r10, %r10
+  xor %r10d, %r10d
   adcxq 88(%rdi), %r8
   movq %r8, 88(%rdi)
   mulxq 40(%rcx), %r10, %r11
@@ -464,7 +464,7 @@ fmul2_e:
   ;# Step 1: Compute dst + carry == tmp_hi * 38 + tmp_lo
   mov $38, %rdx
   mulxq 32(%rsi), %r8, %r13
-  xor %rcx, %rcx
+  xor %ecx, %ecx
   adoxq 0(%rsi), %r8
   mulxq 40(%rsi), %r9, %rbx
   adcx %r13, %r9
@@ -497,7 +497,7 @@ fmul2_e:
   ;# Step 1: Compute dst + carry == tmp_hi * 38 + tmp_lo
   mov $38, %rdx
   mulxq 96(%rsi), %r8, %r13
-  xor %rcx, %rcx
+  xor %ecx, %ecx
   adoxq 64(%rsi), %r8
   mulxq 104(%rsi), %r9, %rbx
   adcx %r13, %r9
@@ -545,7 +545,7 @@ fsqr_e:
   movq 0(%rsi), %rdx
   ;# f[0]
   mulxq 8(%rsi), %r8, %r14
-  xor %r15, %r15
+  xor %r15d, %r15d
   ;# f[1]*f[0]
   mulxq 16(%rsi), %r9, %r10
   adcx %r14, %r9
@@ -569,7 +569,7 @@ fsqr_e:
   ;# f[2]*f[1]
   
   ;# Step 2: Compute two parallel carry chains
-  xor %r15, %r15
+  xor %r15d, %r15d
   adox %rax, %r10
   adcx %r8, %r8
   adox %rcx, %r11
@@ -627,7 +627,7 @@ fsqr_e:
   ;# Step 1: Compute dst + carry == tmp_hi * 38 + tmp_lo
   mov $38, %rdx
   mulxq 32(%rsi), %r8, %r13
-  xor %rcx, %rcx
+  xor %ecx, %ecx
   adoxq 0(%rsi), %r8
   mulxq 40(%rsi), %r9, %rbx
   adcx %r13, %r9
@@ -675,7 +675,7 @@ fsqr2_e:
   movq 0(%rsi), %rdx
   ;# f[0]
   mulxq 8(%rsi), %r8, %r14
-  xor %r15, %r15
+  xor %r15d, %r15d
   ;# f[1]*f[0]
   mulxq 16(%rsi), %r9, %r10
   adcx %r14, %r9
@@ -699,7 +699,7 @@ fsqr2_e:
   ;# f[2]*f[1]
   
   ;# Step 2: Compute two parallel carry chains
-  xor %r15, %r15
+  xor %r15d, %r15d
   adox %rax, %r10
   adcx %r8, %r8
   adox %rcx, %r11
@@ -754,7 +754,7 @@ fsqr2_e:
   movq 32(%rsi), %rdx
   ;# f[0]
   mulxq 40(%rsi), %r8, %r14
-  xor %r15, %r15
+  xor %r15d, %r15d
   ;# f[1]*f[0]
   mulxq 48(%rsi), %r9, %r10
   adcx %r14, %r9
@@ -778,7 +778,7 @@ fsqr2_e:
   ;# f[2]*f[1]
   
   ;# Step 2: Compute two parallel carry chains
-  xor %r15, %r15
+  xor %r15d, %r15d
   adox %rax, %r10
   adcx %r8, %r8
   adox %rcx, %r11
@@ -836,7 +836,7 @@ fsqr2_e:
   ;# Step 1: Compute dst + carry == tmp_hi * 38 + tmp_lo
   mov $38, %rdx
   mulxq 32(%rsi), %r8, %r13
-  xor %rcx, %rcx
+  xor %ecx, %ecx
   adoxq 0(%rsi), %r8
   mulxq 40(%rsi), %r9, %rbx
   adcx %r13, %r9
@@ -869,7 +869,7 @@ fsqr2_e:
   ;# Step 1: Compute dst + carry == tmp_hi * 38 + tmp_lo
   mov $38, %rdx
   mulxq 96(%rsi), %r8, %r13
-  xor %rcx, %rcx
+  xor %ecx, %ecx
   adoxq 64(%rsi), %r8
   mulxq 104(%rsi), %r9, %rbx
   adcx %r13, %r9

--- a/dist/c89-compatible/curve25519-x86_64-mingw.S
+++ b/dist/c89-compatible/curve25519-x86_64-mingw.S
@@ -7,11 +7,11 @@ add_scalar_e:
   mov %rdx, %rsi
   mov %r8, %rdx
   ;# Clear registers to propagate the carry bit
-  xor %r8, %r8
-  xor %r9, %r9
-  xor %r10, %r10
-  xor %r11, %r11
-  xor %rax, %rax
+  xor %r8d, %r8d
+  xor %r9d, %r9d
+  xor %r10d, %r10d
+  xor %r11d, %r11d
+  xor %eax, %eax
   
   ;# Begin addition chain
   addq 0(%rsi), %rdx
@@ -52,7 +52,7 @@ fadd_e:
   cmovc %rdx, %rax
   
   ;# Step 2: Add carry*38 to the original sum
-  xor %rcx, %rcx
+  xor %ecx, %ecx
   add %rax, %r8
   adcx %rcx, %r9
   movq %r9, 8(%rdi)
@@ -176,7 +176,7 @@ fmul_e:
   ;# Compute src1[0] * src2
   movq 0(%rsi), %rdx
   mulxq 0(%rcx), %r8, %r9
-  xor %r10, %r10
+  xor %r10d, %r10d
   movq %r8, 0(%rdi)
   
   mulxq 8(%rcx), %r10, %r11
@@ -194,7 +194,7 @@ fmul_e:
   ;# Compute src1[1] * src2
   movq 8(%rsi), %rdx
   mulxq 0(%rcx), %r8, %r9
-  xor %r10, %r10
+  xor %r10d, %r10d
   adcxq 8(%rdi), %r8
   movq %r8, 8(%rdi)
   mulxq 8(%rcx), %r10, %r11
@@ -216,7 +216,7 @@ fmul_e:
   ;# Compute src1[2] * src2
   movq 16(%rsi), %rdx
   mulxq 0(%rcx), %r8, %r9
-  xor %r10, %r10
+  xor %r10d, %r10d
   adcxq 16(%rdi), %r8
   movq %r8, 16(%rdi)
   mulxq 8(%rcx), %r10, %r11
@@ -238,7 +238,7 @@ fmul_e:
   ;# Compute src1[3] * src2
   movq 24(%rsi), %rdx
   mulxq 0(%rcx), %r8, %r9
-  xor %r10, %r10
+  xor %r10d, %r10d
   adcxq 24(%rdi), %r8
   movq %r8, 24(%rdi)
   mulxq 8(%rcx), %r10, %r11
@@ -267,7 +267,7 @@ fmul_e:
   ;# Step 1: Compute dst + carry == tmp_hi * 38 + tmp_lo
   mov $38, %rdx
   mulxq 32(%rsi), %r8, %r13
-  xor %rcx, %rcx
+  xor %ecx, %ecx
   adoxq 0(%rsi), %r8
   mulxq 40(%rsi), %r9, %rbx
   adcx %r13, %r9
@@ -320,7 +320,7 @@ fmul2_e:
   ;# Compute src1[0] * src2
   movq 0(%rsi), %rdx
   mulxq 0(%rcx), %r8, %r9
-  xor %r10, %r10
+  xor %r10d, %r10d
   movq %r8, 0(%rdi)
   
   mulxq 8(%rcx), %r10, %r11
@@ -338,7 +338,7 @@ fmul2_e:
   ;# Compute src1[1] * src2
   movq 8(%rsi), %rdx
   mulxq 0(%rcx), %r8, %r9
-  xor %r10, %r10
+  xor %r10d, %r10d
   adcxq 8(%rdi), %r8
   movq %r8, 8(%rdi)
   mulxq 8(%rcx), %r10, %r11
@@ -360,7 +360,7 @@ fmul2_e:
   ;# Compute src1[2] * src2
   movq 16(%rsi), %rdx
   mulxq 0(%rcx), %r8, %r9
-  xor %r10, %r10
+  xor %r10d, %r10d
   adcxq 16(%rdi), %r8
   movq %r8, 16(%rdi)
   mulxq 8(%rcx), %r10, %r11
@@ -382,7 +382,7 @@ fmul2_e:
   ;# Compute src1[3] * src2
   movq 24(%rsi), %rdx
   mulxq 0(%rcx), %r8, %r9
-  xor %r10, %r10
+  xor %r10d, %r10d
   adcxq 24(%rdi), %r8
   movq %r8, 24(%rdi)
   mulxq 8(%rcx), %r10, %r11
@@ -407,7 +407,7 @@ fmul2_e:
   ;# Compute src1[0] * src2
   movq 32(%rsi), %rdx
   mulxq 32(%rcx), %r8, %r9
-  xor %r10, %r10
+  xor %r10d, %r10d
   movq %r8, 64(%rdi)
   
   mulxq 40(%rcx), %r10, %r11
@@ -425,7 +425,7 @@ fmul2_e:
   ;# Compute src1[1] * src2
   movq 40(%rsi), %rdx
   mulxq 32(%rcx), %r8, %r9
-  xor %r10, %r10
+  xor %r10d, %r10d
   adcxq 72(%rdi), %r8
   movq %r8, 72(%rdi)
   mulxq 40(%rcx), %r10, %r11
@@ -447,7 +447,7 @@ fmul2_e:
   ;# Compute src1[2] * src2
   movq 48(%rsi), %rdx
   mulxq 32(%rcx), %r8, %r9
-  xor %r10, %r10
+  xor %r10d, %r10d
   adcxq 80(%rdi), %r8
   movq %r8, 80(%rdi)
   mulxq 40(%rcx), %r10, %r11
@@ -469,7 +469,7 @@ fmul2_e:
   ;# Compute src1[3] * src2
   movq 56(%rsi), %rdx
   mulxq 32(%rcx), %r8, %r9
-  xor %r10, %r10
+  xor %r10d, %r10d
   adcxq 88(%rdi), %r8
   movq %r8, 88(%rdi)
   mulxq 40(%rcx), %r10, %r11
@@ -498,7 +498,7 @@ fmul2_e:
   ;# Step 1: Compute dst + carry == tmp_hi * 38 + tmp_lo
   mov $38, %rdx
   mulxq 32(%rsi), %r8, %r13
-  xor %rcx, %rcx
+  xor %ecx, %ecx
   adoxq 0(%rsi), %r8
   mulxq 40(%rsi), %r9, %rbx
   adcx %r13, %r9
@@ -531,7 +531,7 @@ fmul2_e:
   ;# Step 1: Compute dst + carry == tmp_hi * 38 + tmp_lo
   mov $38, %rdx
   mulxq 96(%rsi), %r8, %r13
-  xor %rcx, %rcx
+  xor %ecx, %ecx
   adoxq 64(%rsi), %r8
   mulxq 104(%rsi), %r9, %rbx
   adcx %r13, %r9
@@ -585,7 +585,7 @@ fsqr_e:
   movq 0(%rsi), %rdx
   ;# f[0]
   mulxq 8(%rsi), %r8, %r14
-  xor %r15, %r15
+  xor %r15d, %r15d
   ;# f[1]*f[0]
   mulxq 16(%rsi), %r9, %r10
   adcx %r14, %r9
@@ -609,7 +609,7 @@ fsqr_e:
   ;# f[2]*f[1]
   
   ;# Step 2: Compute two parallel carry chains
-  xor %r15, %r15
+  xor %r15d, %r15d
   adox %rax, %r10
   adcx %r8, %r8
   adox %rcx, %r11
@@ -667,7 +667,7 @@ fsqr_e:
   ;# Step 1: Compute dst + carry == tmp_hi * 38 + tmp_lo
   mov $38, %rdx
   mulxq 32(%rsi), %r8, %r13
-  xor %rcx, %rcx
+  xor %ecx, %ecx
   adoxq 0(%rsi), %r8
   mulxq 40(%rsi), %r9, %rbx
   adcx %r13, %r9
@@ -721,7 +721,7 @@ fsqr2_e:
   movq 0(%rsi), %rdx
   ;# f[0]
   mulxq 8(%rsi), %r8, %r14
-  xor %r15, %r15
+  xor %r15d, %r15d
   ;# f[1]*f[0]
   mulxq 16(%rsi), %r9, %r10
   adcx %r14, %r9
@@ -745,7 +745,7 @@ fsqr2_e:
   ;# f[2]*f[1]
   
   ;# Step 2: Compute two parallel carry chains
-  xor %r15, %r15
+  xor %r15d, %r15d
   adox %rax, %r10
   adcx %r8, %r8
   adox %rcx, %r11
@@ -800,7 +800,7 @@ fsqr2_e:
   movq 32(%rsi), %rdx
   ;# f[0]
   mulxq 40(%rsi), %r8, %r14
-  xor %r15, %r15
+  xor %r15d, %r15d
   ;# f[1]*f[0]
   mulxq 48(%rsi), %r9, %r10
   adcx %r14, %r9
@@ -824,7 +824,7 @@ fsqr2_e:
   ;# f[2]*f[1]
   
   ;# Step 2: Compute two parallel carry chains
-  xor %r15, %r15
+  xor %r15d, %r15d
   adox %rax, %r10
   adcx %r8, %r8
   adox %rcx, %r11
@@ -882,7 +882,7 @@ fsqr2_e:
   ;# Step 1: Compute dst + carry == tmp_hi * 38 + tmp_lo
   mov $38, %rdx
   mulxq 32(%rsi), %r8, %r13
-  xor %rcx, %rcx
+  xor %ecx, %ecx
   adoxq 0(%rsi), %r8
   mulxq 40(%rsi), %r9, %rbx
   adcx %r13, %r9
@@ -915,7 +915,7 @@ fsqr2_e:
   ;# Step 1: Compute dst + carry == tmp_hi * 38 + tmp_lo
   mov $38, %rdx
   mulxq 96(%rsi), %r8, %r13
-  xor %rcx, %rcx
+  xor %ecx, %ecx
   adoxq 64(%rsi), %r8
   mulxq 104(%rsi), %r9, %rbx
   adcx %r13, %r9

--- a/dist/c89-compatible/curve25519-x86_64-msvc.asm
+++ b/dist/c89-compatible/curve25519-x86_64-msvc.asm
@@ -7,11 +7,11 @@ add_scalar_e proc
   mov rsi, rdx
   mov rdx, r8
   ;# Clear registers to propagate the carry bit
-  xor r8, r8
-  xor r9, r9
-  xor r10, r10
-  xor r11, r11
-  xor rax, rax
+  xor r8d, r8d
+  xor r9d, r9d
+  xor r10d, r10d
+  xor r11d, r11d
+  xor eax, eax
   
   ;# Begin addition chain
   add rdx, qword ptr [rsi + 0]
@@ -52,7 +52,7 @@ fadd_e proc
   cmovc rax, rdx
   
   ;# Step 2: Add carry*38 to the original sum
-  xor rcx, rcx
+  xor ecx, ecx
   add r8, rax
   adcx r9, rcx
   mov qword ptr [rdi + 8], r9
@@ -176,7 +176,7 @@ fmul_e proc
   ;# Compute src1[0] * src2
   mov rdx, qword ptr [rsi + 0]
   mulx r9, r8, qword ptr [rcx + 0]
-  xor r10, r10
+  xor r10d, r10d
   mov qword ptr [rdi + 0], r8
   
   mulx r11, r10, qword ptr [rcx + 8]
@@ -194,7 +194,7 @@ fmul_e proc
   ;# Compute src1[1] * src2
   mov rdx, qword ptr [rsi + 8]
   mulx r9, r8, qword ptr [rcx + 0]
-  xor r10, r10
+  xor r10d, r10d
   adcx r8, qword ptr [rdi + 8]
   mov qword ptr [rdi + 8], r8
   mulx r11, r10, qword ptr [rcx + 8]
@@ -216,7 +216,7 @@ fmul_e proc
   ;# Compute src1[2] * src2
   mov rdx, qword ptr [rsi + 16]
   mulx r9, r8, qword ptr [rcx + 0]
-  xor r10, r10
+  xor r10d, r10d
   adcx r8, qword ptr [rdi + 16]
   mov qword ptr [rdi + 16], r8
   mulx r11, r10, qword ptr [rcx + 8]
@@ -238,7 +238,7 @@ fmul_e proc
   ;# Compute src1[3] * src2
   mov rdx, qword ptr [rsi + 24]
   mulx r9, r8, qword ptr [rcx + 0]
-  xor r10, r10
+  xor r10d, r10d
   adcx r8, qword ptr [rdi + 24]
   mov qword ptr [rdi + 24], r8
   mulx r11, r10, qword ptr [rcx + 8]
@@ -267,7 +267,7 @@ fmul_e proc
   ;# Step 1: Compute dst + carry == tmp_hi * 38 + tmp_lo
   mov rdx, 38
   mulx r13, r8, qword ptr [rsi + 32]
-  xor rcx, rcx
+  xor ecx, ecx
   adox r8, qword ptr [rsi + 0]
   mulx rbx, r9, qword ptr [rsi + 40]
   adcx r9, r13
@@ -320,7 +320,7 @@ fmul2_e proc
   ;# Compute src1[0] * src2
   mov rdx, qword ptr [rsi + 0]
   mulx r9, r8, qword ptr [rcx + 0]
-  xor r10, r10
+  xor r10d, r10d
   mov qword ptr [rdi + 0], r8
   
   mulx r11, r10, qword ptr [rcx + 8]
@@ -338,7 +338,7 @@ fmul2_e proc
   ;# Compute src1[1] * src2
   mov rdx, qword ptr [rsi + 8]
   mulx r9, r8, qword ptr [rcx + 0]
-  xor r10, r10
+  xor r10d, r10d
   adcx r8, qword ptr [rdi + 8]
   mov qword ptr [rdi + 8], r8
   mulx r11, r10, qword ptr [rcx + 8]
@@ -360,7 +360,7 @@ fmul2_e proc
   ;# Compute src1[2] * src2
   mov rdx, qword ptr [rsi + 16]
   mulx r9, r8, qword ptr [rcx + 0]
-  xor r10, r10
+  xor r10d, r10d
   adcx r8, qword ptr [rdi + 16]
   mov qword ptr [rdi + 16], r8
   mulx r11, r10, qword ptr [rcx + 8]
@@ -382,7 +382,7 @@ fmul2_e proc
   ;# Compute src1[3] * src2
   mov rdx, qword ptr [rsi + 24]
   mulx r9, r8, qword ptr [rcx + 0]
-  xor r10, r10
+  xor r10d, r10d
   adcx r8, qword ptr [rdi + 24]
   mov qword ptr [rdi + 24], r8
   mulx r11, r10, qword ptr [rcx + 8]
@@ -407,7 +407,7 @@ fmul2_e proc
   ;# Compute src1[0] * src2
   mov rdx, qword ptr [rsi + 32]
   mulx r9, r8, qword ptr [rcx + 32]
-  xor r10, r10
+  xor r10d, r10d
   mov qword ptr [rdi + 64], r8
   
   mulx r11, r10, qword ptr [rcx + 40]
@@ -425,7 +425,7 @@ fmul2_e proc
   ;# Compute src1[1] * src2
   mov rdx, qword ptr [rsi + 40]
   mulx r9, r8, qword ptr [rcx + 32]
-  xor r10, r10
+  xor r10d, r10d
   adcx r8, qword ptr [rdi + 72]
   mov qword ptr [rdi + 72], r8
   mulx r11, r10, qword ptr [rcx + 40]
@@ -447,7 +447,7 @@ fmul2_e proc
   ;# Compute src1[2] * src2
   mov rdx, qword ptr [rsi + 48]
   mulx r9, r8, qword ptr [rcx + 32]
-  xor r10, r10
+  xor r10d, r10d
   adcx r8, qword ptr [rdi + 80]
   mov qword ptr [rdi + 80], r8
   mulx r11, r10, qword ptr [rcx + 40]
@@ -469,7 +469,7 @@ fmul2_e proc
   ;# Compute src1[3] * src2
   mov rdx, qword ptr [rsi + 56]
   mulx r9, r8, qword ptr [rcx + 32]
-  xor r10, r10
+  xor r10d, r10d
   adcx r8, qword ptr [rdi + 88]
   mov qword ptr [rdi + 88], r8
   mulx r11, r10, qword ptr [rcx + 40]
@@ -498,7 +498,7 @@ fmul2_e proc
   ;# Step 1: Compute dst + carry == tmp_hi * 38 + tmp_lo
   mov rdx, 38
   mulx r13, r8, qword ptr [rsi + 32]
-  xor rcx, rcx
+  xor ecx, ecx
   adox r8, qword ptr [rsi + 0]
   mulx rbx, r9, qword ptr [rsi + 40]
   adcx r9, r13
@@ -531,7 +531,7 @@ fmul2_e proc
   ;# Step 1: Compute dst + carry == tmp_hi * 38 + tmp_lo
   mov rdx, 38
   mulx r13, r8, qword ptr [rsi + 96]
-  xor rcx, rcx
+  xor ecx, ecx
   adox r8, qword ptr [rsi + 64]
   mulx rbx, r9, qword ptr [rsi + 104]
   adcx r9, r13
@@ -585,7 +585,7 @@ fsqr_e proc
   mov rdx, qword ptr [rsi + 0]
   ;# f[0]
   mulx r14, r8, qword ptr [rsi + 8]
-  xor r15, r15
+  xor r15d, r15d
   ;# f[1]*f[0]
   mulx r10, r9, qword ptr [rsi + 16]
   adcx r9, r14
@@ -609,7 +609,7 @@ fsqr_e proc
   ;# f[2]*f[1]
   
   ;# Step 2: Compute two parallel carry chains
-  xor r15, r15
+  xor r15d, r15d
   adox r10, rax
   adcx r8, r8
   adox r11, rcx
@@ -667,7 +667,7 @@ fsqr_e proc
   ;# Step 1: Compute dst + carry == tmp_hi * 38 + tmp_lo
   mov rdx, 38
   mulx r13, r8, qword ptr [rsi + 32]
-  xor rcx, rcx
+  xor ecx, ecx
   adox r8, qword ptr [rsi + 0]
   mulx rbx, r9, qword ptr [rsi + 40]
   adcx r9, r13
@@ -721,7 +721,7 @@ fsqr2_e proc
   mov rdx, qword ptr [rsi + 0]
   ;# f[0]
   mulx r14, r8, qword ptr [rsi + 8]
-  xor r15, r15
+  xor r15d, r15d
   ;# f[1]*f[0]
   mulx r10, r9, qword ptr [rsi + 16]
   adcx r9, r14
@@ -745,7 +745,7 @@ fsqr2_e proc
   ;# f[2]*f[1]
   
   ;# Step 2: Compute two parallel carry chains
-  xor r15, r15
+  xor r15d, r15d
   adox r10, rax
   adcx r8, r8
   adox r11, rcx
@@ -800,7 +800,7 @@ fsqr2_e proc
   mov rdx, qword ptr [rsi + 32]
   ;# f[0]
   mulx r14, r8, qword ptr [rsi + 40]
-  xor r15, r15
+  xor r15d, r15d
   ;# f[1]*f[0]
   mulx r10, r9, qword ptr [rsi + 48]
   adcx r9, r14
@@ -824,7 +824,7 @@ fsqr2_e proc
   ;# f[2]*f[1]
   
   ;# Step 2: Compute two parallel carry chains
-  xor r15, r15
+  xor r15d, r15d
   adox r10, rax
   adcx r8, r8
   adox r11, rcx
@@ -882,7 +882,7 @@ fsqr2_e proc
   ;# Step 1: Compute dst + carry == tmp_hi * 38 + tmp_lo
   mov rdx, 38
   mulx r13, r8, qword ptr [rsi + 32]
-  xor rcx, rcx
+  xor ecx, ecx
   adox r8, qword ptr [rsi + 0]
   mulx rbx, r9, qword ptr [rsi + 40]
   adcx r9, r13
@@ -915,7 +915,7 @@ fsqr2_e proc
   ;# Step 1: Compute dst + carry == tmp_hi * 38 + tmp_lo
   mov rdx, 38
   mulx r13, r8, qword ptr [rsi + 96]
-  xor rcx, rcx
+  xor ecx, ecx
   adox r8, qword ptr [rsi + 64]
   mulx rbx, r9, qword ptr [rsi + 104]
   adcx r9, r13

--- a/dist/ccf/curve25519-inline.h
+++ b/dist/ccf/curve25519-inline.h
@@ -10,11 +10,11 @@ static inline uint64_t add_scalar (uint64_t *out, uint64_t *f1, uint64_t f2)
 
   asm volatile(
     // Clear registers to propagate the carry bit
-    "  xor %%r8, %%r8;"
-    "  xor %%r9, %%r9;"
-    "  xor %%r10, %%r10;"
-    "  xor %%r11, %%r11;"
-    "  xor %1, %1;"
+    "  xor %%r8d, %%r8d;"
+    "  xor %%r9d, %%r9d;"
+    "  xor %%r10d, %%r10d;"
+    "  xor %%r11d, %%r11d;"
+    "  xor %k1, %k1;"
 
     // Begin addition chain
     "  addq 0(%3), %0;"
@@ -58,7 +58,7 @@ static inline void fadd (uint64_t *out, uint64_t *f1, uint64_t *f2)
     "  cmovc %0, %%rax;"
 
     // Step 2: Add carry*38 to the original sum
-    "  xor %%rcx, %%rcx;"
+    "  xor %%ecx, %%ecx;"
     "  add %%rax, %%r8;"
     "  adcx %%rcx, %%r9;"
     "  movq %%r9, 8(%1);"
@@ -131,7 +131,7 @@ static inline void fmul (uint64_t *out, uint64_t *f1, uint64_t *f2, uint64_t *tm
 
     // Compute src1[0] * src2
     "  movq 0(%1), %%rdx;"
-    "  mulxq 0(%2), %%r8, %%r9;"       "  xor %%r10, %%r10;"     "  movq %%r8, 0(%3);"
+    "  mulxq 0(%2), %%r8, %%r9;"       "  xor %%r10d, %%r10d;"     "  movq %%r8, 0(%3);"
     "  mulxq 8(%2), %%r10, %%r11;"     "  adox %%r9, %%r10;"     "  movq %%r10, 8(%3);"
     "  mulxq 16(%2), %%rbx, %%r13;"    "  adox %%r11, %%rbx;"
     "  mulxq 24(%2), %%r14, %%rdx;"    "  adox %%r13, %%r14;"    "  mov $0, %%rax;"
@@ -139,7 +139,7 @@ static inline void fmul (uint64_t *out, uint64_t *f1, uint64_t *f2, uint64_t *tm
 
     // Compute src1[1] * src2
     "  movq 8(%1), %%rdx;"
-    "  mulxq 0(%2), %%r8, %%r9;"       "  xor %%r10, %%r10;"     "  adcxq 8(%3), %%r8;"    "  movq %%r8, 8(%3);"
+    "  mulxq 0(%2), %%r8, %%r9;"       "  xor %%r10d, %%r10d;"     "  adcxq 8(%3), %%r8;"    "  movq %%r8, 8(%3);"
     "  mulxq 8(%2), %%r10, %%r11;"     "  adox %%r9, %%r10;"     "  adcx %%rbx, %%r10;"    "  movq %%r10, 16(%3);"
     "  mulxq 16(%2), %%rbx, %%r13;"    "  adox %%r11, %%rbx;"    "  adcx %%r14, %%rbx;"    "  mov $0, %%r8;"
     "  mulxq 24(%2), %%r14, %%rdx;"    "  adox %%r13, %%r14;"    "  adcx %%rax, %%r14;"    "  mov $0, %%rax;"
@@ -148,7 +148,7 @@ static inline void fmul (uint64_t *out, uint64_t *f1, uint64_t *f2, uint64_t *tm
 
     // Compute src1[2] * src2
     "  movq 16(%1), %%rdx;"
-    "  mulxq 0(%2), %%r8, %%r9;"       "  xor %%r10, %%r10;"    "  adcxq 16(%3), %%r8;"    "  movq %%r8, 16(%3);"
+    "  mulxq 0(%2), %%r8, %%r9;"       "  xor %%r10d, %%r10d;"    "  adcxq 16(%3), %%r8;"    "  movq %%r8, 16(%3);"
     "  mulxq 8(%2), %%r10, %%r11;"     "  adox %%r9, %%r10;"     "  adcx %%rbx, %%r10;"    "  movq %%r10, 24(%3);"
     "  mulxq 16(%2), %%rbx, %%r13;"    "  adox %%r11, %%rbx;"    "  adcx %%r14, %%rbx;"    "  mov $0, %%r8;"
     "  mulxq 24(%2), %%r14, %%rdx;"    "  adox %%r13, %%r14;"    "  adcx %%rax, %%r14;"    "  mov $0, %%rax;"
@@ -157,7 +157,7 @@ static inline void fmul (uint64_t *out, uint64_t *f1, uint64_t *f2, uint64_t *tm
 
     // Compute src1[3] * src2
     "  movq 24(%1), %%rdx;"
-    "  mulxq 0(%2), %%r8, %%r9;"       "  xor %%r10, %%r10;"    "  adcxq 24(%3), %%r8;"    "  movq %%r8, 24(%3);"
+    "  mulxq 0(%2), %%r8, %%r9;"       "  xor %%r10d, %%r10d;"    "  adcxq 24(%3), %%r8;"    "  movq %%r8, 24(%3);"
     "  mulxq 8(%2), %%r10, %%r11;"     "  adox %%r9, %%r10;"     "  adcx %%rbx, %%r10;"    "  movq %%r10, 32(%3);"
     "  mulxq 16(%2), %%rbx, %%r13;"    "  adox %%r11, %%rbx;"    "  adcx %%r14, %%rbx;"    "  movq %%rbx, 40(%3);"    "  mov $0, %%r8;"
     "  mulxq 24(%2), %%r14, %%rdx;"    "  adox %%r13, %%r14;"    "  adcx %%rax, %%r14;"    "  movq %%r14, 48(%3);"    "  mov $0, %%rax;"
@@ -172,7 +172,7 @@ static inline void fmul (uint64_t *out, uint64_t *f1, uint64_t *f2, uint64_t *tm
     // Step 1: Compute dst + carry == tmp_hi * 38 + tmp_lo
     "  mov $38, %%rdx;"
     "  mulxq 32(%1), %%r8, %%r13;"
-    "  xor %2, %2;"
+    "  xor %k2, %k2;"
     "  adoxq 0(%1), %%r8;"
     "  mulxq 40(%1), %%r9, %%rbx;"
     "  adcx %%r13, %%r9;"
@@ -219,7 +219,7 @@ static inline void fmul2 (uint64_t *out, uint64_t *f1, uint64_t *f2, uint64_t *t
 
     // Compute src1[0] * src2
     "  movq 0(%1), %%rdx;"
-    "  mulxq 0(%2), %%r8, %%r9;"       "  xor %%r10, %%r10;"     "  movq %%r8, 0(%3);"
+    "  mulxq 0(%2), %%r8, %%r9;"       "  xor %%r10d, %%r10d;"     "  movq %%r8, 0(%3);"
     "  mulxq 8(%2), %%r10, %%r11;"     "  adox %%r9, %%r10;"     "  movq %%r10, 8(%3);"
     "  mulxq 16(%2), %%rbx, %%r13;"    "  adox %%r11, %%rbx;"
     "  mulxq 24(%2), %%r14, %%rdx;"    "  adox %%r13, %%r14;"    "  mov $0, %%rax;"
@@ -227,7 +227,7 @@ static inline void fmul2 (uint64_t *out, uint64_t *f1, uint64_t *f2, uint64_t *t
 
     // Compute src1[1] * src2
     "  movq 8(%1), %%rdx;"
-    "  mulxq 0(%2), %%r8, %%r9;"       "  xor %%r10, %%r10;"     "  adcxq 8(%3), %%r8;"    "  movq %%r8, 8(%3);"
+    "  mulxq 0(%2), %%r8, %%r9;"       "  xor %%r10d, %%r10d;"     "  adcxq 8(%3), %%r8;"    "  movq %%r8, 8(%3);"
     "  mulxq 8(%2), %%r10, %%r11;"     "  adox %%r9, %%r10;"     "  adcx %%rbx, %%r10;"    "  movq %%r10, 16(%3);"
     "  mulxq 16(%2), %%rbx, %%r13;"    "  adox %%r11, %%rbx;"    "  adcx %%r14, %%rbx;"    "  mov $0, %%r8;"
     "  mulxq 24(%2), %%r14, %%rdx;"    "  adox %%r13, %%r14;"    "  adcx %%rax, %%r14;"    "  mov $0, %%rax;"
@@ -236,7 +236,7 @@ static inline void fmul2 (uint64_t *out, uint64_t *f1, uint64_t *f2, uint64_t *t
 
     // Compute src1[2] * src2
     "  movq 16(%1), %%rdx;"
-    "  mulxq 0(%2), %%r8, %%r9;"       "  xor %%r10, %%r10;"    "  adcxq 16(%3), %%r8;"    "  movq %%r8, 16(%3);"
+    "  mulxq 0(%2), %%r8, %%r9;"       "  xor %%r10d, %%r10d;"    "  adcxq 16(%3), %%r8;"    "  movq %%r8, 16(%3);"
     "  mulxq 8(%2), %%r10, %%r11;"     "  adox %%r9, %%r10;"     "  adcx %%rbx, %%r10;"    "  movq %%r10, 24(%3);"
     "  mulxq 16(%2), %%rbx, %%r13;"    "  adox %%r11, %%rbx;"    "  adcx %%r14, %%rbx;"    "  mov $0, %%r8;"
     "  mulxq 24(%2), %%r14, %%rdx;"    "  adox %%r13, %%r14;"    "  adcx %%rax, %%r14;"    "  mov $0, %%rax;"
@@ -245,7 +245,7 @@ static inline void fmul2 (uint64_t *out, uint64_t *f1, uint64_t *f2, uint64_t *t
 
     // Compute src1[3] * src2
     "  movq 24(%1), %%rdx;"
-    "  mulxq 0(%2), %%r8, %%r9;"       "  xor %%r10, %%r10;"    "  adcxq 24(%3), %%r8;"    "  movq %%r8, 24(%3);"
+    "  mulxq 0(%2), %%r8, %%r9;"       "  xor %%r10d, %%r10d;"    "  adcxq 24(%3), %%r8;"    "  movq %%r8, 24(%3);"
     "  mulxq 8(%2), %%r10, %%r11;"     "  adox %%r9, %%r10;"     "  adcx %%rbx, %%r10;"    "  movq %%r10, 32(%3);"
     "  mulxq 16(%2), %%rbx, %%r13;"    "  adox %%r11, %%rbx;"    "  adcx %%r14, %%rbx;"    "  movq %%rbx, 40(%3);"    "  mov $0, %%r8;"
     "  mulxq 24(%2), %%r14, %%rdx;"    "  adox %%r13, %%r14;"    "  adcx %%rax, %%r14;"    "  movq %%r14, 48(%3);"    "  mov $0, %%rax;"
@@ -255,7 +255,7 @@ static inline void fmul2 (uint64_t *out, uint64_t *f1, uint64_t *f2, uint64_t *t
 
     // Compute src1[0] * src2
     "  movq 32(%1), %%rdx;"
-    "  mulxq 32(%2), %%r8, %%r9;"       "  xor %%r10, %%r10;"     "  movq %%r8, 64(%3);"
+    "  mulxq 32(%2), %%r8, %%r9;"       "  xor %%r10d, %%r10d;"     "  movq %%r8, 64(%3);"
     "  mulxq 40(%2), %%r10, %%r11;"     "  adox %%r9, %%r10;"     "  movq %%r10, 72(%3);"
     "  mulxq 48(%2), %%rbx, %%r13;"    "  adox %%r11, %%rbx;"
     "  mulxq 56(%2), %%r14, %%rdx;"    "  adox %%r13, %%r14;"    "  mov $0, %%rax;"
@@ -263,7 +263,7 @@ static inline void fmul2 (uint64_t *out, uint64_t *f1, uint64_t *f2, uint64_t *t
 
     // Compute src1[1] * src2
     "  movq 40(%1), %%rdx;"
-    "  mulxq 32(%2), %%r8, %%r9;"       "  xor %%r10, %%r10;"     "  adcxq 72(%3), %%r8;"    "  movq %%r8, 72(%3);"
+    "  mulxq 32(%2), %%r8, %%r9;"       "  xor %%r10d, %%r10d;"     "  adcxq 72(%3), %%r8;"    "  movq %%r8, 72(%3);"
     "  mulxq 40(%2), %%r10, %%r11;"     "  adox %%r9, %%r10;"     "  adcx %%rbx, %%r10;"    "  movq %%r10, 80(%3);"
     "  mulxq 48(%2), %%rbx, %%r13;"    "  adox %%r11, %%rbx;"    "  adcx %%r14, %%rbx;"    "  mov $0, %%r8;"
     "  mulxq 56(%2), %%r14, %%rdx;"    "  adox %%r13, %%r14;"    "  adcx %%rax, %%r14;"    "  mov $0, %%rax;"
@@ -272,7 +272,7 @@ static inline void fmul2 (uint64_t *out, uint64_t *f1, uint64_t *f2, uint64_t *t
 
     // Compute src1[2] * src2
     "  movq 48(%1), %%rdx;"
-    "  mulxq 32(%2), %%r8, %%r9;"       "  xor %%r10, %%r10;"    "  adcxq 80(%3), %%r8;"    "  movq %%r8, 80(%3);"
+    "  mulxq 32(%2), %%r8, %%r9;"       "  xor %%r10d, %%r10d;"    "  adcxq 80(%3), %%r8;"    "  movq %%r8, 80(%3);"
     "  mulxq 40(%2), %%r10, %%r11;"     "  adox %%r9, %%r10;"     "  adcx %%rbx, %%r10;"    "  movq %%r10, 88(%3);"
     "  mulxq 48(%2), %%rbx, %%r13;"    "  adox %%r11, %%rbx;"    "  adcx %%r14, %%rbx;"    "  mov $0, %%r8;"
     "  mulxq 56(%2), %%r14, %%rdx;"    "  adox %%r13, %%r14;"    "  adcx %%rax, %%r14;"    "  mov $0, %%rax;"
@@ -281,7 +281,7 @@ static inline void fmul2 (uint64_t *out, uint64_t *f1, uint64_t *f2, uint64_t *t
 
     // Compute src1[3] * src2
     "  movq 56(%1), %%rdx;"
-    "  mulxq 32(%2), %%r8, %%r9;"       "  xor %%r10, %%r10;"    "  adcxq 88(%3), %%r8;"    "  movq %%r8, 88(%3);"
+    "  mulxq 32(%2), %%r8, %%r9;"       "  xor %%r10d, %%r10d;"    "  adcxq 88(%3), %%r8;"    "  movq %%r8, 88(%3);"
     "  mulxq 40(%2), %%r10, %%r11;"     "  adox %%r9, %%r10;"     "  adcx %%rbx, %%r10;"    "  movq %%r10, 96(%3);"
     "  mulxq 48(%2), %%rbx, %%r13;"    "  adox %%r11, %%rbx;"    "  adcx %%r14, %%rbx;"    "  movq %%rbx, 104(%3);"    "  mov $0, %%r8;"
     "  mulxq 56(%2), %%r14, %%rdx;"    "  adox %%r13, %%r14;"    "  adcx %%rax, %%r14;"    "  movq %%r14, 112(%3);"    "  mov $0, %%rax;"
@@ -296,7 +296,7 @@ static inline void fmul2 (uint64_t *out, uint64_t *f1, uint64_t *f2, uint64_t *t
     // Step 1: Compute dst + carry == tmp_hi * 38 + tmp_lo
     "  mov $38, %%rdx;"
     "  mulxq 32(%1), %%r8, %%r13;"
-    "  xor %2, %2;"
+    "  xor %k2, %k2;"
     "  adoxq 0(%1), %%r8;"
     "  mulxq 40(%1), %%r9, %%rbx;"
     "  adcx %%r13, %%r9;"
@@ -329,7 +329,7 @@ static inline void fmul2 (uint64_t *out, uint64_t *f1, uint64_t *f2, uint64_t *t
     // Step 1: Compute dst + carry == tmp_hi * 38 + tmp_lo
     "  mov $38, %%rdx;"
     "  mulxq 96(%1), %%r8, %%r13;"
-    "  xor %2, %2;"
+    "  xor %k2, %k2;"
     "  adoxq 64(%1), %%r8;"
     "  mulxq 104(%1), %%r9, %%rbx;"
     "  adcx %%r13, %%r9;"
@@ -502,7 +502,7 @@ static inline void fsqr (uint64_t *out, uint64_t *f, uint64_t *tmp)
 
     // Step 1: Compute all partial products
     "  movq 0(%1), %%rdx;"                                       // f[0]
-    "  mulxq 8(%1), %%r8, %%r14;"      "  xor %%r15, %%r15;"     // f[1]*f[0]
+    "  mulxq 8(%1), %%r8, %%r14;"      "  xor %%r15d, %%r15d;"     // f[1]*f[0]
     "  mulxq 16(%1), %%r9, %%r10;"     "  adcx %%r14, %%r9;"     // f[2]*f[0]
     "  mulxq 24(%1), %%rax, %%rcx;"    "  adcx %%rax, %%r10;"    // f[3]*f[0]
     "  movq 24(%1), %%rdx;"                                      // f[3]
@@ -512,7 +512,7 @@ static inline void fsqr (uint64_t *out, uint64_t *f, uint64_t *tmp)
     "  mulxq 16(%1), %%rax, %%rcx;"    "  mov $0, %%r14;"        // f[2]*f[1]
 
     // Step 2: Compute two parallel carry chains
-    "  xor %%r15, %%r15;"
+    "  xor %%r15d, %%r15d;"
     "  adox %%rax, %%r10;"
     "  adcx %%r8, %%r8;"
     "  adox %%rcx, %%r11;"
@@ -549,7 +549,7 @@ static inline void fsqr (uint64_t *out, uint64_t *f, uint64_t *tmp)
     // Step 1: Compute dst + carry == tmp_hi * 38 + tmp_lo
     "  mov $38, %%rdx;"
     "  mulxq 32(%1), %%r8, %%r13;"
-    "  xor %%rcx, %%rcx;"
+    "  xor %%ecx, %%ecx;"
     "  adoxq 0(%1), %%r8;"
     "  mulxq 40(%1), %%r9, %%rbx;"
     "  adcx %%r13, %%r9;"
@@ -593,7 +593,7 @@ static inline void fsqr2 (uint64_t *out, uint64_t *f, uint64_t *tmp)
   asm volatile(
     // Step 1: Compute all partial products
     "  movq 0(%1), %%rdx;"                                       // f[0]
-    "  mulxq 8(%1), %%r8, %%r14;"      "  xor %%r15, %%r15;"     // f[1]*f[0]
+    "  mulxq 8(%1), %%r8, %%r14;"      "  xor %%r15d, %%r15d;"     // f[1]*f[0]
     "  mulxq 16(%1), %%r9, %%r10;"     "  adcx %%r14, %%r9;"     // f[2]*f[0]
     "  mulxq 24(%1), %%rax, %%rcx;"    "  adcx %%rax, %%r10;"    // f[3]*f[0]
     "  movq 24(%1), %%rdx;"                                      // f[3]
@@ -603,7 +603,7 @@ static inline void fsqr2 (uint64_t *out, uint64_t *f, uint64_t *tmp)
     "  mulxq 16(%1), %%rax, %%rcx;"    "  mov $0, %%r14;"        // f[2]*f[1]
 
     // Step 2: Compute two parallel carry chains
-    "  xor %%r15, %%r15;"
+    "  xor %%r15d, %%r15d;"
     "  adox %%rax, %%r10;"
     "  adcx %%r8, %%r8;"
     "  adox %%rcx, %%r11;"
@@ -633,7 +633,7 @@ static inline void fsqr2 (uint64_t *out, uint64_t *f, uint64_t *tmp)
 
     // Step 1: Compute all partial products
     "  movq 32(%1), %%rdx;"                                       // f[0]
-    "  mulxq 40(%1), %%r8, %%r14;"      "  xor %%r15, %%r15;"     // f[1]*f[0]
+    "  mulxq 40(%1), %%r8, %%r14;"      "  xor %%r15d, %%r15d;"     // f[1]*f[0]
     "  mulxq 48(%1), %%r9, %%r10;"     "  adcx %%r14, %%r9;"     // f[2]*f[0]
     "  mulxq 56(%1), %%rax, %%rcx;"    "  adcx %%rax, %%r10;"    // f[3]*f[0]
     "  movq 56(%1), %%rdx;"                                      // f[3]
@@ -643,7 +643,7 @@ static inline void fsqr2 (uint64_t *out, uint64_t *f, uint64_t *tmp)
     "  mulxq 48(%1), %%rax, %%rcx;"    "  mov $0, %%r14;"        // f[2]*f[1]
 
     // Step 2: Compute two parallel carry chains
-    "  xor %%r15, %%r15;"
+    "  xor %%r15d, %%r15d;"
     "  adox %%rax, %%r10;"
     "  adcx %%r8, %%r8;"
     "  adox %%rcx, %%r11;"
@@ -678,7 +678,7 @@ static inline void fsqr2 (uint64_t *out, uint64_t *f, uint64_t *tmp)
     // Step 1: Compute dst + carry == tmp_hi * 38 + tmp_lo
     "  mov $38, %%rdx;"
     "  mulxq 32(%1), %%r8, %%r13;"
-    "  xor %%rcx, %%rcx;"
+    "  xor %%ecx, %%ecx;"
     "  adoxq 0(%1), %%r8;"
     "  mulxq 40(%1), %%r9, %%rbx;"
     "  adcx %%r13, %%r9;"
@@ -711,7 +711,7 @@ static inline void fsqr2 (uint64_t *out, uint64_t *f, uint64_t *tmp)
     // Step 1: Compute dst + carry == tmp_hi * 38 + tmp_lo
     "  mov $38, %%rdx;"
     "  mulxq 96(%1), %%r8, %%r13;"
-    "  xor %%rcx, %%rcx;"
+    "  xor %%ecx, %%ecx;"
     "  adoxq 64(%1), %%r8;"
     "  mulxq 104(%1), %%r9, %%rbx;"
     "  adcx %%r13, %%r9;"

--- a/dist/ccf/curve25519-x86_64-darwin.S
+++ b/dist/ccf/curve25519-x86_64-darwin.S
@@ -4,11 +4,11 @@ _add_scalar_e:
   push %rdi
   push %rsi
   ;# Clear registers to propagate the carry bit
-  xor %r8, %r8
-  xor %r9, %r9
-  xor %r10, %r10
-  xor %r11, %r11
-  xor %rax, %rax
+  xor %r8d, %r8d
+  xor %r9d, %r9d
+  xor %r10d, %r10d
+  xor %r11d, %r11d
+  xor %eax, %eax
   
   ;# Begin addition chain
   addq 0(%rsi), %rdx
@@ -44,7 +44,7 @@ _fadd_e:
   cmovc %rdx, %rax
   
   ;# Step 2: Add carry*38 to the original sum
-  xor %rcx, %rcx
+  xor %ecx, %ecx
   add %rax, %r8
   adcx %rcx, %r9
   movq %r9, 8(%rdi)
@@ -149,7 +149,7 @@ _fmul_e:
   ;# Compute src1[0] * src2
   movq 0(%rsi), %rdx
   mulxq 0(%rcx), %r8, %r9
-  xor %r10, %r10
+  xor %r10d, %r10d
   movq %r8, 0(%rdi)
   
   mulxq 8(%rcx), %r10, %r11
@@ -167,7 +167,7 @@ _fmul_e:
   ;# Compute src1[1] * src2
   movq 8(%rsi), %rdx
   mulxq 0(%rcx), %r8, %r9
-  xor %r10, %r10
+  xor %r10d, %r10d
   adcxq 8(%rdi), %r8
   movq %r8, 8(%rdi)
   mulxq 8(%rcx), %r10, %r11
@@ -189,7 +189,7 @@ _fmul_e:
   ;# Compute src1[2] * src2
   movq 16(%rsi), %rdx
   mulxq 0(%rcx), %r8, %r9
-  xor %r10, %r10
+  xor %r10d, %r10d
   adcxq 16(%rdi), %r8
   movq %r8, 16(%rdi)
   mulxq 8(%rcx), %r10, %r11
@@ -211,7 +211,7 @@ _fmul_e:
   ;# Compute src1[3] * src2
   movq 24(%rsi), %rdx
   mulxq 0(%rcx), %r8, %r9
-  xor %r10, %r10
+  xor %r10d, %r10d
   adcxq 24(%rdi), %r8
   movq %r8, 24(%rdi)
   mulxq 8(%rcx), %r10, %r11
@@ -240,7 +240,7 @@ _fmul_e:
   ;# Step 1: Compute dst + carry == tmp_hi * 38 + tmp_lo
   mov $38, %rdx
   mulxq 32(%rsi), %r8, %r13
-  xor %rcx, %rcx
+  xor %ecx, %ecx
   adoxq 0(%rsi), %r8
   mulxq 40(%rsi), %r9, %rbx
   adcx %r13, %r9
@@ -286,7 +286,7 @@ _fmul2_e:
   ;# Compute src1[0] * src2
   movq 0(%rsi), %rdx
   mulxq 0(%rcx), %r8, %r9
-  xor %r10, %r10
+  xor %r10d, %r10d
   movq %r8, 0(%rdi)
   
   mulxq 8(%rcx), %r10, %r11
@@ -304,7 +304,7 @@ _fmul2_e:
   ;# Compute src1[1] * src2
   movq 8(%rsi), %rdx
   mulxq 0(%rcx), %r8, %r9
-  xor %r10, %r10
+  xor %r10d, %r10d
   adcxq 8(%rdi), %r8
   movq %r8, 8(%rdi)
   mulxq 8(%rcx), %r10, %r11
@@ -326,7 +326,7 @@ _fmul2_e:
   ;# Compute src1[2] * src2
   movq 16(%rsi), %rdx
   mulxq 0(%rcx), %r8, %r9
-  xor %r10, %r10
+  xor %r10d, %r10d
   adcxq 16(%rdi), %r8
   movq %r8, 16(%rdi)
   mulxq 8(%rcx), %r10, %r11
@@ -348,7 +348,7 @@ _fmul2_e:
   ;# Compute src1[3] * src2
   movq 24(%rsi), %rdx
   mulxq 0(%rcx), %r8, %r9
-  xor %r10, %r10
+  xor %r10d, %r10d
   adcxq 24(%rdi), %r8
   movq %r8, 24(%rdi)
   mulxq 8(%rcx), %r10, %r11
@@ -373,7 +373,7 @@ _fmul2_e:
   ;# Compute src1[0] * src2
   movq 32(%rsi), %rdx
   mulxq 32(%rcx), %r8, %r9
-  xor %r10, %r10
+  xor %r10d, %r10d
   movq %r8, 64(%rdi)
   
   mulxq 40(%rcx), %r10, %r11
@@ -391,7 +391,7 @@ _fmul2_e:
   ;# Compute src1[1] * src2
   movq 40(%rsi), %rdx
   mulxq 32(%rcx), %r8, %r9
-  xor %r10, %r10
+  xor %r10d, %r10d
   adcxq 72(%rdi), %r8
   movq %r8, 72(%rdi)
   mulxq 40(%rcx), %r10, %r11
@@ -413,7 +413,7 @@ _fmul2_e:
   ;# Compute src1[2] * src2
   movq 48(%rsi), %rdx
   mulxq 32(%rcx), %r8, %r9
-  xor %r10, %r10
+  xor %r10d, %r10d
   adcxq 80(%rdi), %r8
   movq %r8, 80(%rdi)
   mulxq 40(%rcx), %r10, %r11
@@ -435,7 +435,7 @@ _fmul2_e:
   ;# Compute src1[3] * src2
   movq 56(%rsi), %rdx
   mulxq 32(%rcx), %r8, %r9
-  xor %r10, %r10
+  xor %r10d, %r10d
   adcxq 88(%rdi), %r8
   movq %r8, 88(%rdi)
   mulxq 40(%rcx), %r10, %r11
@@ -464,7 +464,7 @@ _fmul2_e:
   ;# Step 1: Compute dst + carry == tmp_hi * 38 + tmp_lo
   mov $38, %rdx
   mulxq 32(%rsi), %r8, %r13
-  xor %rcx, %rcx
+  xor %ecx, %ecx
   adoxq 0(%rsi), %r8
   mulxq 40(%rsi), %r9, %rbx
   adcx %r13, %r9
@@ -497,7 +497,7 @@ _fmul2_e:
   ;# Step 1: Compute dst + carry == tmp_hi * 38 + tmp_lo
   mov $38, %rdx
   mulxq 96(%rsi), %r8, %r13
-  xor %rcx, %rcx
+  xor %ecx, %ecx
   adoxq 64(%rsi), %r8
   mulxq 104(%rsi), %r9, %rbx
   adcx %r13, %r9
@@ -545,7 +545,7 @@ _fsqr_e:
   movq 0(%rsi), %rdx
   ;# f[0]
   mulxq 8(%rsi), %r8, %r14
-  xor %r15, %r15
+  xor %r15d, %r15d
   ;# f[1]*f[0]
   mulxq 16(%rsi), %r9, %r10
   adcx %r14, %r9
@@ -569,7 +569,7 @@ _fsqr_e:
   ;# f[2]*f[1]
   
   ;# Step 2: Compute two parallel carry chains
-  xor %r15, %r15
+  xor %r15d, %r15d
   adox %rax, %r10
   adcx %r8, %r8
   adox %rcx, %r11
@@ -627,7 +627,7 @@ _fsqr_e:
   ;# Step 1: Compute dst + carry == tmp_hi * 38 + tmp_lo
   mov $38, %rdx
   mulxq 32(%rsi), %r8, %r13
-  xor %rcx, %rcx
+  xor %ecx, %ecx
   adoxq 0(%rsi), %r8
   mulxq 40(%rsi), %r9, %rbx
   adcx %r13, %r9
@@ -675,7 +675,7 @@ _fsqr2_e:
   movq 0(%rsi), %rdx
   ;# f[0]
   mulxq 8(%rsi), %r8, %r14
-  xor %r15, %r15
+  xor %r15d, %r15d
   ;# f[1]*f[0]
   mulxq 16(%rsi), %r9, %r10
   adcx %r14, %r9
@@ -699,7 +699,7 @@ _fsqr2_e:
   ;# f[2]*f[1]
   
   ;# Step 2: Compute two parallel carry chains
-  xor %r15, %r15
+  xor %r15d, %r15d
   adox %rax, %r10
   adcx %r8, %r8
   adox %rcx, %r11
@@ -754,7 +754,7 @@ _fsqr2_e:
   movq 32(%rsi), %rdx
   ;# f[0]
   mulxq 40(%rsi), %r8, %r14
-  xor %r15, %r15
+  xor %r15d, %r15d
   ;# f[1]*f[0]
   mulxq 48(%rsi), %r9, %r10
   adcx %r14, %r9
@@ -778,7 +778,7 @@ _fsqr2_e:
   ;# f[2]*f[1]
   
   ;# Step 2: Compute two parallel carry chains
-  xor %r15, %r15
+  xor %r15d, %r15d
   adox %rax, %r10
   adcx %r8, %r8
   adox %rcx, %r11
@@ -836,7 +836,7 @@ _fsqr2_e:
   ;# Step 1: Compute dst + carry == tmp_hi * 38 + tmp_lo
   mov $38, %rdx
   mulxq 32(%rsi), %r8, %r13
-  xor %rcx, %rcx
+  xor %ecx, %ecx
   adoxq 0(%rsi), %r8
   mulxq 40(%rsi), %r9, %rbx
   adcx %r13, %r9
@@ -869,7 +869,7 @@ _fsqr2_e:
   ;# Step 1: Compute dst + carry == tmp_hi * 38 + tmp_lo
   mov $38, %rdx
   mulxq 96(%rsi), %r8, %r13
-  xor %rcx, %rcx
+  xor %ecx, %ecx
   adoxq 64(%rsi), %r8
   mulxq 104(%rsi), %r9, %rbx
   adcx %r13, %r9

--- a/dist/ccf/curve25519-x86_64-linux.S
+++ b/dist/ccf/curve25519-x86_64-linux.S
@@ -4,11 +4,11 @@ add_scalar_e:
   push %rdi
   push %rsi
   ;# Clear registers to propagate the carry bit
-  xor %r8, %r8
-  xor %r9, %r9
-  xor %r10, %r10
-  xor %r11, %r11
-  xor %rax, %rax
+  xor %r8d, %r8d
+  xor %r9d, %r9d
+  xor %r10d, %r10d
+  xor %r11d, %r11d
+  xor %eax, %eax
   
   ;# Begin addition chain
   addq 0(%rsi), %rdx
@@ -44,7 +44,7 @@ fadd_e:
   cmovc %rdx, %rax
   
   ;# Step 2: Add carry*38 to the original sum
-  xor %rcx, %rcx
+  xor %ecx, %ecx
   add %rax, %r8
   adcx %rcx, %r9
   movq %r9, 8(%rdi)
@@ -149,7 +149,7 @@ fmul_e:
   ;# Compute src1[0] * src2
   movq 0(%rsi), %rdx
   mulxq 0(%rcx), %r8, %r9
-  xor %r10, %r10
+  xor %r10d, %r10d
   movq %r8, 0(%rdi)
   
   mulxq 8(%rcx), %r10, %r11
@@ -167,7 +167,7 @@ fmul_e:
   ;# Compute src1[1] * src2
   movq 8(%rsi), %rdx
   mulxq 0(%rcx), %r8, %r9
-  xor %r10, %r10
+  xor %r10d, %r10d
   adcxq 8(%rdi), %r8
   movq %r8, 8(%rdi)
   mulxq 8(%rcx), %r10, %r11
@@ -189,7 +189,7 @@ fmul_e:
   ;# Compute src1[2] * src2
   movq 16(%rsi), %rdx
   mulxq 0(%rcx), %r8, %r9
-  xor %r10, %r10
+  xor %r10d, %r10d
   adcxq 16(%rdi), %r8
   movq %r8, 16(%rdi)
   mulxq 8(%rcx), %r10, %r11
@@ -211,7 +211,7 @@ fmul_e:
   ;# Compute src1[3] * src2
   movq 24(%rsi), %rdx
   mulxq 0(%rcx), %r8, %r9
-  xor %r10, %r10
+  xor %r10d, %r10d
   adcxq 24(%rdi), %r8
   movq %r8, 24(%rdi)
   mulxq 8(%rcx), %r10, %r11
@@ -240,7 +240,7 @@ fmul_e:
   ;# Step 1: Compute dst + carry == tmp_hi * 38 + tmp_lo
   mov $38, %rdx
   mulxq 32(%rsi), %r8, %r13
-  xor %rcx, %rcx
+  xor %ecx, %ecx
   adoxq 0(%rsi), %r8
   mulxq 40(%rsi), %r9, %rbx
   adcx %r13, %r9
@@ -286,7 +286,7 @@ fmul2_e:
   ;# Compute src1[0] * src2
   movq 0(%rsi), %rdx
   mulxq 0(%rcx), %r8, %r9
-  xor %r10, %r10
+  xor %r10d, %r10d
   movq %r8, 0(%rdi)
   
   mulxq 8(%rcx), %r10, %r11
@@ -304,7 +304,7 @@ fmul2_e:
   ;# Compute src1[1] * src2
   movq 8(%rsi), %rdx
   mulxq 0(%rcx), %r8, %r9
-  xor %r10, %r10
+  xor %r10d, %r10d
   adcxq 8(%rdi), %r8
   movq %r8, 8(%rdi)
   mulxq 8(%rcx), %r10, %r11
@@ -326,7 +326,7 @@ fmul2_e:
   ;# Compute src1[2] * src2
   movq 16(%rsi), %rdx
   mulxq 0(%rcx), %r8, %r9
-  xor %r10, %r10
+  xor %r10d, %r10d
   adcxq 16(%rdi), %r8
   movq %r8, 16(%rdi)
   mulxq 8(%rcx), %r10, %r11
@@ -348,7 +348,7 @@ fmul2_e:
   ;# Compute src1[3] * src2
   movq 24(%rsi), %rdx
   mulxq 0(%rcx), %r8, %r9
-  xor %r10, %r10
+  xor %r10d, %r10d
   adcxq 24(%rdi), %r8
   movq %r8, 24(%rdi)
   mulxq 8(%rcx), %r10, %r11
@@ -373,7 +373,7 @@ fmul2_e:
   ;# Compute src1[0] * src2
   movq 32(%rsi), %rdx
   mulxq 32(%rcx), %r8, %r9
-  xor %r10, %r10
+  xor %r10d, %r10d
   movq %r8, 64(%rdi)
   
   mulxq 40(%rcx), %r10, %r11
@@ -391,7 +391,7 @@ fmul2_e:
   ;# Compute src1[1] * src2
   movq 40(%rsi), %rdx
   mulxq 32(%rcx), %r8, %r9
-  xor %r10, %r10
+  xor %r10d, %r10d
   adcxq 72(%rdi), %r8
   movq %r8, 72(%rdi)
   mulxq 40(%rcx), %r10, %r11
@@ -413,7 +413,7 @@ fmul2_e:
   ;# Compute src1[2] * src2
   movq 48(%rsi), %rdx
   mulxq 32(%rcx), %r8, %r9
-  xor %r10, %r10
+  xor %r10d, %r10d
   adcxq 80(%rdi), %r8
   movq %r8, 80(%rdi)
   mulxq 40(%rcx), %r10, %r11
@@ -435,7 +435,7 @@ fmul2_e:
   ;# Compute src1[3] * src2
   movq 56(%rsi), %rdx
   mulxq 32(%rcx), %r8, %r9
-  xor %r10, %r10
+  xor %r10d, %r10d
   adcxq 88(%rdi), %r8
   movq %r8, 88(%rdi)
   mulxq 40(%rcx), %r10, %r11
@@ -464,7 +464,7 @@ fmul2_e:
   ;# Step 1: Compute dst + carry == tmp_hi * 38 + tmp_lo
   mov $38, %rdx
   mulxq 32(%rsi), %r8, %r13
-  xor %rcx, %rcx
+  xor %ecx, %ecx
   adoxq 0(%rsi), %r8
   mulxq 40(%rsi), %r9, %rbx
   adcx %r13, %r9
@@ -497,7 +497,7 @@ fmul2_e:
   ;# Step 1: Compute dst + carry == tmp_hi * 38 + tmp_lo
   mov $38, %rdx
   mulxq 96(%rsi), %r8, %r13
-  xor %rcx, %rcx
+  xor %ecx, %ecx
   adoxq 64(%rsi), %r8
   mulxq 104(%rsi), %r9, %rbx
   adcx %r13, %r9
@@ -545,7 +545,7 @@ fsqr_e:
   movq 0(%rsi), %rdx
   ;# f[0]
   mulxq 8(%rsi), %r8, %r14
-  xor %r15, %r15
+  xor %r15d, %r15d
   ;# f[1]*f[0]
   mulxq 16(%rsi), %r9, %r10
   adcx %r14, %r9
@@ -569,7 +569,7 @@ fsqr_e:
   ;# f[2]*f[1]
   
   ;# Step 2: Compute two parallel carry chains
-  xor %r15, %r15
+  xor %r15d, %r15d
   adox %rax, %r10
   adcx %r8, %r8
   adox %rcx, %r11
@@ -627,7 +627,7 @@ fsqr_e:
   ;# Step 1: Compute dst + carry == tmp_hi * 38 + tmp_lo
   mov $38, %rdx
   mulxq 32(%rsi), %r8, %r13
-  xor %rcx, %rcx
+  xor %ecx, %ecx
   adoxq 0(%rsi), %r8
   mulxq 40(%rsi), %r9, %rbx
   adcx %r13, %r9
@@ -675,7 +675,7 @@ fsqr2_e:
   movq 0(%rsi), %rdx
   ;# f[0]
   mulxq 8(%rsi), %r8, %r14
-  xor %r15, %r15
+  xor %r15d, %r15d
   ;# f[1]*f[0]
   mulxq 16(%rsi), %r9, %r10
   adcx %r14, %r9
@@ -699,7 +699,7 @@ fsqr2_e:
   ;# f[2]*f[1]
   
   ;# Step 2: Compute two parallel carry chains
-  xor %r15, %r15
+  xor %r15d, %r15d
   adox %rax, %r10
   adcx %r8, %r8
   adox %rcx, %r11
@@ -754,7 +754,7 @@ fsqr2_e:
   movq 32(%rsi), %rdx
   ;# f[0]
   mulxq 40(%rsi), %r8, %r14
-  xor %r15, %r15
+  xor %r15d, %r15d
   ;# f[1]*f[0]
   mulxq 48(%rsi), %r9, %r10
   adcx %r14, %r9
@@ -778,7 +778,7 @@ fsqr2_e:
   ;# f[2]*f[1]
   
   ;# Step 2: Compute two parallel carry chains
-  xor %r15, %r15
+  xor %r15d, %r15d
   adox %rax, %r10
   adcx %r8, %r8
   adox %rcx, %r11
@@ -836,7 +836,7 @@ fsqr2_e:
   ;# Step 1: Compute dst + carry == tmp_hi * 38 + tmp_lo
   mov $38, %rdx
   mulxq 32(%rsi), %r8, %r13
-  xor %rcx, %rcx
+  xor %ecx, %ecx
   adoxq 0(%rsi), %r8
   mulxq 40(%rsi), %r9, %rbx
   adcx %r13, %r9
@@ -869,7 +869,7 @@ fsqr2_e:
   ;# Step 1: Compute dst + carry == tmp_hi * 38 + tmp_lo
   mov $38, %rdx
   mulxq 96(%rsi), %r8, %r13
-  xor %rcx, %rcx
+  xor %ecx, %ecx
   adoxq 64(%rsi), %r8
   mulxq 104(%rsi), %r9, %rbx
   adcx %r13, %r9

--- a/dist/ccf/curve25519-x86_64-mingw.S
+++ b/dist/ccf/curve25519-x86_64-mingw.S
@@ -7,11 +7,11 @@ add_scalar_e:
   mov %rdx, %rsi
   mov %r8, %rdx
   ;# Clear registers to propagate the carry bit
-  xor %r8, %r8
-  xor %r9, %r9
-  xor %r10, %r10
-  xor %r11, %r11
-  xor %rax, %rax
+  xor %r8d, %r8d
+  xor %r9d, %r9d
+  xor %r10d, %r10d
+  xor %r11d, %r11d
+  xor %eax, %eax
   
   ;# Begin addition chain
   addq 0(%rsi), %rdx
@@ -52,7 +52,7 @@ fadd_e:
   cmovc %rdx, %rax
   
   ;# Step 2: Add carry*38 to the original sum
-  xor %rcx, %rcx
+  xor %ecx, %ecx
   add %rax, %r8
   adcx %rcx, %r9
   movq %r9, 8(%rdi)
@@ -176,7 +176,7 @@ fmul_e:
   ;# Compute src1[0] * src2
   movq 0(%rsi), %rdx
   mulxq 0(%rcx), %r8, %r9
-  xor %r10, %r10
+  xor %r10d, %r10d
   movq %r8, 0(%rdi)
   
   mulxq 8(%rcx), %r10, %r11
@@ -194,7 +194,7 @@ fmul_e:
   ;# Compute src1[1] * src2
   movq 8(%rsi), %rdx
   mulxq 0(%rcx), %r8, %r9
-  xor %r10, %r10
+  xor %r10d, %r10d
   adcxq 8(%rdi), %r8
   movq %r8, 8(%rdi)
   mulxq 8(%rcx), %r10, %r11
@@ -216,7 +216,7 @@ fmul_e:
   ;# Compute src1[2] * src2
   movq 16(%rsi), %rdx
   mulxq 0(%rcx), %r8, %r9
-  xor %r10, %r10
+  xor %r10d, %r10d
   adcxq 16(%rdi), %r8
   movq %r8, 16(%rdi)
   mulxq 8(%rcx), %r10, %r11
@@ -238,7 +238,7 @@ fmul_e:
   ;# Compute src1[3] * src2
   movq 24(%rsi), %rdx
   mulxq 0(%rcx), %r8, %r9
-  xor %r10, %r10
+  xor %r10d, %r10d
   adcxq 24(%rdi), %r8
   movq %r8, 24(%rdi)
   mulxq 8(%rcx), %r10, %r11
@@ -267,7 +267,7 @@ fmul_e:
   ;# Step 1: Compute dst + carry == tmp_hi * 38 + tmp_lo
   mov $38, %rdx
   mulxq 32(%rsi), %r8, %r13
-  xor %rcx, %rcx
+  xor %ecx, %ecx
   adoxq 0(%rsi), %r8
   mulxq 40(%rsi), %r9, %rbx
   adcx %r13, %r9
@@ -320,7 +320,7 @@ fmul2_e:
   ;# Compute src1[0] * src2
   movq 0(%rsi), %rdx
   mulxq 0(%rcx), %r8, %r9
-  xor %r10, %r10
+  xor %r10d, %r10d
   movq %r8, 0(%rdi)
   
   mulxq 8(%rcx), %r10, %r11
@@ -338,7 +338,7 @@ fmul2_e:
   ;# Compute src1[1] * src2
   movq 8(%rsi), %rdx
   mulxq 0(%rcx), %r8, %r9
-  xor %r10, %r10
+  xor %r10d, %r10d
   adcxq 8(%rdi), %r8
   movq %r8, 8(%rdi)
   mulxq 8(%rcx), %r10, %r11
@@ -360,7 +360,7 @@ fmul2_e:
   ;# Compute src1[2] * src2
   movq 16(%rsi), %rdx
   mulxq 0(%rcx), %r8, %r9
-  xor %r10, %r10
+  xor %r10d, %r10d
   adcxq 16(%rdi), %r8
   movq %r8, 16(%rdi)
   mulxq 8(%rcx), %r10, %r11
@@ -382,7 +382,7 @@ fmul2_e:
   ;# Compute src1[3] * src2
   movq 24(%rsi), %rdx
   mulxq 0(%rcx), %r8, %r9
-  xor %r10, %r10
+  xor %r10d, %r10d
   adcxq 24(%rdi), %r8
   movq %r8, 24(%rdi)
   mulxq 8(%rcx), %r10, %r11
@@ -407,7 +407,7 @@ fmul2_e:
   ;# Compute src1[0] * src2
   movq 32(%rsi), %rdx
   mulxq 32(%rcx), %r8, %r9
-  xor %r10, %r10
+  xor %r10d, %r10d
   movq %r8, 64(%rdi)
   
   mulxq 40(%rcx), %r10, %r11
@@ -425,7 +425,7 @@ fmul2_e:
   ;# Compute src1[1] * src2
   movq 40(%rsi), %rdx
   mulxq 32(%rcx), %r8, %r9
-  xor %r10, %r10
+  xor %r10d, %r10d
   adcxq 72(%rdi), %r8
   movq %r8, 72(%rdi)
   mulxq 40(%rcx), %r10, %r11
@@ -447,7 +447,7 @@ fmul2_e:
   ;# Compute src1[2] * src2
   movq 48(%rsi), %rdx
   mulxq 32(%rcx), %r8, %r9
-  xor %r10, %r10
+  xor %r10d, %r10d
   adcxq 80(%rdi), %r8
   movq %r8, 80(%rdi)
   mulxq 40(%rcx), %r10, %r11
@@ -469,7 +469,7 @@ fmul2_e:
   ;# Compute src1[3] * src2
   movq 56(%rsi), %rdx
   mulxq 32(%rcx), %r8, %r9
-  xor %r10, %r10
+  xor %r10d, %r10d
   adcxq 88(%rdi), %r8
   movq %r8, 88(%rdi)
   mulxq 40(%rcx), %r10, %r11
@@ -498,7 +498,7 @@ fmul2_e:
   ;# Step 1: Compute dst + carry == tmp_hi * 38 + tmp_lo
   mov $38, %rdx
   mulxq 32(%rsi), %r8, %r13
-  xor %rcx, %rcx
+  xor %ecx, %ecx
   adoxq 0(%rsi), %r8
   mulxq 40(%rsi), %r9, %rbx
   adcx %r13, %r9
@@ -531,7 +531,7 @@ fmul2_e:
   ;# Step 1: Compute dst + carry == tmp_hi * 38 + tmp_lo
   mov $38, %rdx
   mulxq 96(%rsi), %r8, %r13
-  xor %rcx, %rcx
+  xor %ecx, %ecx
   adoxq 64(%rsi), %r8
   mulxq 104(%rsi), %r9, %rbx
   adcx %r13, %r9
@@ -585,7 +585,7 @@ fsqr_e:
   movq 0(%rsi), %rdx
   ;# f[0]
   mulxq 8(%rsi), %r8, %r14
-  xor %r15, %r15
+  xor %r15d, %r15d
   ;# f[1]*f[0]
   mulxq 16(%rsi), %r9, %r10
   adcx %r14, %r9
@@ -609,7 +609,7 @@ fsqr_e:
   ;# f[2]*f[1]
   
   ;# Step 2: Compute two parallel carry chains
-  xor %r15, %r15
+  xor %r15d, %r15d
   adox %rax, %r10
   adcx %r8, %r8
   adox %rcx, %r11
@@ -667,7 +667,7 @@ fsqr_e:
   ;# Step 1: Compute dst + carry == tmp_hi * 38 + tmp_lo
   mov $38, %rdx
   mulxq 32(%rsi), %r8, %r13
-  xor %rcx, %rcx
+  xor %ecx, %ecx
   adoxq 0(%rsi), %r8
   mulxq 40(%rsi), %r9, %rbx
   adcx %r13, %r9
@@ -721,7 +721,7 @@ fsqr2_e:
   movq 0(%rsi), %rdx
   ;# f[0]
   mulxq 8(%rsi), %r8, %r14
-  xor %r15, %r15
+  xor %r15d, %r15d
   ;# f[1]*f[0]
   mulxq 16(%rsi), %r9, %r10
   adcx %r14, %r9
@@ -745,7 +745,7 @@ fsqr2_e:
   ;# f[2]*f[1]
   
   ;# Step 2: Compute two parallel carry chains
-  xor %r15, %r15
+  xor %r15d, %r15d
   adox %rax, %r10
   adcx %r8, %r8
   adox %rcx, %r11
@@ -800,7 +800,7 @@ fsqr2_e:
   movq 32(%rsi), %rdx
   ;# f[0]
   mulxq 40(%rsi), %r8, %r14
-  xor %r15, %r15
+  xor %r15d, %r15d
   ;# f[1]*f[0]
   mulxq 48(%rsi), %r9, %r10
   adcx %r14, %r9
@@ -824,7 +824,7 @@ fsqr2_e:
   ;# f[2]*f[1]
   
   ;# Step 2: Compute two parallel carry chains
-  xor %r15, %r15
+  xor %r15d, %r15d
   adox %rax, %r10
   adcx %r8, %r8
   adox %rcx, %r11
@@ -882,7 +882,7 @@ fsqr2_e:
   ;# Step 1: Compute dst + carry == tmp_hi * 38 + tmp_lo
   mov $38, %rdx
   mulxq 32(%rsi), %r8, %r13
-  xor %rcx, %rcx
+  xor %ecx, %ecx
   adoxq 0(%rsi), %r8
   mulxq 40(%rsi), %r9, %rbx
   adcx %r13, %r9
@@ -915,7 +915,7 @@ fsqr2_e:
   ;# Step 1: Compute dst + carry == tmp_hi * 38 + tmp_lo
   mov $38, %rdx
   mulxq 96(%rsi), %r8, %r13
-  xor %rcx, %rcx
+  xor %ecx, %ecx
   adoxq 64(%rsi), %r8
   mulxq 104(%rsi), %r9, %rbx
   adcx %r13, %r9

--- a/dist/ccf/curve25519-x86_64-msvc.asm
+++ b/dist/ccf/curve25519-x86_64-msvc.asm
@@ -7,11 +7,11 @@ add_scalar_e proc
   mov rsi, rdx
   mov rdx, r8
   ;# Clear registers to propagate the carry bit
-  xor r8, r8
-  xor r9, r9
-  xor r10, r10
-  xor r11, r11
-  xor rax, rax
+  xor r8d, r8d
+  xor r9d, r9d
+  xor r10d, r10d
+  xor r11d, r11d
+  xor eax, eax
   
   ;# Begin addition chain
   add rdx, qword ptr [rsi + 0]
@@ -52,7 +52,7 @@ fadd_e proc
   cmovc rax, rdx
   
   ;# Step 2: Add carry*38 to the original sum
-  xor rcx, rcx
+  xor ecx, ecx
   add r8, rax
   adcx r9, rcx
   mov qword ptr [rdi + 8], r9
@@ -176,7 +176,7 @@ fmul_e proc
   ;# Compute src1[0] * src2
   mov rdx, qword ptr [rsi + 0]
   mulx r9, r8, qword ptr [rcx + 0]
-  xor r10, r10
+  xor r10d, r10d
   mov qword ptr [rdi + 0], r8
   
   mulx r11, r10, qword ptr [rcx + 8]
@@ -194,7 +194,7 @@ fmul_e proc
   ;# Compute src1[1] * src2
   mov rdx, qword ptr [rsi + 8]
   mulx r9, r8, qword ptr [rcx + 0]
-  xor r10, r10
+  xor r10d, r10d
   adcx r8, qword ptr [rdi + 8]
   mov qword ptr [rdi + 8], r8
   mulx r11, r10, qword ptr [rcx + 8]
@@ -216,7 +216,7 @@ fmul_e proc
   ;# Compute src1[2] * src2
   mov rdx, qword ptr [rsi + 16]
   mulx r9, r8, qword ptr [rcx + 0]
-  xor r10, r10
+  xor r10d, r10d
   adcx r8, qword ptr [rdi + 16]
   mov qword ptr [rdi + 16], r8
   mulx r11, r10, qword ptr [rcx + 8]
@@ -238,7 +238,7 @@ fmul_e proc
   ;# Compute src1[3] * src2
   mov rdx, qword ptr [rsi + 24]
   mulx r9, r8, qword ptr [rcx + 0]
-  xor r10, r10
+  xor r10d, r10d
   adcx r8, qword ptr [rdi + 24]
   mov qword ptr [rdi + 24], r8
   mulx r11, r10, qword ptr [rcx + 8]
@@ -267,7 +267,7 @@ fmul_e proc
   ;# Step 1: Compute dst + carry == tmp_hi * 38 + tmp_lo
   mov rdx, 38
   mulx r13, r8, qword ptr [rsi + 32]
-  xor rcx, rcx
+  xor ecx, ecx
   adox r8, qword ptr [rsi + 0]
   mulx rbx, r9, qword ptr [rsi + 40]
   adcx r9, r13
@@ -320,7 +320,7 @@ fmul2_e proc
   ;# Compute src1[0] * src2
   mov rdx, qword ptr [rsi + 0]
   mulx r9, r8, qword ptr [rcx + 0]
-  xor r10, r10
+  xor r10d, r10d
   mov qword ptr [rdi + 0], r8
   
   mulx r11, r10, qword ptr [rcx + 8]
@@ -338,7 +338,7 @@ fmul2_e proc
   ;# Compute src1[1] * src2
   mov rdx, qword ptr [rsi + 8]
   mulx r9, r8, qword ptr [rcx + 0]
-  xor r10, r10
+  xor r10d, r10d
   adcx r8, qword ptr [rdi + 8]
   mov qword ptr [rdi + 8], r8
   mulx r11, r10, qword ptr [rcx + 8]
@@ -360,7 +360,7 @@ fmul2_e proc
   ;# Compute src1[2] * src2
   mov rdx, qword ptr [rsi + 16]
   mulx r9, r8, qword ptr [rcx + 0]
-  xor r10, r10
+  xor r10d, r10d
   adcx r8, qword ptr [rdi + 16]
   mov qword ptr [rdi + 16], r8
   mulx r11, r10, qword ptr [rcx + 8]
@@ -382,7 +382,7 @@ fmul2_e proc
   ;# Compute src1[3] * src2
   mov rdx, qword ptr [rsi + 24]
   mulx r9, r8, qword ptr [rcx + 0]
-  xor r10, r10
+  xor r10d, r10d
   adcx r8, qword ptr [rdi + 24]
   mov qword ptr [rdi + 24], r8
   mulx r11, r10, qword ptr [rcx + 8]
@@ -407,7 +407,7 @@ fmul2_e proc
   ;# Compute src1[0] * src2
   mov rdx, qword ptr [rsi + 32]
   mulx r9, r8, qword ptr [rcx + 32]
-  xor r10, r10
+  xor r10d, r10d
   mov qword ptr [rdi + 64], r8
   
   mulx r11, r10, qword ptr [rcx + 40]
@@ -425,7 +425,7 @@ fmul2_e proc
   ;# Compute src1[1] * src2
   mov rdx, qword ptr [rsi + 40]
   mulx r9, r8, qword ptr [rcx + 32]
-  xor r10, r10
+  xor r10d, r10d
   adcx r8, qword ptr [rdi + 72]
   mov qword ptr [rdi + 72], r8
   mulx r11, r10, qword ptr [rcx + 40]
@@ -447,7 +447,7 @@ fmul2_e proc
   ;# Compute src1[2] * src2
   mov rdx, qword ptr [rsi + 48]
   mulx r9, r8, qword ptr [rcx + 32]
-  xor r10, r10
+  xor r10d, r10d
   adcx r8, qword ptr [rdi + 80]
   mov qword ptr [rdi + 80], r8
   mulx r11, r10, qword ptr [rcx + 40]
@@ -469,7 +469,7 @@ fmul2_e proc
   ;# Compute src1[3] * src2
   mov rdx, qword ptr [rsi + 56]
   mulx r9, r8, qword ptr [rcx + 32]
-  xor r10, r10
+  xor r10d, r10d
   adcx r8, qword ptr [rdi + 88]
   mov qword ptr [rdi + 88], r8
   mulx r11, r10, qword ptr [rcx + 40]
@@ -498,7 +498,7 @@ fmul2_e proc
   ;# Step 1: Compute dst + carry == tmp_hi * 38 + tmp_lo
   mov rdx, 38
   mulx r13, r8, qword ptr [rsi + 32]
-  xor rcx, rcx
+  xor ecx, ecx
   adox r8, qword ptr [rsi + 0]
   mulx rbx, r9, qword ptr [rsi + 40]
   adcx r9, r13
@@ -531,7 +531,7 @@ fmul2_e proc
   ;# Step 1: Compute dst + carry == tmp_hi * 38 + tmp_lo
   mov rdx, 38
   mulx r13, r8, qword ptr [rsi + 96]
-  xor rcx, rcx
+  xor ecx, ecx
   adox r8, qword ptr [rsi + 64]
   mulx rbx, r9, qword ptr [rsi + 104]
   adcx r9, r13
@@ -585,7 +585,7 @@ fsqr_e proc
   mov rdx, qword ptr [rsi + 0]
   ;# f[0]
   mulx r14, r8, qword ptr [rsi + 8]
-  xor r15, r15
+  xor r15d, r15d
   ;# f[1]*f[0]
   mulx r10, r9, qword ptr [rsi + 16]
   adcx r9, r14
@@ -609,7 +609,7 @@ fsqr_e proc
   ;# f[2]*f[1]
   
   ;# Step 2: Compute two parallel carry chains
-  xor r15, r15
+  xor r15d, r15d
   adox r10, rax
   adcx r8, r8
   adox r11, rcx
@@ -667,7 +667,7 @@ fsqr_e proc
   ;# Step 1: Compute dst + carry == tmp_hi * 38 + tmp_lo
   mov rdx, 38
   mulx r13, r8, qword ptr [rsi + 32]
-  xor rcx, rcx
+  xor ecx, ecx
   adox r8, qword ptr [rsi + 0]
   mulx rbx, r9, qword ptr [rsi + 40]
   adcx r9, r13
@@ -721,7 +721,7 @@ fsqr2_e proc
   mov rdx, qword ptr [rsi + 0]
   ;# f[0]
   mulx r14, r8, qword ptr [rsi + 8]
-  xor r15, r15
+  xor r15d, r15d
   ;# f[1]*f[0]
   mulx r10, r9, qword ptr [rsi + 16]
   adcx r9, r14
@@ -745,7 +745,7 @@ fsqr2_e proc
   ;# f[2]*f[1]
   
   ;# Step 2: Compute two parallel carry chains
-  xor r15, r15
+  xor r15d, r15d
   adox r10, rax
   adcx r8, r8
   adox r11, rcx
@@ -800,7 +800,7 @@ fsqr2_e proc
   mov rdx, qword ptr [rsi + 32]
   ;# f[0]
   mulx r14, r8, qword ptr [rsi + 40]
-  xor r15, r15
+  xor r15d, r15d
   ;# f[1]*f[0]
   mulx r10, r9, qword ptr [rsi + 48]
   adcx r9, r14
@@ -824,7 +824,7 @@ fsqr2_e proc
   ;# f[2]*f[1]
   
   ;# Step 2: Compute two parallel carry chains
-  xor r15, r15
+  xor r15d, r15d
   adox r10, rax
   adcx r8, r8
   adox r11, rcx
@@ -882,7 +882,7 @@ fsqr2_e proc
   ;# Step 1: Compute dst + carry == tmp_hi * 38 + tmp_lo
   mov rdx, 38
   mulx r13, r8, qword ptr [rsi + 32]
-  xor rcx, rcx
+  xor ecx, ecx
   adox r8, qword ptr [rsi + 0]
   mulx rbx, r9, qword ptr [rsi + 40]
   adcx r9, r13
@@ -915,7 +915,7 @@ fsqr2_e proc
   ;# Step 1: Compute dst + carry == tmp_hi * 38 + tmp_lo
   mov rdx, 38
   mulx r13, r8, qword ptr [rsi + 96]
-  xor rcx, rcx
+  xor ecx, ecx
   adox r8, qword ptr [rsi + 64]
   mulx rbx, r9, qword ptr [rsi + 104]
   adcx r9, r13

--- a/dist/gcc-compatible/curve25519-inline.h
+++ b/dist/gcc-compatible/curve25519-inline.h
@@ -10,11 +10,11 @@ static inline uint64_t add_scalar (uint64_t *out, uint64_t *f1, uint64_t f2)
 
   asm volatile(
     // Clear registers to propagate the carry bit
-    "  xor %%r8, %%r8;"
-    "  xor %%r9, %%r9;"
-    "  xor %%r10, %%r10;"
-    "  xor %%r11, %%r11;"
-    "  xor %1, %1;"
+    "  xor %%r8d, %%r8d;"
+    "  xor %%r9d, %%r9d;"
+    "  xor %%r10d, %%r10d;"
+    "  xor %%r11d, %%r11d;"
+    "  xor %k1, %k1;"
 
     // Begin addition chain
     "  addq 0(%3), %0;"
@@ -58,7 +58,7 @@ static inline void fadd (uint64_t *out, uint64_t *f1, uint64_t *f2)
     "  cmovc %0, %%rax;"
 
     // Step 2: Add carry*38 to the original sum
-    "  xor %%rcx, %%rcx;"
+    "  xor %%ecx, %%ecx;"
     "  add %%rax, %%r8;"
     "  adcx %%rcx, %%r9;"
     "  movq %%r9, 8(%1);"
@@ -131,7 +131,7 @@ static inline void fmul (uint64_t *out, uint64_t *f1, uint64_t *f2, uint64_t *tm
 
     // Compute src1[0] * src2
     "  movq 0(%1), %%rdx;"
-    "  mulxq 0(%2), %%r8, %%r9;"       "  xor %%r10, %%r10;"     "  movq %%r8, 0(%3);"
+    "  mulxq 0(%2), %%r8, %%r9;"       "  xor %%r10d, %%r10d;"     "  movq %%r8, 0(%3);"
     "  mulxq 8(%2), %%r10, %%r11;"     "  adox %%r9, %%r10;"     "  movq %%r10, 8(%3);"
     "  mulxq 16(%2), %%rbx, %%r13;"    "  adox %%r11, %%rbx;"
     "  mulxq 24(%2), %%r14, %%rdx;"    "  adox %%r13, %%r14;"    "  mov $0, %%rax;"
@@ -139,7 +139,7 @@ static inline void fmul (uint64_t *out, uint64_t *f1, uint64_t *f2, uint64_t *tm
 
     // Compute src1[1] * src2
     "  movq 8(%1), %%rdx;"
-    "  mulxq 0(%2), %%r8, %%r9;"       "  xor %%r10, %%r10;"     "  adcxq 8(%3), %%r8;"    "  movq %%r8, 8(%3);"
+    "  mulxq 0(%2), %%r8, %%r9;"       "  xor %%r10d, %%r10d;"     "  adcxq 8(%3), %%r8;"    "  movq %%r8, 8(%3);"
     "  mulxq 8(%2), %%r10, %%r11;"     "  adox %%r9, %%r10;"     "  adcx %%rbx, %%r10;"    "  movq %%r10, 16(%3);"
     "  mulxq 16(%2), %%rbx, %%r13;"    "  adox %%r11, %%rbx;"    "  adcx %%r14, %%rbx;"    "  mov $0, %%r8;"
     "  mulxq 24(%2), %%r14, %%rdx;"    "  adox %%r13, %%r14;"    "  adcx %%rax, %%r14;"    "  mov $0, %%rax;"
@@ -148,7 +148,7 @@ static inline void fmul (uint64_t *out, uint64_t *f1, uint64_t *f2, uint64_t *tm
 
     // Compute src1[2] * src2
     "  movq 16(%1), %%rdx;"
-    "  mulxq 0(%2), %%r8, %%r9;"       "  xor %%r10, %%r10;"    "  adcxq 16(%3), %%r8;"    "  movq %%r8, 16(%3);"
+    "  mulxq 0(%2), %%r8, %%r9;"       "  xor %%r10d, %%r10d;"    "  adcxq 16(%3), %%r8;"    "  movq %%r8, 16(%3);"
     "  mulxq 8(%2), %%r10, %%r11;"     "  adox %%r9, %%r10;"     "  adcx %%rbx, %%r10;"    "  movq %%r10, 24(%3);"
     "  mulxq 16(%2), %%rbx, %%r13;"    "  adox %%r11, %%rbx;"    "  adcx %%r14, %%rbx;"    "  mov $0, %%r8;"
     "  mulxq 24(%2), %%r14, %%rdx;"    "  adox %%r13, %%r14;"    "  adcx %%rax, %%r14;"    "  mov $0, %%rax;"
@@ -157,7 +157,7 @@ static inline void fmul (uint64_t *out, uint64_t *f1, uint64_t *f2, uint64_t *tm
 
     // Compute src1[3] * src2
     "  movq 24(%1), %%rdx;"
-    "  mulxq 0(%2), %%r8, %%r9;"       "  xor %%r10, %%r10;"    "  adcxq 24(%3), %%r8;"    "  movq %%r8, 24(%3);"
+    "  mulxq 0(%2), %%r8, %%r9;"       "  xor %%r10d, %%r10d;"    "  adcxq 24(%3), %%r8;"    "  movq %%r8, 24(%3);"
     "  mulxq 8(%2), %%r10, %%r11;"     "  adox %%r9, %%r10;"     "  adcx %%rbx, %%r10;"    "  movq %%r10, 32(%3);"
     "  mulxq 16(%2), %%rbx, %%r13;"    "  adox %%r11, %%rbx;"    "  adcx %%r14, %%rbx;"    "  movq %%rbx, 40(%3);"    "  mov $0, %%r8;"
     "  mulxq 24(%2), %%r14, %%rdx;"    "  adox %%r13, %%r14;"    "  adcx %%rax, %%r14;"    "  movq %%r14, 48(%3);"    "  mov $0, %%rax;"
@@ -172,7 +172,7 @@ static inline void fmul (uint64_t *out, uint64_t *f1, uint64_t *f2, uint64_t *tm
     // Step 1: Compute dst + carry == tmp_hi * 38 + tmp_lo
     "  mov $38, %%rdx;"
     "  mulxq 32(%1), %%r8, %%r13;"
-    "  xor %2, %2;"
+    "  xor %k2, %k2;"
     "  adoxq 0(%1), %%r8;"
     "  mulxq 40(%1), %%r9, %%rbx;"
     "  adcx %%r13, %%r9;"
@@ -219,7 +219,7 @@ static inline void fmul2 (uint64_t *out, uint64_t *f1, uint64_t *f2, uint64_t *t
 
     // Compute src1[0] * src2
     "  movq 0(%1), %%rdx;"
-    "  mulxq 0(%2), %%r8, %%r9;"       "  xor %%r10, %%r10;"     "  movq %%r8, 0(%3);"
+    "  mulxq 0(%2), %%r8, %%r9;"       "  xor %%r10d, %%r10d;"     "  movq %%r8, 0(%3);"
     "  mulxq 8(%2), %%r10, %%r11;"     "  adox %%r9, %%r10;"     "  movq %%r10, 8(%3);"
     "  mulxq 16(%2), %%rbx, %%r13;"    "  adox %%r11, %%rbx;"
     "  mulxq 24(%2), %%r14, %%rdx;"    "  adox %%r13, %%r14;"    "  mov $0, %%rax;"
@@ -227,7 +227,7 @@ static inline void fmul2 (uint64_t *out, uint64_t *f1, uint64_t *f2, uint64_t *t
 
     // Compute src1[1] * src2
     "  movq 8(%1), %%rdx;"
-    "  mulxq 0(%2), %%r8, %%r9;"       "  xor %%r10, %%r10;"     "  adcxq 8(%3), %%r8;"    "  movq %%r8, 8(%3);"
+    "  mulxq 0(%2), %%r8, %%r9;"       "  xor %%r10d, %%r10d;"     "  adcxq 8(%3), %%r8;"    "  movq %%r8, 8(%3);"
     "  mulxq 8(%2), %%r10, %%r11;"     "  adox %%r9, %%r10;"     "  adcx %%rbx, %%r10;"    "  movq %%r10, 16(%3);"
     "  mulxq 16(%2), %%rbx, %%r13;"    "  adox %%r11, %%rbx;"    "  adcx %%r14, %%rbx;"    "  mov $0, %%r8;"
     "  mulxq 24(%2), %%r14, %%rdx;"    "  adox %%r13, %%r14;"    "  adcx %%rax, %%r14;"    "  mov $0, %%rax;"
@@ -236,7 +236,7 @@ static inline void fmul2 (uint64_t *out, uint64_t *f1, uint64_t *f2, uint64_t *t
 
     // Compute src1[2] * src2
     "  movq 16(%1), %%rdx;"
-    "  mulxq 0(%2), %%r8, %%r9;"       "  xor %%r10, %%r10;"    "  adcxq 16(%3), %%r8;"    "  movq %%r8, 16(%3);"
+    "  mulxq 0(%2), %%r8, %%r9;"       "  xor %%r10d, %%r10d;"    "  adcxq 16(%3), %%r8;"    "  movq %%r8, 16(%3);"
     "  mulxq 8(%2), %%r10, %%r11;"     "  adox %%r9, %%r10;"     "  adcx %%rbx, %%r10;"    "  movq %%r10, 24(%3);"
     "  mulxq 16(%2), %%rbx, %%r13;"    "  adox %%r11, %%rbx;"    "  adcx %%r14, %%rbx;"    "  mov $0, %%r8;"
     "  mulxq 24(%2), %%r14, %%rdx;"    "  adox %%r13, %%r14;"    "  adcx %%rax, %%r14;"    "  mov $0, %%rax;"
@@ -245,7 +245,7 @@ static inline void fmul2 (uint64_t *out, uint64_t *f1, uint64_t *f2, uint64_t *t
 
     // Compute src1[3] * src2
     "  movq 24(%1), %%rdx;"
-    "  mulxq 0(%2), %%r8, %%r9;"       "  xor %%r10, %%r10;"    "  adcxq 24(%3), %%r8;"    "  movq %%r8, 24(%3);"
+    "  mulxq 0(%2), %%r8, %%r9;"       "  xor %%r10d, %%r10d;"    "  adcxq 24(%3), %%r8;"    "  movq %%r8, 24(%3);"
     "  mulxq 8(%2), %%r10, %%r11;"     "  adox %%r9, %%r10;"     "  adcx %%rbx, %%r10;"    "  movq %%r10, 32(%3);"
     "  mulxq 16(%2), %%rbx, %%r13;"    "  adox %%r11, %%rbx;"    "  adcx %%r14, %%rbx;"    "  movq %%rbx, 40(%3);"    "  mov $0, %%r8;"
     "  mulxq 24(%2), %%r14, %%rdx;"    "  adox %%r13, %%r14;"    "  adcx %%rax, %%r14;"    "  movq %%r14, 48(%3);"    "  mov $0, %%rax;"
@@ -255,7 +255,7 @@ static inline void fmul2 (uint64_t *out, uint64_t *f1, uint64_t *f2, uint64_t *t
 
     // Compute src1[0] * src2
     "  movq 32(%1), %%rdx;"
-    "  mulxq 32(%2), %%r8, %%r9;"       "  xor %%r10, %%r10;"     "  movq %%r8, 64(%3);"
+    "  mulxq 32(%2), %%r8, %%r9;"       "  xor %%r10d, %%r10d;"     "  movq %%r8, 64(%3);"
     "  mulxq 40(%2), %%r10, %%r11;"     "  adox %%r9, %%r10;"     "  movq %%r10, 72(%3);"
     "  mulxq 48(%2), %%rbx, %%r13;"    "  adox %%r11, %%rbx;"
     "  mulxq 56(%2), %%r14, %%rdx;"    "  adox %%r13, %%r14;"    "  mov $0, %%rax;"
@@ -263,7 +263,7 @@ static inline void fmul2 (uint64_t *out, uint64_t *f1, uint64_t *f2, uint64_t *t
 
     // Compute src1[1] * src2
     "  movq 40(%1), %%rdx;"
-    "  mulxq 32(%2), %%r8, %%r9;"       "  xor %%r10, %%r10;"     "  adcxq 72(%3), %%r8;"    "  movq %%r8, 72(%3);"
+    "  mulxq 32(%2), %%r8, %%r9;"       "  xor %%r10d, %%r10d;"     "  adcxq 72(%3), %%r8;"    "  movq %%r8, 72(%3);"
     "  mulxq 40(%2), %%r10, %%r11;"     "  adox %%r9, %%r10;"     "  adcx %%rbx, %%r10;"    "  movq %%r10, 80(%3);"
     "  mulxq 48(%2), %%rbx, %%r13;"    "  adox %%r11, %%rbx;"    "  adcx %%r14, %%rbx;"    "  mov $0, %%r8;"
     "  mulxq 56(%2), %%r14, %%rdx;"    "  adox %%r13, %%r14;"    "  adcx %%rax, %%r14;"    "  mov $0, %%rax;"
@@ -272,7 +272,7 @@ static inline void fmul2 (uint64_t *out, uint64_t *f1, uint64_t *f2, uint64_t *t
 
     // Compute src1[2] * src2
     "  movq 48(%1), %%rdx;"
-    "  mulxq 32(%2), %%r8, %%r9;"       "  xor %%r10, %%r10;"    "  adcxq 80(%3), %%r8;"    "  movq %%r8, 80(%3);"
+    "  mulxq 32(%2), %%r8, %%r9;"       "  xor %%r10d, %%r10d;"    "  adcxq 80(%3), %%r8;"    "  movq %%r8, 80(%3);"
     "  mulxq 40(%2), %%r10, %%r11;"     "  adox %%r9, %%r10;"     "  adcx %%rbx, %%r10;"    "  movq %%r10, 88(%3);"
     "  mulxq 48(%2), %%rbx, %%r13;"    "  adox %%r11, %%rbx;"    "  adcx %%r14, %%rbx;"    "  mov $0, %%r8;"
     "  mulxq 56(%2), %%r14, %%rdx;"    "  adox %%r13, %%r14;"    "  adcx %%rax, %%r14;"    "  mov $0, %%rax;"
@@ -281,7 +281,7 @@ static inline void fmul2 (uint64_t *out, uint64_t *f1, uint64_t *f2, uint64_t *t
 
     // Compute src1[3] * src2
     "  movq 56(%1), %%rdx;"
-    "  mulxq 32(%2), %%r8, %%r9;"       "  xor %%r10, %%r10;"    "  adcxq 88(%3), %%r8;"    "  movq %%r8, 88(%3);"
+    "  mulxq 32(%2), %%r8, %%r9;"       "  xor %%r10d, %%r10d;"    "  adcxq 88(%3), %%r8;"    "  movq %%r8, 88(%3);"
     "  mulxq 40(%2), %%r10, %%r11;"     "  adox %%r9, %%r10;"     "  adcx %%rbx, %%r10;"    "  movq %%r10, 96(%3);"
     "  mulxq 48(%2), %%rbx, %%r13;"    "  adox %%r11, %%rbx;"    "  adcx %%r14, %%rbx;"    "  movq %%rbx, 104(%3);"    "  mov $0, %%r8;"
     "  mulxq 56(%2), %%r14, %%rdx;"    "  adox %%r13, %%r14;"    "  adcx %%rax, %%r14;"    "  movq %%r14, 112(%3);"    "  mov $0, %%rax;"
@@ -296,7 +296,7 @@ static inline void fmul2 (uint64_t *out, uint64_t *f1, uint64_t *f2, uint64_t *t
     // Step 1: Compute dst + carry == tmp_hi * 38 + tmp_lo
     "  mov $38, %%rdx;"
     "  mulxq 32(%1), %%r8, %%r13;"
-    "  xor %2, %2;"
+    "  xor %k2, %k2;"
     "  adoxq 0(%1), %%r8;"
     "  mulxq 40(%1), %%r9, %%rbx;"
     "  adcx %%r13, %%r9;"
@@ -329,7 +329,7 @@ static inline void fmul2 (uint64_t *out, uint64_t *f1, uint64_t *f2, uint64_t *t
     // Step 1: Compute dst + carry == tmp_hi * 38 + tmp_lo
     "  mov $38, %%rdx;"
     "  mulxq 96(%1), %%r8, %%r13;"
-    "  xor %2, %2;"
+    "  xor %k2, %k2;"
     "  adoxq 64(%1), %%r8;"
     "  mulxq 104(%1), %%r9, %%rbx;"
     "  adcx %%r13, %%r9;"
@@ -502,7 +502,7 @@ static inline void fsqr (uint64_t *out, uint64_t *f, uint64_t *tmp)
 
     // Step 1: Compute all partial products
     "  movq 0(%1), %%rdx;"                                       // f[0]
-    "  mulxq 8(%1), %%r8, %%r14;"      "  xor %%r15, %%r15;"     // f[1]*f[0]
+    "  mulxq 8(%1), %%r8, %%r14;"      "  xor %%r15d, %%r15d;"     // f[1]*f[0]
     "  mulxq 16(%1), %%r9, %%r10;"     "  adcx %%r14, %%r9;"     // f[2]*f[0]
     "  mulxq 24(%1), %%rax, %%rcx;"    "  adcx %%rax, %%r10;"    // f[3]*f[0]
     "  movq 24(%1), %%rdx;"                                      // f[3]
@@ -512,7 +512,7 @@ static inline void fsqr (uint64_t *out, uint64_t *f, uint64_t *tmp)
     "  mulxq 16(%1), %%rax, %%rcx;"    "  mov $0, %%r14;"        // f[2]*f[1]
 
     // Step 2: Compute two parallel carry chains
-    "  xor %%r15, %%r15;"
+    "  xor %%r15d, %%r15d;"
     "  adox %%rax, %%r10;"
     "  adcx %%r8, %%r8;"
     "  adox %%rcx, %%r11;"
@@ -549,7 +549,7 @@ static inline void fsqr (uint64_t *out, uint64_t *f, uint64_t *tmp)
     // Step 1: Compute dst + carry == tmp_hi * 38 + tmp_lo
     "  mov $38, %%rdx;"
     "  mulxq 32(%1), %%r8, %%r13;"
-    "  xor %%rcx, %%rcx;"
+    "  xor %%ecx, %%ecx;"
     "  adoxq 0(%1), %%r8;"
     "  mulxq 40(%1), %%r9, %%rbx;"
     "  adcx %%r13, %%r9;"
@@ -593,7 +593,7 @@ static inline void fsqr2 (uint64_t *out, uint64_t *f, uint64_t *tmp)
   asm volatile(
     // Step 1: Compute all partial products
     "  movq 0(%1), %%rdx;"                                       // f[0]
-    "  mulxq 8(%1), %%r8, %%r14;"      "  xor %%r15, %%r15;"     // f[1]*f[0]
+    "  mulxq 8(%1), %%r8, %%r14;"      "  xor %%r15d, %%r15d;"     // f[1]*f[0]
     "  mulxq 16(%1), %%r9, %%r10;"     "  adcx %%r14, %%r9;"     // f[2]*f[0]
     "  mulxq 24(%1), %%rax, %%rcx;"    "  adcx %%rax, %%r10;"    // f[3]*f[0]
     "  movq 24(%1), %%rdx;"                                      // f[3]
@@ -603,7 +603,7 @@ static inline void fsqr2 (uint64_t *out, uint64_t *f, uint64_t *tmp)
     "  mulxq 16(%1), %%rax, %%rcx;"    "  mov $0, %%r14;"        // f[2]*f[1]
 
     // Step 2: Compute two parallel carry chains
-    "  xor %%r15, %%r15;"
+    "  xor %%r15d, %%r15d;"
     "  adox %%rax, %%r10;"
     "  adcx %%r8, %%r8;"
     "  adox %%rcx, %%r11;"
@@ -633,7 +633,7 @@ static inline void fsqr2 (uint64_t *out, uint64_t *f, uint64_t *tmp)
 
     // Step 1: Compute all partial products
     "  movq 32(%1), %%rdx;"                                       // f[0]
-    "  mulxq 40(%1), %%r8, %%r14;"      "  xor %%r15, %%r15;"     // f[1]*f[0]
+    "  mulxq 40(%1), %%r8, %%r14;"      "  xor %%r15d, %%r15d;"     // f[1]*f[0]
     "  mulxq 48(%1), %%r9, %%r10;"     "  adcx %%r14, %%r9;"     // f[2]*f[0]
     "  mulxq 56(%1), %%rax, %%rcx;"    "  adcx %%rax, %%r10;"    // f[3]*f[0]
     "  movq 56(%1), %%rdx;"                                      // f[3]
@@ -643,7 +643,7 @@ static inline void fsqr2 (uint64_t *out, uint64_t *f, uint64_t *tmp)
     "  mulxq 48(%1), %%rax, %%rcx;"    "  mov $0, %%r14;"        // f[2]*f[1]
 
     // Step 2: Compute two parallel carry chains
-    "  xor %%r15, %%r15;"
+    "  xor %%r15d, %%r15d;"
     "  adox %%rax, %%r10;"
     "  adcx %%r8, %%r8;"
     "  adox %%rcx, %%r11;"
@@ -678,7 +678,7 @@ static inline void fsqr2 (uint64_t *out, uint64_t *f, uint64_t *tmp)
     // Step 1: Compute dst + carry == tmp_hi * 38 + tmp_lo
     "  mov $38, %%rdx;"
     "  mulxq 32(%1), %%r8, %%r13;"
-    "  xor %%rcx, %%rcx;"
+    "  xor %%ecx, %%ecx;"
     "  adoxq 0(%1), %%r8;"
     "  mulxq 40(%1), %%r9, %%rbx;"
     "  adcx %%r13, %%r9;"
@@ -711,7 +711,7 @@ static inline void fsqr2 (uint64_t *out, uint64_t *f, uint64_t *tmp)
     // Step 1: Compute dst + carry == tmp_hi * 38 + tmp_lo
     "  mov $38, %%rdx;"
     "  mulxq 96(%1), %%r8, %%r13;"
-    "  xor %%rcx, %%rcx;"
+    "  xor %%ecx, %%ecx;"
     "  adoxq 64(%1), %%r8;"
     "  mulxq 104(%1), %%r9, %%rbx;"
     "  adcx %%r13, %%r9;"

--- a/dist/gcc-compatible/curve25519-x86_64-darwin.S
+++ b/dist/gcc-compatible/curve25519-x86_64-darwin.S
@@ -4,11 +4,11 @@ _add_scalar_e:
   push %rdi
   push %rsi
   ;# Clear registers to propagate the carry bit
-  xor %r8, %r8
-  xor %r9, %r9
-  xor %r10, %r10
-  xor %r11, %r11
-  xor %rax, %rax
+  xor %r8d, %r8d
+  xor %r9d, %r9d
+  xor %r10d, %r10d
+  xor %r11d, %r11d
+  xor %eax, %eax
   
   ;# Begin addition chain
   addq 0(%rsi), %rdx
@@ -44,7 +44,7 @@ _fadd_e:
   cmovc %rdx, %rax
   
   ;# Step 2: Add carry*38 to the original sum
-  xor %rcx, %rcx
+  xor %ecx, %ecx
   add %rax, %r8
   adcx %rcx, %r9
   movq %r9, 8(%rdi)
@@ -149,7 +149,7 @@ _fmul_e:
   ;# Compute src1[0] * src2
   movq 0(%rsi), %rdx
   mulxq 0(%rcx), %r8, %r9
-  xor %r10, %r10
+  xor %r10d, %r10d
   movq %r8, 0(%rdi)
   
   mulxq 8(%rcx), %r10, %r11
@@ -167,7 +167,7 @@ _fmul_e:
   ;# Compute src1[1] * src2
   movq 8(%rsi), %rdx
   mulxq 0(%rcx), %r8, %r9
-  xor %r10, %r10
+  xor %r10d, %r10d
   adcxq 8(%rdi), %r8
   movq %r8, 8(%rdi)
   mulxq 8(%rcx), %r10, %r11
@@ -189,7 +189,7 @@ _fmul_e:
   ;# Compute src1[2] * src2
   movq 16(%rsi), %rdx
   mulxq 0(%rcx), %r8, %r9
-  xor %r10, %r10
+  xor %r10d, %r10d
   adcxq 16(%rdi), %r8
   movq %r8, 16(%rdi)
   mulxq 8(%rcx), %r10, %r11
@@ -211,7 +211,7 @@ _fmul_e:
   ;# Compute src1[3] * src2
   movq 24(%rsi), %rdx
   mulxq 0(%rcx), %r8, %r9
-  xor %r10, %r10
+  xor %r10d, %r10d
   adcxq 24(%rdi), %r8
   movq %r8, 24(%rdi)
   mulxq 8(%rcx), %r10, %r11
@@ -240,7 +240,7 @@ _fmul_e:
   ;# Step 1: Compute dst + carry == tmp_hi * 38 + tmp_lo
   mov $38, %rdx
   mulxq 32(%rsi), %r8, %r13
-  xor %rcx, %rcx
+  xor %ecx, %ecx
   adoxq 0(%rsi), %r8
   mulxq 40(%rsi), %r9, %rbx
   adcx %r13, %r9
@@ -286,7 +286,7 @@ _fmul2_e:
   ;# Compute src1[0] * src2
   movq 0(%rsi), %rdx
   mulxq 0(%rcx), %r8, %r9
-  xor %r10, %r10
+  xor %r10d, %r10d
   movq %r8, 0(%rdi)
   
   mulxq 8(%rcx), %r10, %r11
@@ -304,7 +304,7 @@ _fmul2_e:
   ;# Compute src1[1] * src2
   movq 8(%rsi), %rdx
   mulxq 0(%rcx), %r8, %r9
-  xor %r10, %r10
+  xor %r10d, %r10d
   adcxq 8(%rdi), %r8
   movq %r8, 8(%rdi)
   mulxq 8(%rcx), %r10, %r11
@@ -326,7 +326,7 @@ _fmul2_e:
   ;# Compute src1[2] * src2
   movq 16(%rsi), %rdx
   mulxq 0(%rcx), %r8, %r9
-  xor %r10, %r10
+  xor %r10d, %r10d
   adcxq 16(%rdi), %r8
   movq %r8, 16(%rdi)
   mulxq 8(%rcx), %r10, %r11
@@ -348,7 +348,7 @@ _fmul2_e:
   ;# Compute src1[3] * src2
   movq 24(%rsi), %rdx
   mulxq 0(%rcx), %r8, %r9
-  xor %r10, %r10
+  xor %r10d, %r10d
   adcxq 24(%rdi), %r8
   movq %r8, 24(%rdi)
   mulxq 8(%rcx), %r10, %r11
@@ -373,7 +373,7 @@ _fmul2_e:
   ;# Compute src1[0] * src2
   movq 32(%rsi), %rdx
   mulxq 32(%rcx), %r8, %r9
-  xor %r10, %r10
+  xor %r10d, %r10d
   movq %r8, 64(%rdi)
   
   mulxq 40(%rcx), %r10, %r11
@@ -391,7 +391,7 @@ _fmul2_e:
   ;# Compute src1[1] * src2
   movq 40(%rsi), %rdx
   mulxq 32(%rcx), %r8, %r9
-  xor %r10, %r10
+  xor %r10d, %r10d
   adcxq 72(%rdi), %r8
   movq %r8, 72(%rdi)
   mulxq 40(%rcx), %r10, %r11
@@ -413,7 +413,7 @@ _fmul2_e:
   ;# Compute src1[2] * src2
   movq 48(%rsi), %rdx
   mulxq 32(%rcx), %r8, %r9
-  xor %r10, %r10
+  xor %r10d, %r10d
   adcxq 80(%rdi), %r8
   movq %r8, 80(%rdi)
   mulxq 40(%rcx), %r10, %r11
@@ -435,7 +435,7 @@ _fmul2_e:
   ;# Compute src1[3] * src2
   movq 56(%rsi), %rdx
   mulxq 32(%rcx), %r8, %r9
-  xor %r10, %r10
+  xor %r10d, %r10d
   adcxq 88(%rdi), %r8
   movq %r8, 88(%rdi)
   mulxq 40(%rcx), %r10, %r11
@@ -464,7 +464,7 @@ _fmul2_e:
   ;# Step 1: Compute dst + carry == tmp_hi * 38 + tmp_lo
   mov $38, %rdx
   mulxq 32(%rsi), %r8, %r13
-  xor %rcx, %rcx
+  xor %ecx, %ecx
   adoxq 0(%rsi), %r8
   mulxq 40(%rsi), %r9, %rbx
   adcx %r13, %r9
@@ -497,7 +497,7 @@ _fmul2_e:
   ;# Step 1: Compute dst + carry == tmp_hi * 38 + tmp_lo
   mov $38, %rdx
   mulxq 96(%rsi), %r8, %r13
-  xor %rcx, %rcx
+  xor %ecx, %ecx
   adoxq 64(%rsi), %r8
   mulxq 104(%rsi), %r9, %rbx
   adcx %r13, %r9
@@ -545,7 +545,7 @@ _fsqr_e:
   movq 0(%rsi), %rdx
   ;# f[0]
   mulxq 8(%rsi), %r8, %r14
-  xor %r15, %r15
+  xor %r15d, %r15d
   ;# f[1]*f[0]
   mulxq 16(%rsi), %r9, %r10
   adcx %r14, %r9
@@ -569,7 +569,7 @@ _fsqr_e:
   ;# f[2]*f[1]
   
   ;# Step 2: Compute two parallel carry chains
-  xor %r15, %r15
+  xor %r15d, %r15d
   adox %rax, %r10
   adcx %r8, %r8
   adox %rcx, %r11
@@ -627,7 +627,7 @@ _fsqr_e:
   ;# Step 1: Compute dst + carry == tmp_hi * 38 + tmp_lo
   mov $38, %rdx
   mulxq 32(%rsi), %r8, %r13
-  xor %rcx, %rcx
+  xor %ecx, %ecx
   adoxq 0(%rsi), %r8
   mulxq 40(%rsi), %r9, %rbx
   adcx %r13, %r9
@@ -675,7 +675,7 @@ _fsqr2_e:
   movq 0(%rsi), %rdx
   ;# f[0]
   mulxq 8(%rsi), %r8, %r14
-  xor %r15, %r15
+  xor %r15d, %r15d
   ;# f[1]*f[0]
   mulxq 16(%rsi), %r9, %r10
   adcx %r14, %r9
@@ -699,7 +699,7 @@ _fsqr2_e:
   ;# f[2]*f[1]
   
   ;# Step 2: Compute two parallel carry chains
-  xor %r15, %r15
+  xor %r15d, %r15d
   adox %rax, %r10
   adcx %r8, %r8
   adox %rcx, %r11
@@ -754,7 +754,7 @@ _fsqr2_e:
   movq 32(%rsi), %rdx
   ;# f[0]
   mulxq 40(%rsi), %r8, %r14
-  xor %r15, %r15
+  xor %r15d, %r15d
   ;# f[1]*f[0]
   mulxq 48(%rsi), %r9, %r10
   adcx %r14, %r9
@@ -778,7 +778,7 @@ _fsqr2_e:
   ;# f[2]*f[1]
   
   ;# Step 2: Compute two parallel carry chains
-  xor %r15, %r15
+  xor %r15d, %r15d
   adox %rax, %r10
   adcx %r8, %r8
   adox %rcx, %r11
@@ -836,7 +836,7 @@ _fsqr2_e:
   ;# Step 1: Compute dst + carry == tmp_hi * 38 + tmp_lo
   mov $38, %rdx
   mulxq 32(%rsi), %r8, %r13
-  xor %rcx, %rcx
+  xor %ecx, %ecx
   adoxq 0(%rsi), %r8
   mulxq 40(%rsi), %r9, %rbx
   adcx %r13, %r9
@@ -869,7 +869,7 @@ _fsqr2_e:
   ;# Step 1: Compute dst + carry == tmp_hi * 38 + tmp_lo
   mov $38, %rdx
   mulxq 96(%rsi), %r8, %r13
-  xor %rcx, %rcx
+  xor %ecx, %ecx
   adoxq 64(%rsi), %r8
   mulxq 104(%rsi), %r9, %rbx
   adcx %r13, %r9

--- a/dist/gcc-compatible/curve25519-x86_64-linux.S
+++ b/dist/gcc-compatible/curve25519-x86_64-linux.S
@@ -4,11 +4,11 @@ add_scalar_e:
   push %rdi
   push %rsi
   ;# Clear registers to propagate the carry bit
-  xor %r8, %r8
-  xor %r9, %r9
-  xor %r10, %r10
-  xor %r11, %r11
-  xor %rax, %rax
+  xor %r8d, %r8d
+  xor %r9d, %r9d
+  xor %r10d, %r10d
+  xor %r11d, %r11d
+  xor %eax, %eax
   
   ;# Begin addition chain
   addq 0(%rsi), %rdx
@@ -44,7 +44,7 @@ fadd_e:
   cmovc %rdx, %rax
   
   ;# Step 2: Add carry*38 to the original sum
-  xor %rcx, %rcx
+  xor %ecx, %ecx
   add %rax, %r8
   adcx %rcx, %r9
   movq %r9, 8(%rdi)
@@ -149,7 +149,7 @@ fmul_e:
   ;# Compute src1[0] * src2
   movq 0(%rsi), %rdx
   mulxq 0(%rcx), %r8, %r9
-  xor %r10, %r10
+  xor %r10d, %r10d
   movq %r8, 0(%rdi)
   
   mulxq 8(%rcx), %r10, %r11
@@ -167,7 +167,7 @@ fmul_e:
   ;# Compute src1[1] * src2
   movq 8(%rsi), %rdx
   mulxq 0(%rcx), %r8, %r9
-  xor %r10, %r10
+  xor %r10d, %r10d
   adcxq 8(%rdi), %r8
   movq %r8, 8(%rdi)
   mulxq 8(%rcx), %r10, %r11
@@ -189,7 +189,7 @@ fmul_e:
   ;# Compute src1[2] * src2
   movq 16(%rsi), %rdx
   mulxq 0(%rcx), %r8, %r9
-  xor %r10, %r10
+  xor %r10d, %r10d
   adcxq 16(%rdi), %r8
   movq %r8, 16(%rdi)
   mulxq 8(%rcx), %r10, %r11
@@ -211,7 +211,7 @@ fmul_e:
   ;# Compute src1[3] * src2
   movq 24(%rsi), %rdx
   mulxq 0(%rcx), %r8, %r9
-  xor %r10, %r10
+  xor %r10d, %r10d
   adcxq 24(%rdi), %r8
   movq %r8, 24(%rdi)
   mulxq 8(%rcx), %r10, %r11
@@ -240,7 +240,7 @@ fmul_e:
   ;# Step 1: Compute dst + carry == tmp_hi * 38 + tmp_lo
   mov $38, %rdx
   mulxq 32(%rsi), %r8, %r13
-  xor %rcx, %rcx
+  xor %ecx, %ecx
   adoxq 0(%rsi), %r8
   mulxq 40(%rsi), %r9, %rbx
   adcx %r13, %r9
@@ -286,7 +286,7 @@ fmul2_e:
   ;# Compute src1[0] * src2
   movq 0(%rsi), %rdx
   mulxq 0(%rcx), %r8, %r9
-  xor %r10, %r10
+  xor %r10d, %r10d
   movq %r8, 0(%rdi)
   
   mulxq 8(%rcx), %r10, %r11
@@ -304,7 +304,7 @@ fmul2_e:
   ;# Compute src1[1] * src2
   movq 8(%rsi), %rdx
   mulxq 0(%rcx), %r8, %r9
-  xor %r10, %r10
+  xor %r10d, %r10d
   adcxq 8(%rdi), %r8
   movq %r8, 8(%rdi)
   mulxq 8(%rcx), %r10, %r11
@@ -326,7 +326,7 @@ fmul2_e:
   ;# Compute src1[2] * src2
   movq 16(%rsi), %rdx
   mulxq 0(%rcx), %r8, %r9
-  xor %r10, %r10
+  xor %r10d, %r10d
   adcxq 16(%rdi), %r8
   movq %r8, 16(%rdi)
   mulxq 8(%rcx), %r10, %r11
@@ -348,7 +348,7 @@ fmul2_e:
   ;# Compute src1[3] * src2
   movq 24(%rsi), %rdx
   mulxq 0(%rcx), %r8, %r9
-  xor %r10, %r10
+  xor %r10d, %r10d
   adcxq 24(%rdi), %r8
   movq %r8, 24(%rdi)
   mulxq 8(%rcx), %r10, %r11
@@ -373,7 +373,7 @@ fmul2_e:
   ;# Compute src1[0] * src2
   movq 32(%rsi), %rdx
   mulxq 32(%rcx), %r8, %r9
-  xor %r10, %r10
+  xor %r10d, %r10d
   movq %r8, 64(%rdi)
   
   mulxq 40(%rcx), %r10, %r11
@@ -391,7 +391,7 @@ fmul2_e:
   ;# Compute src1[1] * src2
   movq 40(%rsi), %rdx
   mulxq 32(%rcx), %r8, %r9
-  xor %r10, %r10
+  xor %r10d, %r10d
   adcxq 72(%rdi), %r8
   movq %r8, 72(%rdi)
   mulxq 40(%rcx), %r10, %r11
@@ -413,7 +413,7 @@ fmul2_e:
   ;# Compute src1[2] * src2
   movq 48(%rsi), %rdx
   mulxq 32(%rcx), %r8, %r9
-  xor %r10, %r10
+  xor %r10d, %r10d
   adcxq 80(%rdi), %r8
   movq %r8, 80(%rdi)
   mulxq 40(%rcx), %r10, %r11
@@ -435,7 +435,7 @@ fmul2_e:
   ;# Compute src1[3] * src2
   movq 56(%rsi), %rdx
   mulxq 32(%rcx), %r8, %r9
-  xor %r10, %r10
+  xor %r10d, %r10d
   adcxq 88(%rdi), %r8
   movq %r8, 88(%rdi)
   mulxq 40(%rcx), %r10, %r11
@@ -464,7 +464,7 @@ fmul2_e:
   ;# Step 1: Compute dst + carry == tmp_hi * 38 + tmp_lo
   mov $38, %rdx
   mulxq 32(%rsi), %r8, %r13
-  xor %rcx, %rcx
+  xor %ecx, %ecx
   adoxq 0(%rsi), %r8
   mulxq 40(%rsi), %r9, %rbx
   adcx %r13, %r9
@@ -497,7 +497,7 @@ fmul2_e:
   ;# Step 1: Compute dst + carry == tmp_hi * 38 + tmp_lo
   mov $38, %rdx
   mulxq 96(%rsi), %r8, %r13
-  xor %rcx, %rcx
+  xor %ecx, %ecx
   adoxq 64(%rsi), %r8
   mulxq 104(%rsi), %r9, %rbx
   adcx %r13, %r9
@@ -545,7 +545,7 @@ fsqr_e:
   movq 0(%rsi), %rdx
   ;# f[0]
   mulxq 8(%rsi), %r8, %r14
-  xor %r15, %r15
+  xor %r15d, %r15d
   ;# f[1]*f[0]
   mulxq 16(%rsi), %r9, %r10
   adcx %r14, %r9
@@ -569,7 +569,7 @@ fsqr_e:
   ;# f[2]*f[1]
   
   ;# Step 2: Compute two parallel carry chains
-  xor %r15, %r15
+  xor %r15d, %r15d
   adox %rax, %r10
   adcx %r8, %r8
   adox %rcx, %r11
@@ -627,7 +627,7 @@ fsqr_e:
   ;# Step 1: Compute dst + carry == tmp_hi * 38 + tmp_lo
   mov $38, %rdx
   mulxq 32(%rsi), %r8, %r13
-  xor %rcx, %rcx
+  xor %ecx, %ecx
   adoxq 0(%rsi), %r8
   mulxq 40(%rsi), %r9, %rbx
   adcx %r13, %r9
@@ -675,7 +675,7 @@ fsqr2_e:
   movq 0(%rsi), %rdx
   ;# f[0]
   mulxq 8(%rsi), %r8, %r14
-  xor %r15, %r15
+  xor %r15d, %r15d
   ;# f[1]*f[0]
   mulxq 16(%rsi), %r9, %r10
   adcx %r14, %r9
@@ -699,7 +699,7 @@ fsqr2_e:
   ;# f[2]*f[1]
   
   ;# Step 2: Compute two parallel carry chains
-  xor %r15, %r15
+  xor %r15d, %r15d
   adox %rax, %r10
   adcx %r8, %r8
   adox %rcx, %r11
@@ -754,7 +754,7 @@ fsqr2_e:
   movq 32(%rsi), %rdx
   ;# f[0]
   mulxq 40(%rsi), %r8, %r14
-  xor %r15, %r15
+  xor %r15d, %r15d
   ;# f[1]*f[0]
   mulxq 48(%rsi), %r9, %r10
   adcx %r14, %r9
@@ -778,7 +778,7 @@ fsqr2_e:
   ;# f[2]*f[1]
   
   ;# Step 2: Compute two parallel carry chains
-  xor %r15, %r15
+  xor %r15d, %r15d
   adox %rax, %r10
   adcx %r8, %r8
   adox %rcx, %r11
@@ -836,7 +836,7 @@ fsqr2_e:
   ;# Step 1: Compute dst + carry == tmp_hi * 38 + tmp_lo
   mov $38, %rdx
   mulxq 32(%rsi), %r8, %r13
-  xor %rcx, %rcx
+  xor %ecx, %ecx
   adoxq 0(%rsi), %r8
   mulxq 40(%rsi), %r9, %rbx
   adcx %r13, %r9
@@ -869,7 +869,7 @@ fsqr2_e:
   ;# Step 1: Compute dst + carry == tmp_hi * 38 + tmp_lo
   mov $38, %rdx
   mulxq 96(%rsi), %r8, %r13
-  xor %rcx, %rcx
+  xor %ecx, %ecx
   adoxq 64(%rsi), %r8
   mulxq 104(%rsi), %r9, %rbx
   adcx %r13, %r9

--- a/dist/gcc-compatible/curve25519-x86_64-mingw.S
+++ b/dist/gcc-compatible/curve25519-x86_64-mingw.S
@@ -7,11 +7,11 @@ add_scalar_e:
   mov %rdx, %rsi
   mov %r8, %rdx
   ;# Clear registers to propagate the carry bit
-  xor %r8, %r8
-  xor %r9, %r9
-  xor %r10, %r10
-  xor %r11, %r11
-  xor %rax, %rax
+  xor %r8d, %r8d
+  xor %r9d, %r9d
+  xor %r10d, %r10d
+  xor %r11d, %r11d
+  xor %eax, %eax
   
   ;# Begin addition chain
   addq 0(%rsi), %rdx
@@ -52,7 +52,7 @@ fadd_e:
   cmovc %rdx, %rax
   
   ;# Step 2: Add carry*38 to the original sum
-  xor %rcx, %rcx
+  xor %ecx, %ecx
   add %rax, %r8
   adcx %rcx, %r9
   movq %r9, 8(%rdi)
@@ -176,7 +176,7 @@ fmul_e:
   ;# Compute src1[0] * src2
   movq 0(%rsi), %rdx
   mulxq 0(%rcx), %r8, %r9
-  xor %r10, %r10
+  xor %r10d, %r10d
   movq %r8, 0(%rdi)
   
   mulxq 8(%rcx), %r10, %r11
@@ -194,7 +194,7 @@ fmul_e:
   ;# Compute src1[1] * src2
   movq 8(%rsi), %rdx
   mulxq 0(%rcx), %r8, %r9
-  xor %r10, %r10
+  xor %r10d, %r10d
   adcxq 8(%rdi), %r8
   movq %r8, 8(%rdi)
   mulxq 8(%rcx), %r10, %r11
@@ -216,7 +216,7 @@ fmul_e:
   ;# Compute src1[2] * src2
   movq 16(%rsi), %rdx
   mulxq 0(%rcx), %r8, %r9
-  xor %r10, %r10
+  xor %r10d, %r10d
   adcxq 16(%rdi), %r8
   movq %r8, 16(%rdi)
   mulxq 8(%rcx), %r10, %r11
@@ -238,7 +238,7 @@ fmul_e:
   ;# Compute src1[3] * src2
   movq 24(%rsi), %rdx
   mulxq 0(%rcx), %r8, %r9
-  xor %r10, %r10
+  xor %r10d, %r10d
   adcxq 24(%rdi), %r8
   movq %r8, 24(%rdi)
   mulxq 8(%rcx), %r10, %r11
@@ -267,7 +267,7 @@ fmul_e:
   ;# Step 1: Compute dst + carry == tmp_hi * 38 + tmp_lo
   mov $38, %rdx
   mulxq 32(%rsi), %r8, %r13
-  xor %rcx, %rcx
+  xor %ecx, %ecx
   adoxq 0(%rsi), %r8
   mulxq 40(%rsi), %r9, %rbx
   adcx %r13, %r9
@@ -320,7 +320,7 @@ fmul2_e:
   ;# Compute src1[0] * src2
   movq 0(%rsi), %rdx
   mulxq 0(%rcx), %r8, %r9
-  xor %r10, %r10
+  xor %r10d, %r10d
   movq %r8, 0(%rdi)
   
   mulxq 8(%rcx), %r10, %r11
@@ -338,7 +338,7 @@ fmul2_e:
   ;# Compute src1[1] * src2
   movq 8(%rsi), %rdx
   mulxq 0(%rcx), %r8, %r9
-  xor %r10, %r10
+  xor %r10d, %r10d
   adcxq 8(%rdi), %r8
   movq %r8, 8(%rdi)
   mulxq 8(%rcx), %r10, %r11
@@ -360,7 +360,7 @@ fmul2_e:
   ;# Compute src1[2] * src2
   movq 16(%rsi), %rdx
   mulxq 0(%rcx), %r8, %r9
-  xor %r10, %r10
+  xor %r10d, %r10d
   adcxq 16(%rdi), %r8
   movq %r8, 16(%rdi)
   mulxq 8(%rcx), %r10, %r11
@@ -382,7 +382,7 @@ fmul2_e:
   ;# Compute src1[3] * src2
   movq 24(%rsi), %rdx
   mulxq 0(%rcx), %r8, %r9
-  xor %r10, %r10
+  xor %r10d, %r10d
   adcxq 24(%rdi), %r8
   movq %r8, 24(%rdi)
   mulxq 8(%rcx), %r10, %r11
@@ -407,7 +407,7 @@ fmul2_e:
   ;# Compute src1[0] * src2
   movq 32(%rsi), %rdx
   mulxq 32(%rcx), %r8, %r9
-  xor %r10, %r10
+  xor %r10d, %r10d
   movq %r8, 64(%rdi)
   
   mulxq 40(%rcx), %r10, %r11
@@ -425,7 +425,7 @@ fmul2_e:
   ;# Compute src1[1] * src2
   movq 40(%rsi), %rdx
   mulxq 32(%rcx), %r8, %r9
-  xor %r10, %r10
+  xor %r10d, %r10d
   adcxq 72(%rdi), %r8
   movq %r8, 72(%rdi)
   mulxq 40(%rcx), %r10, %r11
@@ -447,7 +447,7 @@ fmul2_e:
   ;# Compute src1[2] * src2
   movq 48(%rsi), %rdx
   mulxq 32(%rcx), %r8, %r9
-  xor %r10, %r10
+  xor %r10d, %r10d
   adcxq 80(%rdi), %r8
   movq %r8, 80(%rdi)
   mulxq 40(%rcx), %r10, %r11
@@ -469,7 +469,7 @@ fmul2_e:
   ;# Compute src1[3] * src2
   movq 56(%rsi), %rdx
   mulxq 32(%rcx), %r8, %r9
-  xor %r10, %r10
+  xor %r10d, %r10d
   adcxq 88(%rdi), %r8
   movq %r8, 88(%rdi)
   mulxq 40(%rcx), %r10, %r11
@@ -498,7 +498,7 @@ fmul2_e:
   ;# Step 1: Compute dst + carry == tmp_hi * 38 + tmp_lo
   mov $38, %rdx
   mulxq 32(%rsi), %r8, %r13
-  xor %rcx, %rcx
+  xor %ecx, %ecx
   adoxq 0(%rsi), %r8
   mulxq 40(%rsi), %r9, %rbx
   adcx %r13, %r9
@@ -531,7 +531,7 @@ fmul2_e:
   ;# Step 1: Compute dst + carry == tmp_hi * 38 + tmp_lo
   mov $38, %rdx
   mulxq 96(%rsi), %r8, %r13
-  xor %rcx, %rcx
+  xor %ecx, %ecx
   adoxq 64(%rsi), %r8
   mulxq 104(%rsi), %r9, %rbx
   adcx %r13, %r9
@@ -585,7 +585,7 @@ fsqr_e:
   movq 0(%rsi), %rdx
   ;# f[0]
   mulxq 8(%rsi), %r8, %r14
-  xor %r15, %r15
+  xor %r15d, %r15d
   ;# f[1]*f[0]
   mulxq 16(%rsi), %r9, %r10
   adcx %r14, %r9
@@ -609,7 +609,7 @@ fsqr_e:
   ;# f[2]*f[1]
   
   ;# Step 2: Compute two parallel carry chains
-  xor %r15, %r15
+  xor %r15d, %r15d
   adox %rax, %r10
   adcx %r8, %r8
   adox %rcx, %r11
@@ -667,7 +667,7 @@ fsqr_e:
   ;# Step 1: Compute dst + carry == tmp_hi * 38 + tmp_lo
   mov $38, %rdx
   mulxq 32(%rsi), %r8, %r13
-  xor %rcx, %rcx
+  xor %ecx, %ecx
   adoxq 0(%rsi), %r8
   mulxq 40(%rsi), %r9, %rbx
   adcx %r13, %r9
@@ -721,7 +721,7 @@ fsqr2_e:
   movq 0(%rsi), %rdx
   ;# f[0]
   mulxq 8(%rsi), %r8, %r14
-  xor %r15, %r15
+  xor %r15d, %r15d
   ;# f[1]*f[0]
   mulxq 16(%rsi), %r9, %r10
   adcx %r14, %r9
@@ -745,7 +745,7 @@ fsqr2_e:
   ;# f[2]*f[1]
   
   ;# Step 2: Compute two parallel carry chains
-  xor %r15, %r15
+  xor %r15d, %r15d
   adox %rax, %r10
   adcx %r8, %r8
   adox %rcx, %r11
@@ -800,7 +800,7 @@ fsqr2_e:
   movq 32(%rsi), %rdx
   ;# f[0]
   mulxq 40(%rsi), %r8, %r14
-  xor %r15, %r15
+  xor %r15d, %r15d
   ;# f[1]*f[0]
   mulxq 48(%rsi), %r9, %r10
   adcx %r14, %r9
@@ -824,7 +824,7 @@ fsqr2_e:
   ;# f[2]*f[1]
   
   ;# Step 2: Compute two parallel carry chains
-  xor %r15, %r15
+  xor %r15d, %r15d
   adox %rax, %r10
   adcx %r8, %r8
   adox %rcx, %r11
@@ -882,7 +882,7 @@ fsqr2_e:
   ;# Step 1: Compute dst + carry == tmp_hi * 38 + tmp_lo
   mov $38, %rdx
   mulxq 32(%rsi), %r8, %r13
-  xor %rcx, %rcx
+  xor %ecx, %ecx
   adoxq 0(%rsi), %r8
   mulxq 40(%rsi), %r9, %rbx
   adcx %r13, %r9
@@ -915,7 +915,7 @@ fsqr2_e:
   ;# Step 1: Compute dst + carry == tmp_hi * 38 + tmp_lo
   mov $38, %rdx
   mulxq 96(%rsi), %r8, %r13
-  xor %rcx, %rcx
+  xor %ecx, %ecx
   adoxq 64(%rsi), %r8
   mulxq 104(%rsi), %r9, %rbx
   adcx %r13, %r9

--- a/dist/gcc-compatible/curve25519-x86_64-msvc.asm
+++ b/dist/gcc-compatible/curve25519-x86_64-msvc.asm
@@ -7,11 +7,11 @@ add_scalar_e proc
   mov rsi, rdx
   mov rdx, r8
   ;# Clear registers to propagate the carry bit
-  xor r8, r8
-  xor r9, r9
-  xor r10, r10
-  xor r11, r11
-  xor rax, rax
+  xor r8d, r8d
+  xor r9d, r9d
+  xor r10d, r10d
+  xor r11d, r11d
+  xor eax, eax
   
   ;# Begin addition chain
   add rdx, qword ptr [rsi + 0]
@@ -52,7 +52,7 @@ fadd_e proc
   cmovc rax, rdx
   
   ;# Step 2: Add carry*38 to the original sum
-  xor rcx, rcx
+  xor ecx, ecx
   add r8, rax
   adcx r9, rcx
   mov qword ptr [rdi + 8], r9
@@ -176,7 +176,7 @@ fmul_e proc
   ;# Compute src1[0] * src2
   mov rdx, qword ptr [rsi + 0]
   mulx r9, r8, qword ptr [rcx + 0]
-  xor r10, r10
+  xor r10d, r10d
   mov qword ptr [rdi + 0], r8
   
   mulx r11, r10, qword ptr [rcx + 8]
@@ -194,7 +194,7 @@ fmul_e proc
   ;# Compute src1[1] * src2
   mov rdx, qword ptr [rsi + 8]
   mulx r9, r8, qword ptr [rcx + 0]
-  xor r10, r10
+  xor r10d, r10d
   adcx r8, qword ptr [rdi + 8]
   mov qword ptr [rdi + 8], r8
   mulx r11, r10, qword ptr [rcx + 8]
@@ -216,7 +216,7 @@ fmul_e proc
   ;# Compute src1[2] * src2
   mov rdx, qword ptr [rsi + 16]
   mulx r9, r8, qword ptr [rcx + 0]
-  xor r10, r10
+  xor r10d, r10d
   adcx r8, qword ptr [rdi + 16]
   mov qword ptr [rdi + 16], r8
   mulx r11, r10, qword ptr [rcx + 8]
@@ -238,7 +238,7 @@ fmul_e proc
   ;# Compute src1[3] * src2
   mov rdx, qword ptr [rsi + 24]
   mulx r9, r8, qword ptr [rcx + 0]
-  xor r10, r10
+  xor r10d, r10d
   adcx r8, qword ptr [rdi + 24]
   mov qword ptr [rdi + 24], r8
   mulx r11, r10, qword ptr [rcx + 8]
@@ -267,7 +267,7 @@ fmul_e proc
   ;# Step 1: Compute dst + carry == tmp_hi * 38 + tmp_lo
   mov rdx, 38
   mulx r13, r8, qword ptr [rsi + 32]
-  xor rcx, rcx
+  xor ecx, ecx
   adox r8, qword ptr [rsi + 0]
   mulx rbx, r9, qword ptr [rsi + 40]
   adcx r9, r13
@@ -320,7 +320,7 @@ fmul2_e proc
   ;# Compute src1[0] * src2
   mov rdx, qword ptr [rsi + 0]
   mulx r9, r8, qword ptr [rcx + 0]
-  xor r10, r10
+  xor r10d, r10d
   mov qword ptr [rdi + 0], r8
   
   mulx r11, r10, qword ptr [rcx + 8]
@@ -338,7 +338,7 @@ fmul2_e proc
   ;# Compute src1[1] * src2
   mov rdx, qword ptr [rsi + 8]
   mulx r9, r8, qword ptr [rcx + 0]
-  xor r10, r10
+  xor r10d, r10d
   adcx r8, qword ptr [rdi + 8]
   mov qword ptr [rdi + 8], r8
   mulx r11, r10, qword ptr [rcx + 8]
@@ -360,7 +360,7 @@ fmul2_e proc
   ;# Compute src1[2] * src2
   mov rdx, qword ptr [rsi + 16]
   mulx r9, r8, qword ptr [rcx + 0]
-  xor r10, r10
+  xor r10d, r10d
   adcx r8, qword ptr [rdi + 16]
   mov qword ptr [rdi + 16], r8
   mulx r11, r10, qword ptr [rcx + 8]
@@ -382,7 +382,7 @@ fmul2_e proc
   ;# Compute src1[3] * src2
   mov rdx, qword ptr [rsi + 24]
   mulx r9, r8, qword ptr [rcx + 0]
-  xor r10, r10
+  xor r10d, r10d
   adcx r8, qword ptr [rdi + 24]
   mov qword ptr [rdi + 24], r8
   mulx r11, r10, qword ptr [rcx + 8]
@@ -407,7 +407,7 @@ fmul2_e proc
   ;# Compute src1[0] * src2
   mov rdx, qword ptr [rsi + 32]
   mulx r9, r8, qword ptr [rcx + 32]
-  xor r10, r10
+  xor r10d, r10d
   mov qword ptr [rdi + 64], r8
   
   mulx r11, r10, qword ptr [rcx + 40]
@@ -425,7 +425,7 @@ fmul2_e proc
   ;# Compute src1[1] * src2
   mov rdx, qword ptr [rsi + 40]
   mulx r9, r8, qword ptr [rcx + 32]
-  xor r10, r10
+  xor r10d, r10d
   adcx r8, qword ptr [rdi + 72]
   mov qword ptr [rdi + 72], r8
   mulx r11, r10, qword ptr [rcx + 40]
@@ -447,7 +447,7 @@ fmul2_e proc
   ;# Compute src1[2] * src2
   mov rdx, qword ptr [rsi + 48]
   mulx r9, r8, qword ptr [rcx + 32]
-  xor r10, r10
+  xor r10d, r10d
   adcx r8, qword ptr [rdi + 80]
   mov qword ptr [rdi + 80], r8
   mulx r11, r10, qword ptr [rcx + 40]
@@ -469,7 +469,7 @@ fmul2_e proc
   ;# Compute src1[3] * src2
   mov rdx, qword ptr [rsi + 56]
   mulx r9, r8, qword ptr [rcx + 32]
-  xor r10, r10
+  xor r10d, r10d
   adcx r8, qword ptr [rdi + 88]
   mov qword ptr [rdi + 88], r8
   mulx r11, r10, qword ptr [rcx + 40]
@@ -498,7 +498,7 @@ fmul2_e proc
   ;# Step 1: Compute dst + carry == tmp_hi * 38 + tmp_lo
   mov rdx, 38
   mulx r13, r8, qword ptr [rsi + 32]
-  xor rcx, rcx
+  xor ecx, ecx
   adox r8, qword ptr [rsi + 0]
   mulx rbx, r9, qword ptr [rsi + 40]
   adcx r9, r13
@@ -531,7 +531,7 @@ fmul2_e proc
   ;# Step 1: Compute dst + carry == tmp_hi * 38 + tmp_lo
   mov rdx, 38
   mulx r13, r8, qword ptr [rsi + 96]
-  xor rcx, rcx
+  xor ecx, ecx
   adox r8, qword ptr [rsi + 64]
   mulx rbx, r9, qword ptr [rsi + 104]
   adcx r9, r13
@@ -585,7 +585,7 @@ fsqr_e proc
   mov rdx, qword ptr [rsi + 0]
   ;# f[0]
   mulx r14, r8, qword ptr [rsi + 8]
-  xor r15, r15
+  xor r15d, r15d
   ;# f[1]*f[0]
   mulx r10, r9, qword ptr [rsi + 16]
   adcx r9, r14
@@ -609,7 +609,7 @@ fsqr_e proc
   ;# f[2]*f[1]
   
   ;# Step 2: Compute two parallel carry chains
-  xor r15, r15
+  xor r15d, r15d
   adox r10, rax
   adcx r8, r8
   adox r11, rcx
@@ -667,7 +667,7 @@ fsqr_e proc
   ;# Step 1: Compute dst + carry == tmp_hi * 38 + tmp_lo
   mov rdx, 38
   mulx r13, r8, qword ptr [rsi + 32]
-  xor rcx, rcx
+  xor ecx, ecx
   adox r8, qword ptr [rsi + 0]
   mulx rbx, r9, qword ptr [rsi + 40]
   adcx r9, r13
@@ -721,7 +721,7 @@ fsqr2_e proc
   mov rdx, qword ptr [rsi + 0]
   ;# f[0]
   mulx r14, r8, qword ptr [rsi + 8]
-  xor r15, r15
+  xor r15d, r15d
   ;# f[1]*f[0]
   mulx r10, r9, qword ptr [rsi + 16]
   adcx r9, r14
@@ -745,7 +745,7 @@ fsqr2_e proc
   ;# f[2]*f[1]
   
   ;# Step 2: Compute two parallel carry chains
-  xor r15, r15
+  xor r15d, r15d
   adox r10, rax
   adcx r8, r8
   adox r11, rcx
@@ -800,7 +800,7 @@ fsqr2_e proc
   mov rdx, qword ptr [rsi + 32]
   ;# f[0]
   mulx r14, r8, qword ptr [rsi + 40]
-  xor r15, r15
+  xor r15d, r15d
   ;# f[1]*f[0]
   mulx r10, r9, qword ptr [rsi + 48]
   adcx r9, r14
@@ -824,7 +824,7 @@ fsqr2_e proc
   ;# f[2]*f[1]
   
   ;# Step 2: Compute two parallel carry chains
-  xor r15, r15
+  xor r15d, r15d
   adox r10, rax
   adcx r8, r8
   adox r11, rcx
@@ -882,7 +882,7 @@ fsqr2_e proc
   ;# Step 1: Compute dst + carry == tmp_hi * 38 + tmp_lo
   mov rdx, 38
   mulx r13, r8, qword ptr [rsi + 32]
-  xor rcx, rcx
+  xor ecx, ecx
   adox r8, qword ptr [rsi + 0]
   mulx rbx, r9, qword ptr [rsi + 40]
   adcx r9, r13
@@ -915,7 +915,7 @@ fsqr2_e proc
   ;# Step 1: Compute dst + carry == tmp_hi * 38 + tmp_lo
   mov rdx, 38
   mulx r13, r8, qword ptr [rsi + 96]
-  xor rcx, rcx
+  xor ecx, ecx
   adox r8, qword ptr [rsi + 64]
   mulx rbx, r9, qword ptr [rsi + 104]
   adcx r9, r13

--- a/dist/gcc64-only/curve25519-inline.h
+++ b/dist/gcc64-only/curve25519-inline.h
@@ -10,11 +10,11 @@ static inline uint64_t add_scalar (uint64_t *out, uint64_t *f1, uint64_t f2)
 
   asm volatile(
     // Clear registers to propagate the carry bit
-    "  xor %%r8, %%r8;"
-    "  xor %%r9, %%r9;"
-    "  xor %%r10, %%r10;"
-    "  xor %%r11, %%r11;"
-    "  xor %1, %1;"
+    "  xor %%r8d, %%r8d;"
+    "  xor %%r9d, %%r9d;"
+    "  xor %%r10d, %%r10d;"
+    "  xor %%r11d, %%r11d;"
+    "  xor %k1, %k1;"
 
     // Begin addition chain
     "  addq 0(%3), %0;"
@@ -58,7 +58,7 @@ static inline void fadd (uint64_t *out, uint64_t *f1, uint64_t *f2)
     "  cmovc %0, %%rax;"
 
     // Step 2: Add carry*38 to the original sum
-    "  xor %%rcx, %%rcx;"
+    "  xor %%ecx, %%ecx;"
     "  add %%rax, %%r8;"
     "  adcx %%rcx, %%r9;"
     "  movq %%r9, 8(%1);"
@@ -131,7 +131,7 @@ static inline void fmul (uint64_t *out, uint64_t *f1, uint64_t *f2, uint64_t *tm
 
     // Compute src1[0] * src2
     "  movq 0(%1), %%rdx;"
-    "  mulxq 0(%2), %%r8, %%r9;"       "  xor %%r10, %%r10;"     "  movq %%r8, 0(%3);"
+    "  mulxq 0(%2), %%r8, %%r9;"       "  xor %%r10d, %%r10d;"     "  movq %%r8, 0(%3);"
     "  mulxq 8(%2), %%r10, %%r11;"     "  adox %%r9, %%r10;"     "  movq %%r10, 8(%3);"
     "  mulxq 16(%2), %%rbx, %%r13;"    "  adox %%r11, %%rbx;"
     "  mulxq 24(%2), %%r14, %%rdx;"    "  adox %%r13, %%r14;"    "  mov $0, %%rax;"
@@ -139,7 +139,7 @@ static inline void fmul (uint64_t *out, uint64_t *f1, uint64_t *f2, uint64_t *tm
 
     // Compute src1[1] * src2
     "  movq 8(%1), %%rdx;"
-    "  mulxq 0(%2), %%r8, %%r9;"       "  xor %%r10, %%r10;"     "  adcxq 8(%3), %%r8;"    "  movq %%r8, 8(%3);"
+    "  mulxq 0(%2), %%r8, %%r9;"       "  xor %%r10d, %%r10d;"     "  adcxq 8(%3), %%r8;"    "  movq %%r8, 8(%3);"
     "  mulxq 8(%2), %%r10, %%r11;"     "  adox %%r9, %%r10;"     "  adcx %%rbx, %%r10;"    "  movq %%r10, 16(%3);"
     "  mulxq 16(%2), %%rbx, %%r13;"    "  adox %%r11, %%rbx;"    "  adcx %%r14, %%rbx;"    "  mov $0, %%r8;"
     "  mulxq 24(%2), %%r14, %%rdx;"    "  adox %%r13, %%r14;"    "  adcx %%rax, %%r14;"    "  mov $0, %%rax;"
@@ -148,7 +148,7 @@ static inline void fmul (uint64_t *out, uint64_t *f1, uint64_t *f2, uint64_t *tm
 
     // Compute src1[2] * src2
     "  movq 16(%1), %%rdx;"
-    "  mulxq 0(%2), %%r8, %%r9;"       "  xor %%r10, %%r10;"    "  adcxq 16(%3), %%r8;"    "  movq %%r8, 16(%3);"
+    "  mulxq 0(%2), %%r8, %%r9;"       "  xor %%r10d, %%r10d;"    "  adcxq 16(%3), %%r8;"    "  movq %%r8, 16(%3);"
     "  mulxq 8(%2), %%r10, %%r11;"     "  adox %%r9, %%r10;"     "  adcx %%rbx, %%r10;"    "  movq %%r10, 24(%3);"
     "  mulxq 16(%2), %%rbx, %%r13;"    "  adox %%r11, %%rbx;"    "  adcx %%r14, %%rbx;"    "  mov $0, %%r8;"
     "  mulxq 24(%2), %%r14, %%rdx;"    "  adox %%r13, %%r14;"    "  adcx %%rax, %%r14;"    "  mov $0, %%rax;"
@@ -157,7 +157,7 @@ static inline void fmul (uint64_t *out, uint64_t *f1, uint64_t *f2, uint64_t *tm
 
     // Compute src1[3] * src2
     "  movq 24(%1), %%rdx;"
-    "  mulxq 0(%2), %%r8, %%r9;"       "  xor %%r10, %%r10;"    "  adcxq 24(%3), %%r8;"    "  movq %%r8, 24(%3);"
+    "  mulxq 0(%2), %%r8, %%r9;"       "  xor %%r10d, %%r10d;"    "  adcxq 24(%3), %%r8;"    "  movq %%r8, 24(%3);"
     "  mulxq 8(%2), %%r10, %%r11;"     "  adox %%r9, %%r10;"     "  adcx %%rbx, %%r10;"    "  movq %%r10, 32(%3);"
     "  mulxq 16(%2), %%rbx, %%r13;"    "  adox %%r11, %%rbx;"    "  adcx %%r14, %%rbx;"    "  movq %%rbx, 40(%3);"    "  mov $0, %%r8;"
     "  mulxq 24(%2), %%r14, %%rdx;"    "  adox %%r13, %%r14;"    "  adcx %%rax, %%r14;"    "  movq %%r14, 48(%3);"    "  mov $0, %%rax;"
@@ -172,7 +172,7 @@ static inline void fmul (uint64_t *out, uint64_t *f1, uint64_t *f2, uint64_t *tm
     // Step 1: Compute dst + carry == tmp_hi * 38 + tmp_lo
     "  mov $38, %%rdx;"
     "  mulxq 32(%1), %%r8, %%r13;"
-    "  xor %2, %2;"
+    "  xor %k2, %k2;"
     "  adoxq 0(%1), %%r8;"
     "  mulxq 40(%1), %%r9, %%rbx;"
     "  adcx %%r13, %%r9;"
@@ -219,7 +219,7 @@ static inline void fmul2 (uint64_t *out, uint64_t *f1, uint64_t *f2, uint64_t *t
 
     // Compute src1[0] * src2
     "  movq 0(%1), %%rdx;"
-    "  mulxq 0(%2), %%r8, %%r9;"       "  xor %%r10, %%r10;"     "  movq %%r8, 0(%3);"
+    "  mulxq 0(%2), %%r8, %%r9;"       "  xor %%r10d, %%r10d;"     "  movq %%r8, 0(%3);"
     "  mulxq 8(%2), %%r10, %%r11;"     "  adox %%r9, %%r10;"     "  movq %%r10, 8(%3);"
     "  mulxq 16(%2), %%rbx, %%r13;"    "  adox %%r11, %%rbx;"
     "  mulxq 24(%2), %%r14, %%rdx;"    "  adox %%r13, %%r14;"    "  mov $0, %%rax;"
@@ -227,7 +227,7 @@ static inline void fmul2 (uint64_t *out, uint64_t *f1, uint64_t *f2, uint64_t *t
 
     // Compute src1[1] * src2
     "  movq 8(%1), %%rdx;"
-    "  mulxq 0(%2), %%r8, %%r9;"       "  xor %%r10, %%r10;"     "  adcxq 8(%3), %%r8;"    "  movq %%r8, 8(%3);"
+    "  mulxq 0(%2), %%r8, %%r9;"       "  xor %%r10d, %%r10d;"     "  adcxq 8(%3), %%r8;"    "  movq %%r8, 8(%3);"
     "  mulxq 8(%2), %%r10, %%r11;"     "  adox %%r9, %%r10;"     "  adcx %%rbx, %%r10;"    "  movq %%r10, 16(%3);"
     "  mulxq 16(%2), %%rbx, %%r13;"    "  adox %%r11, %%rbx;"    "  adcx %%r14, %%rbx;"    "  mov $0, %%r8;"
     "  mulxq 24(%2), %%r14, %%rdx;"    "  adox %%r13, %%r14;"    "  adcx %%rax, %%r14;"    "  mov $0, %%rax;"
@@ -236,7 +236,7 @@ static inline void fmul2 (uint64_t *out, uint64_t *f1, uint64_t *f2, uint64_t *t
 
     // Compute src1[2] * src2
     "  movq 16(%1), %%rdx;"
-    "  mulxq 0(%2), %%r8, %%r9;"       "  xor %%r10, %%r10;"    "  adcxq 16(%3), %%r8;"    "  movq %%r8, 16(%3);"
+    "  mulxq 0(%2), %%r8, %%r9;"       "  xor %%r10d, %%r10d;"    "  adcxq 16(%3), %%r8;"    "  movq %%r8, 16(%3);"
     "  mulxq 8(%2), %%r10, %%r11;"     "  adox %%r9, %%r10;"     "  adcx %%rbx, %%r10;"    "  movq %%r10, 24(%3);"
     "  mulxq 16(%2), %%rbx, %%r13;"    "  adox %%r11, %%rbx;"    "  adcx %%r14, %%rbx;"    "  mov $0, %%r8;"
     "  mulxq 24(%2), %%r14, %%rdx;"    "  adox %%r13, %%r14;"    "  adcx %%rax, %%r14;"    "  mov $0, %%rax;"
@@ -245,7 +245,7 @@ static inline void fmul2 (uint64_t *out, uint64_t *f1, uint64_t *f2, uint64_t *t
 
     // Compute src1[3] * src2
     "  movq 24(%1), %%rdx;"
-    "  mulxq 0(%2), %%r8, %%r9;"       "  xor %%r10, %%r10;"    "  adcxq 24(%3), %%r8;"    "  movq %%r8, 24(%3);"
+    "  mulxq 0(%2), %%r8, %%r9;"       "  xor %%r10d, %%r10d;"    "  adcxq 24(%3), %%r8;"    "  movq %%r8, 24(%3);"
     "  mulxq 8(%2), %%r10, %%r11;"     "  adox %%r9, %%r10;"     "  adcx %%rbx, %%r10;"    "  movq %%r10, 32(%3);"
     "  mulxq 16(%2), %%rbx, %%r13;"    "  adox %%r11, %%rbx;"    "  adcx %%r14, %%rbx;"    "  movq %%rbx, 40(%3);"    "  mov $0, %%r8;"
     "  mulxq 24(%2), %%r14, %%rdx;"    "  adox %%r13, %%r14;"    "  adcx %%rax, %%r14;"    "  movq %%r14, 48(%3);"    "  mov $0, %%rax;"
@@ -255,7 +255,7 @@ static inline void fmul2 (uint64_t *out, uint64_t *f1, uint64_t *f2, uint64_t *t
 
     // Compute src1[0] * src2
     "  movq 32(%1), %%rdx;"
-    "  mulxq 32(%2), %%r8, %%r9;"       "  xor %%r10, %%r10;"     "  movq %%r8, 64(%3);"
+    "  mulxq 32(%2), %%r8, %%r9;"       "  xor %%r10d, %%r10d;"     "  movq %%r8, 64(%3);"
     "  mulxq 40(%2), %%r10, %%r11;"     "  adox %%r9, %%r10;"     "  movq %%r10, 72(%3);"
     "  mulxq 48(%2), %%rbx, %%r13;"    "  adox %%r11, %%rbx;"
     "  mulxq 56(%2), %%r14, %%rdx;"    "  adox %%r13, %%r14;"    "  mov $0, %%rax;"
@@ -263,7 +263,7 @@ static inline void fmul2 (uint64_t *out, uint64_t *f1, uint64_t *f2, uint64_t *t
 
     // Compute src1[1] * src2
     "  movq 40(%1), %%rdx;"
-    "  mulxq 32(%2), %%r8, %%r9;"       "  xor %%r10, %%r10;"     "  adcxq 72(%3), %%r8;"    "  movq %%r8, 72(%3);"
+    "  mulxq 32(%2), %%r8, %%r9;"       "  xor %%r10d, %%r10d;"     "  adcxq 72(%3), %%r8;"    "  movq %%r8, 72(%3);"
     "  mulxq 40(%2), %%r10, %%r11;"     "  adox %%r9, %%r10;"     "  adcx %%rbx, %%r10;"    "  movq %%r10, 80(%3);"
     "  mulxq 48(%2), %%rbx, %%r13;"    "  adox %%r11, %%rbx;"    "  adcx %%r14, %%rbx;"    "  mov $0, %%r8;"
     "  mulxq 56(%2), %%r14, %%rdx;"    "  adox %%r13, %%r14;"    "  adcx %%rax, %%r14;"    "  mov $0, %%rax;"
@@ -272,7 +272,7 @@ static inline void fmul2 (uint64_t *out, uint64_t *f1, uint64_t *f2, uint64_t *t
 
     // Compute src1[2] * src2
     "  movq 48(%1), %%rdx;"
-    "  mulxq 32(%2), %%r8, %%r9;"       "  xor %%r10, %%r10;"    "  adcxq 80(%3), %%r8;"    "  movq %%r8, 80(%3);"
+    "  mulxq 32(%2), %%r8, %%r9;"       "  xor %%r10d, %%r10d;"    "  adcxq 80(%3), %%r8;"    "  movq %%r8, 80(%3);"
     "  mulxq 40(%2), %%r10, %%r11;"     "  adox %%r9, %%r10;"     "  adcx %%rbx, %%r10;"    "  movq %%r10, 88(%3);"
     "  mulxq 48(%2), %%rbx, %%r13;"    "  adox %%r11, %%rbx;"    "  adcx %%r14, %%rbx;"    "  mov $0, %%r8;"
     "  mulxq 56(%2), %%r14, %%rdx;"    "  adox %%r13, %%r14;"    "  adcx %%rax, %%r14;"    "  mov $0, %%rax;"
@@ -281,7 +281,7 @@ static inline void fmul2 (uint64_t *out, uint64_t *f1, uint64_t *f2, uint64_t *t
 
     // Compute src1[3] * src2
     "  movq 56(%1), %%rdx;"
-    "  mulxq 32(%2), %%r8, %%r9;"       "  xor %%r10, %%r10;"    "  adcxq 88(%3), %%r8;"    "  movq %%r8, 88(%3);"
+    "  mulxq 32(%2), %%r8, %%r9;"       "  xor %%r10d, %%r10d;"    "  adcxq 88(%3), %%r8;"    "  movq %%r8, 88(%3);"
     "  mulxq 40(%2), %%r10, %%r11;"     "  adox %%r9, %%r10;"     "  adcx %%rbx, %%r10;"    "  movq %%r10, 96(%3);"
     "  mulxq 48(%2), %%rbx, %%r13;"    "  adox %%r11, %%rbx;"    "  adcx %%r14, %%rbx;"    "  movq %%rbx, 104(%3);"    "  mov $0, %%r8;"
     "  mulxq 56(%2), %%r14, %%rdx;"    "  adox %%r13, %%r14;"    "  adcx %%rax, %%r14;"    "  movq %%r14, 112(%3);"    "  mov $0, %%rax;"
@@ -296,7 +296,7 @@ static inline void fmul2 (uint64_t *out, uint64_t *f1, uint64_t *f2, uint64_t *t
     // Step 1: Compute dst + carry == tmp_hi * 38 + tmp_lo
     "  mov $38, %%rdx;"
     "  mulxq 32(%1), %%r8, %%r13;"
-    "  xor %2, %2;"
+    "  xor %k2, %k2;"
     "  adoxq 0(%1), %%r8;"
     "  mulxq 40(%1), %%r9, %%rbx;"
     "  adcx %%r13, %%r9;"
@@ -329,7 +329,7 @@ static inline void fmul2 (uint64_t *out, uint64_t *f1, uint64_t *f2, uint64_t *t
     // Step 1: Compute dst + carry == tmp_hi * 38 + tmp_lo
     "  mov $38, %%rdx;"
     "  mulxq 96(%1), %%r8, %%r13;"
-    "  xor %2, %2;"
+    "  xor %k2, %k2;"
     "  adoxq 64(%1), %%r8;"
     "  mulxq 104(%1), %%r9, %%rbx;"
     "  adcx %%r13, %%r9;"
@@ -502,7 +502,7 @@ static inline void fsqr (uint64_t *out, uint64_t *f, uint64_t *tmp)
 
     // Step 1: Compute all partial products
     "  movq 0(%1), %%rdx;"                                       // f[0]
-    "  mulxq 8(%1), %%r8, %%r14;"      "  xor %%r15, %%r15;"     // f[1]*f[0]
+    "  mulxq 8(%1), %%r8, %%r14;"      "  xor %%r15d, %%r15d;"     // f[1]*f[0]
     "  mulxq 16(%1), %%r9, %%r10;"     "  adcx %%r14, %%r9;"     // f[2]*f[0]
     "  mulxq 24(%1), %%rax, %%rcx;"    "  adcx %%rax, %%r10;"    // f[3]*f[0]
     "  movq 24(%1), %%rdx;"                                      // f[3]
@@ -512,7 +512,7 @@ static inline void fsqr (uint64_t *out, uint64_t *f, uint64_t *tmp)
     "  mulxq 16(%1), %%rax, %%rcx;"    "  mov $0, %%r14;"        // f[2]*f[1]
 
     // Step 2: Compute two parallel carry chains
-    "  xor %%r15, %%r15;"
+    "  xor %%r15d, %%r15d;"
     "  adox %%rax, %%r10;"
     "  adcx %%r8, %%r8;"
     "  adox %%rcx, %%r11;"
@@ -549,7 +549,7 @@ static inline void fsqr (uint64_t *out, uint64_t *f, uint64_t *tmp)
     // Step 1: Compute dst + carry == tmp_hi * 38 + tmp_lo
     "  mov $38, %%rdx;"
     "  mulxq 32(%1), %%r8, %%r13;"
-    "  xor %%rcx, %%rcx;"
+    "  xor %%ecx, %%ecx;"
     "  adoxq 0(%1), %%r8;"
     "  mulxq 40(%1), %%r9, %%rbx;"
     "  adcx %%r13, %%r9;"
@@ -593,7 +593,7 @@ static inline void fsqr2 (uint64_t *out, uint64_t *f, uint64_t *tmp)
   asm volatile(
     // Step 1: Compute all partial products
     "  movq 0(%1), %%rdx;"                                       // f[0]
-    "  mulxq 8(%1), %%r8, %%r14;"      "  xor %%r15, %%r15;"     // f[1]*f[0]
+    "  mulxq 8(%1), %%r8, %%r14;"      "  xor %%r15d, %%r15d;"     // f[1]*f[0]
     "  mulxq 16(%1), %%r9, %%r10;"     "  adcx %%r14, %%r9;"     // f[2]*f[0]
     "  mulxq 24(%1), %%rax, %%rcx;"    "  adcx %%rax, %%r10;"    // f[3]*f[0]
     "  movq 24(%1), %%rdx;"                                      // f[3]
@@ -603,7 +603,7 @@ static inline void fsqr2 (uint64_t *out, uint64_t *f, uint64_t *tmp)
     "  mulxq 16(%1), %%rax, %%rcx;"    "  mov $0, %%r14;"        // f[2]*f[1]
 
     // Step 2: Compute two parallel carry chains
-    "  xor %%r15, %%r15;"
+    "  xor %%r15d, %%r15d;"
     "  adox %%rax, %%r10;"
     "  adcx %%r8, %%r8;"
     "  adox %%rcx, %%r11;"
@@ -633,7 +633,7 @@ static inline void fsqr2 (uint64_t *out, uint64_t *f, uint64_t *tmp)
 
     // Step 1: Compute all partial products
     "  movq 32(%1), %%rdx;"                                       // f[0]
-    "  mulxq 40(%1), %%r8, %%r14;"      "  xor %%r15, %%r15;"     // f[1]*f[0]
+    "  mulxq 40(%1), %%r8, %%r14;"      "  xor %%r15d, %%r15d;"     // f[1]*f[0]
     "  mulxq 48(%1), %%r9, %%r10;"     "  adcx %%r14, %%r9;"     // f[2]*f[0]
     "  mulxq 56(%1), %%rax, %%rcx;"    "  adcx %%rax, %%r10;"    // f[3]*f[0]
     "  movq 56(%1), %%rdx;"                                      // f[3]
@@ -643,7 +643,7 @@ static inline void fsqr2 (uint64_t *out, uint64_t *f, uint64_t *tmp)
     "  mulxq 48(%1), %%rax, %%rcx;"    "  mov $0, %%r14;"        // f[2]*f[1]
 
     // Step 2: Compute two parallel carry chains
-    "  xor %%r15, %%r15;"
+    "  xor %%r15d, %%r15d;"
     "  adox %%rax, %%r10;"
     "  adcx %%r8, %%r8;"
     "  adox %%rcx, %%r11;"
@@ -678,7 +678,7 @@ static inline void fsqr2 (uint64_t *out, uint64_t *f, uint64_t *tmp)
     // Step 1: Compute dst + carry == tmp_hi * 38 + tmp_lo
     "  mov $38, %%rdx;"
     "  mulxq 32(%1), %%r8, %%r13;"
-    "  xor %%rcx, %%rcx;"
+    "  xor %%ecx, %%ecx;"
     "  adoxq 0(%1), %%r8;"
     "  mulxq 40(%1), %%r9, %%rbx;"
     "  adcx %%r13, %%r9;"
@@ -711,7 +711,7 @@ static inline void fsqr2 (uint64_t *out, uint64_t *f, uint64_t *tmp)
     // Step 1: Compute dst + carry == tmp_hi * 38 + tmp_lo
     "  mov $38, %%rdx;"
     "  mulxq 96(%1), %%r8, %%r13;"
-    "  xor %%rcx, %%rcx;"
+    "  xor %%ecx, %%ecx;"
     "  adoxq 64(%1), %%r8;"
     "  mulxq 104(%1), %%r9, %%rbx;"
     "  adcx %%r13, %%r9;"

--- a/dist/gcc64-only/curve25519-x86_64-darwin.S
+++ b/dist/gcc64-only/curve25519-x86_64-darwin.S
@@ -4,11 +4,11 @@ _add_scalar_e:
   push %rdi
   push %rsi
   ;# Clear registers to propagate the carry bit
-  xor %r8, %r8
-  xor %r9, %r9
-  xor %r10, %r10
-  xor %r11, %r11
-  xor %rax, %rax
+  xor %r8d, %r8d
+  xor %r9d, %r9d
+  xor %r10d, %r10d
+  xor %r11d, %r11d
+  xor %eax, %eax
   
   ;# Begin addition chain
   addq 0(%rsi), %rdx
@@ -44,7 +44,7 @@ _fadd_e:
   cmovc %rdx, %rax
   
   ;# Step 2: Add carry*38 to the original sum
-  xor %rcx, %rcx
+  xor %ecx, %ecx
   add %rax, %r8
   adcx %rcx, %r9
   movq %r9, 8(%rdi)
@@ -149,7 +149,7 @@ _fmul_e:
   ;# Compute src1[0] * src2
   movq 0(%rsi), %rdx
   mulxq 0(%rcx), %r8, %r9
-  xor %r10, %r10
+  xor %r10d, %r10d
   movq %r8, 0(%rdi)
   
   mulxq 8(%rcx), %r10, %r11
@@ -167,7 +167,7 @@ _fmul_e:
   ;# Compute src1[1] * src2
   movq 8(%rsi), %rdx
   mulxq 0(%rcx), %r8, %r9
-  xor %r10, %r10
+  xor %r10d, %r10d
   adcxq 8(%rdi), %r8
   movq %r8, 8(%rdi)
   mulxq 8(%rcx), %r10, %r11
@@ -189,7 +189,7 @@ _fmul_e:
   ;# Compute src1[2] * src2
   movq 16(%rsi), %rdx
   mulxq 0(%rcx), %r8, %r9
-  xor %r10, %r10
+  xor %r10d, %r10d
   adcxq 16(%rdi), %r8
   movq %r8, 16(%rdi)
   mulxq 8(%rcx), %r10, %r11
@@ -211,7 +211,7 @@ _fmul_e:
   ;# Compute src1[3] * src2
   movq 24(%rsi), %rdx
   mulxq 0(%rcx), %r8, %r9
-  xor %r10, %r10
+  xor %r10d, %r10d
   adcxq 24(%rdi), %r8
   movq %r8, 24(%rdi)
   mulxq 8(%rcx), %r10, %r11
@@ -240,7 +240,7 @@ _fmul_e:
   ;# Step 1: Compute dst + carry == tmp_hi * 38 + tmp_lo
   mov $38, %rdx
   mulxq 32(%rsi), %r8, %r13
-  xor %rcx, %rcx
+  xor %ecx, %ecx
   adoxq 0(%rsi), %r8
   mulxq 40(%rsi), %r9, %rbx
   adcx %r13, %r9
@@ -286,7 +286,7 @@ _fmul2_e:
   ;# Compute src1[0] * src2
   movq 0(%rsi), %rdx
   mulxq 0(%rcx), %r8, %r9
-  xor %r10, %r10
+  xor %r10d, %r10d
   movq %r8, 0(%rdi)
   
   mulxq 8(%rcx), %r10, %r11
@@ -304,7 +304,7 @@ _fmul2_e:
   ;# Compute src1[1] * src2
   movq 8(%rsi), %rdx
   mulxq 0(%rcx), %r8, %r9
-  xor %r10, %r10
+  xor %r10d, %r10d
   adcxq 8(%rdi), %r8
   movq %r8, 8(%rdi)
   mulxq 8(%rcx), %r10, %r11
@@ -326,7 +326,7 @@ _fmul2_e:
   ;# Compute src1[2] * src2
   movq 16(%rsi), %rdx
   mulxq 0(%rcx), %r8, %r9
-  xor %r10, %r10
+  xor %r10d, %r10d
   adcxq 16(%rdi), %r8
   movq %r8, 16(%rdi)
   mulxq 8(%rcx), %r10, %r11
@@ -348,7 +348,7 @@ _fmul2_e:
   ;# Compute src1[3] * src2
   movq 24(%rsi), %rdx
   mulxq 0(%rcx), %r8, %r9
-  xor %r10, %r10
+  xor %r10d, %r10d
   adcxq 24(%rdi), %r8
   movq %r8, 24(%rdi)
   mulxq 8(%rcx), %r10, %r11
@@ -373,7 +373,7 @@ _fmul2_e:
   ;# Compute src1[0] * src2
   movq 32(%rsi), %rdx
   mulxq 32(%rcx), %r8, %r9
-  xor %r10, %r10
+  xor %r10d, %r10d
   movq %r8, 64(%rdi)
   
   mulxq 40(%rcx), %r10, %r11
@@ -391,7 +391,7 @@ _fmul2_e:
   ;# Compute src1[1] * src2
   movq 40(%rsi), %rdx
   mulxq 32(%rcx), %r8, %r9
-  xor %r10, %r10
+  xor %r10d, %r10d
   adcxq 72(%rdi), %r8
   movq %r8, 72(%rdi)
   mulxq 40(%rcx), %r10, %r11
@@ -413,7 +413,7 @@ _fmul2_e:
   ;# Compute src1[2] * src2
   movq 48(%rsi), %rdx
   mulxq 32(%rcx), %r8, %r9
-  xor %r10, %r10
+  xor %r10d, %r10d
   adcxq 80(%rdi), %r8
   movq %r8, 80(%rdi)
   mulxq 40(%rcx), %r10, %r11
@@ -435,7 +435,7 @@ _fmul2_e:
   ;# Compute src1[3] * src2
   movq 56(%rsi), %rdx
   mulxq 32(%rcx), %r8, %r9
-  xor %r10, %r10
+  xor %r10d, %r10d
   adcxq 88(%rdi), %r8
   movq %r8, 88(%rdi)
   mulxq 40(%rcx), %r10, %r11
@@ -464,7 +464,7 @@ _fmul2_e:
   ;# Step 1: Compute dst + carry == tmp_hi * 38 + tmp_lo
   mov $38, %rdx
   mulxq 32(%rsi), %r8, %r13
-  xor %rcx, %rcx
+  xor %ecx, %ecx
   adoxq 0(%rsi), %r8
   mulxq 40(%rsi), %r9, %rbx
   adcx %r13, %r9
@@ -497,7 +497,7 @@ _fmul2_e:
   ;# Step 1: Compute dst + carry == tmp_hi * 38 + tmp_lo
   mov $38, %rdx
   mulxq 96(%rsi), %r8, %r13
-  xor %rcx, %rcx
+  xor %ecx, %ecx
   adoxq 64(%rsi), %r8
   mulxq 104(%rsi), %r9, %rbx
   adcx %r13, %r9
@@ -545,7 +545,7 @@ _fsqr_e:
   movq 0(%rsi), %rdx
   ;# f[0]
   mulxq 8(%rsi), %r8, %r14
-  xor %r15, %r15
+  xor %r15d, %r15d
   ;# f[1]*f[0]
   mulxq 16(%rsi), %r9, %r10
   adcx %r14, %r9
@@ -569,7 +569,7 @@ _fsqr_e:
   ;# f[2]*f[1]
   
   ;# Step 2: Compute two parallel carry chains
-  xor %r15, %r15
+  xor %r15d, %r15d
   adox %rax, %r10
   adcx %r8, %r8
   adox %rcx, %r11
@@ -627,7 +627,7 @@ _fsqr_e:
   ;# Step 1: Compute dst + carry == tmp_hi * 38 + tmp_lo
   mov $38, %rdx
   mulxq 32(%rsi), %r8, %r13
-  xor %rcx, %rcx
+  xor %ecx, %ecx
   adoxq 0(%rsi), %r8
   mulxq 40(%rsi), %r9, %rbx
   adcx %r13, %r9
@@ -675,7 +675,7 @@ _fsqr2_e:
   movq 0(%rsi), %rdx
   ;# f[0]
   mulxq 8(%rsi), %r8, %r14
-  xor %r15, %r15
+  xor %r15d, %r15d
   ;# f[1]*f[0]
   mulxq 16(%rsi), %r9, %r10
   adcx %r14, %r9
@@ -699,7 +699,7 @@ _fsqr2_e:
   ;# f[2]*f[1]
   
   ;# Step 2: Compute two parallel carry chains
-  xor %r15, %r15
+  xor %r15d, %r15d
   adox %rax, %r10
   adcx %r8, %r8
   adox %rcx, %r11
@@ -754,7 +754,7 @@ _fsqr2_e:
   movq 32(%rsi), %rdx
   ;# f[0]
   mulxq 40(%rsi), %r8, %r14
-  xor %r15, %r15
+  xor %r15d, %r15d
   ;# f[1]*f[0]
   mulxq 48(%rsi), %r9, %r10
   adcx %r14, %r9
@@ -778,7 +778,7 @@ _fsqr2_e:
   ;# f[2]*f[1]
   
   ;# Step 2: Compute two parallel carry chains
-  xor %r15, %r15
+  xor %r15d, %r15d
   adox %rax, %r10
   adcx %r8, %r8
   adox %rcx, %r11
@@ -836,7 +836,7 @@ _fsqr2_e:
   ;# Step 1: Compute dst + carry == tmp_hi * 38 + tmp_lo
   mov $38, %rdx
   mulxq 32(%rsi), %r8, %r13
-  xor %rcx, %rcx
+  xor %ecx, %ecx
   adoxq 0(%rsi), %r8
   mulxq 40(%rsi), %r9, %rbx
   adcx %r13, %r9
@@ -869,7 +869,7 @@ _fsqr2_e:
   ;# Step 1: Compute dst + carry == tmp_hi * 38 + tmp_lo
   mov $38, %rdx
   mulxq 96(%rsi), %r8, %r13
-  xor %rcx, %rcx
+  xor %ecx, %ecx
   adoxq 64(%rsi), %r8
   mulxq 104(%rsi), %r9, %rbx
   adcx %r13, %r9

--- a/dist/gcc64-only/curve25519-x86_64-linux.S
+++ b/dist/gcc64-only/curve25519-x86_64-linux.S
@@ -4,11 +4,11 @@ add_scalar_e:
   push %rdi
   push %rsi
   ;# Clear registers to propagate the carry bit
-  xor %r8, %r8
-  xor %r9, %r9
-  xor %r10, %r10
-  xor %r11, %r11
-  xor %rax, %rax
+  xor %r8d, %r8d
+  xor %r9d, %r9d
+  xor %r10d, %r10d
+  xor %r11d, %r11d
+  xor %eax, %eax
   
   ;# Begin addition chain
   addq 0(%rsi), %rdx
@@ -44,7 +44,7 @@ fadd_e:
   cmovc %rdx, %rax
   
   ;# Step 2: Add carry*38 to the original sum
-  xor %rcx, %rcx
+  xor %ecx, %ecx
   add %rax, %r8
   adcx %rcx, %r9
   movq %r9, 8(%rdi)
@@ -149,7 +149,7 @@ fmul_e:
   ;# Compute src1[0] * src2
   movq 0(%rsi), %rdx
   mulxq 0(%rcx), %r8, %r9
-  xor %r10, %r10
+  xor %r10d, %r10d
   movq %r8, 0(%rdi)
   
   mulxq 8(%rcx), %r10, %r11
@@ -167,7 +167,7 @@ fmul_e:
   ;# Compute src1[1] * src2
   movq 8(%rsi), %rdx
   mulxq 0(%rcx), %r8, %r9
-  xor %r10, %r10
+  xor %r10d, %r10d
   adcxq 8(%rdi), %r8
   movq %r8, 8(%rdi)
   mulxq 8(%rcx), %r10, %r11
@@ -189,7 +189,7 @@ fmul_e:
   ;# Compute src1[2] * src2
   movq 16(%rsi), %rdx
   mulxq 0(%rcx), %r8, %r9
-  xor %r10, %r10
+  xor %r10d, %r10d
   adcxq 16(%rdi), %r8
   movq %r8, 16(%rdi)
   mulxq 8(%rcx), %r10, %r11
@@ -211,7 +211,7 @@ fmul_e:
   ;# Compute src1[3] * src2
   movq 24(%rsi), %rdx
   mulxq 0(%rcx), %r8, %r9
-  xor %r10, %r10
+  xor %r10d, %r10d
   adcxq 24(%rdi), %r8
   movq %r8, 24(%rdi)
   mulxq 8(%rcx), %r10, %r11
@@ -240,7 +240,7 @@ fmul_e:
   ;# Step 1: Compute dst + carry == tmp_hi * 38 + tmp_lo
   mov $38, %rdx
   mulxq 32(%rsi), %r8, %r13
-  xor %rcx, %rcx
+  xor %ecx, %ecx
   adoxq 0(%rsi), %r8
   mulxq 40(%rsi), %r9, %rbx
   adcx %r13, %r9
@@ -286,7 +286,7 @@ fmul2_e:
   ;# Compute src1[0] * src2
   movq 0(%rsi), %rdx
   mulxq 0(%rcx), %r8, %r9
-  xor %r10, %r10
+  xor %r10d, %r10d
   movq %r8, 0(%rdi)
   
   mulxq 8(%rcx), %r10, %r11
@@ -304,7 +304,7 @@ fmul2_e:
   ;# Compute src1[1] * src2
   movq 8(%rsi), %rdx
   mulxq 0(%rcx), %r8, %r9
-  xor %r10, %r10
+  xor %r10d, %r10d
   adcxq 8(%rdi), %r8
   movq %r8, 8(%rdi)
   mulxq 8(%rcx), %r10, %r11
@@ -326,7 +326,7 @@ fmul2_e:
   ;# Compute src1[2] * src2
   movq 16(%rsi), %rdx
   mulxq 0(%rcx), %r8, %r9
-  xor %r10, %r10
+  xor %r10d, %r10d
   adcxq 16(%rdi), %r8
   movq %r8, 16(%rdi)
   mulxq 8(%rcx), %r10, %r11
@@ -348,7 +348,7 @@ fmul2_e:
   ;# Compute src1[3] * src2
   movq 24(%rsi), %rdx
   mulxq 0(%rcx), %r8, %r9
-  xor %r10, %r10
+  xor %r10d, %r10d
   adcxq 24(%rdi), %r8
   movq %r8, 24(%rdi)
   mulxq 8(%rcx), %r10, %r11
@@ -373,7 +373,7 @@ fmul2_e:
   ;# Compute src1[0] * src2
   movq 32(%rsi), %rdx
   mulxq 32(%rcx), %r8, %r9
-  xor %r10, %r10
+  xor %r10d, %r10d
   movq %r8, 64(%rdi)
   
   mulxq 40(%rcx), %r10, %r11
@@ -391,7 +391,7 @@ fmul2_e:
   ;# Compute src1[1] * src2
   movq 40(%rsi), %rdx
   mulxq 32(%rcx), %r8, %r9
-  xor %r10, %r10
+  xor %r10d, %r10d
   adcxq 72(%rdi), %r8
   movq %r8, 72(%rdi)
   mulxq 40(%rcx), %r10, %r11
@@ -413,7 +413,7 @@ fmul2_e:
   ;# Compute src1[2] * src2
   movq 48(%rsi), %rdx
   mulxq 32(%rcx), %r8, %r9
-  xor %r10, %r10
+  xor %r10d, %r10d
   adcxq 80(%rdi), %r8
   movq %r8, 80(%rdi)
   mulxq 40(%rcx), %r10, %r11
@@ -435,7 +435,7 @@ fmul2_e:
   ;# Compute src1[3] * src2
   movq 56(%rsi), %rdx
   mulxq 32(%rcx), %r8, %r9
-  xor %r10, %r10
+  xor %r10d, %r10d
   adcxq 88(%rdi), %r8
   movq %r8, 88(%rdi)
   mulxq 40(%rcx), %r10, %r11
@@ -464,7 +464,7 @@ fmul2_e:
   ;# Step 1: Compute dst + carry == tmp_hi * 38 + tmp_lo
   mov $38, %rdx
   mulxq 32(%rsi), %r8, %r13
-  xor %rcx, %rcx
+  xor %ecx, %ecx
   adoxq 0(%rsi), %r8
   mulxq 40(%rsi), %r9, %rbx
   adcx %r13, %r9
@@ -497,7 +497,7 @@ fmul2_e:
   ;# Step 1: Compute dst + carry == tmp_hi * 38 + tmp_lo
   mov $38, %rdx
   mulxq 96(%rsi), %r8, %r13
-  xor %rcx, %rcx
+  xor %ecx, %ecx
   adoxq 64(%rsi), %r8
   mulxq 104(%rsi), %r9, %rbx
   adcx %r13, %r9
@@ -545,7 +545,7 @@ fsqr_e:
   movq 0(%rsi), %rdx
   ;# f[0]
   mulxq 8(%rsi), %r8, %r14
-  xor %r15, %r15
+  xor %r15d, %r15d
   ;# f[1]*f[0]
   mulxq 16(%rsi), %r9, %r10
   adcx %r14, %r9
@@ -569,7 +569,7 @@ fsqr_e:
   ;# f[2]*f[1]
   
   ;# Step 2: Compute two parallel carry chains
-  xor %r15, %r15
+  xor %r15d, %r15d
   adox %rax, %r10
   adcx %r8, %r8
   adox %rcx, %r11
@@ -627,7 +627,7 @@ fsqr_e:
   ;# Step 1: Compute dst + carry == tmp_hi * 38 + tmp_lo
   mov $38, %rdx
   mulxq 32(%rsi), %r8, %r13
-  xor %rcx, %rcx
+  xor %ecx, %ecx
   adoxq 0(%rsi), %r8
   mulxq 40(%rsi), %r9, %rbx
   adcx %r13, %r9
@@ -675,7 +675,7 @@ fsqr2_e:
   movq 0(%rsi), %rdx
   ;# f[0]
   mulxq 8(%rsi), %r8, %r14
-  xor %r15, %r15
+  xor %r15d, %r15d
   ;# f[1]*f[0]
   mulxq 16(%rsi), %r9, %r10
   adcx %r14, %r9
@@ -699,7 +699,7 @@ fsqr2_e:
   ;# f[2]*f[1]
   
   ;# Step 2: Compute two parallel carry chains
-  xor %r15, %r15
+  xor %r15d, %r15d
   adox %rax, %r10
   adcx %r8, %r8
   adox %rcx, %r11
@@ -754,7 +754,7 @@ fsqr2_e:
   movq 32(%rsi), %rdx
   ;# f[0]
   mulxq 40(%rsi), %r8, %r14
-  xor %r15, %r15
+  xor %r15d, %r15d
   ;# f[1]*f[0]
   mulxq 48(%rsi), %r9, %r10
   adcx %r14, %r9
@@ -778,7 +778,7 @@ fsqr2_e:
   ;# f[2]*f[1]
   
   ;# Step 2: Compute two parallel carry chains
-  xor %r15, %r15
+  xor %r15d, %r15d
   adox %rax, %r10
   adcx %r8, %r8
   adox %rcx, %r11
@@ -836,7 +836,7 @@ fsqr2_e:
   ;# Step 1: Compute dst + carry == tmp_hi * 38 + tmp_lo
   mov $38, %rdx
   mulxq 32(%rsi), %r8, %r13
-  xor %rcx, %rcx
+  xor %ecx, %ecx
   adoxq 0(%rsi), %r8
   mulxq 40(%rsi), %r9, %rbx
   adcx %r13, %r9
@@ -869,7 +869,7 @@ fsqr2_e:
   ;# Step 1: Compute dst + carry == tmp_hi * 38 + tmp_lo
   mov $38, %rdx
   mulxq 96(%rsi), %r8, %r13
-  xor %rcx, %rcx
+  xor %ecx, %ecx
   adoxq 64(%rsi), %r8
   mulxq 104(%rsi), %r9, %rbx
   adcx %r13, %r9

--- a/dist/gcc64-only/curve25519-x86_64-mingw.S
+++ b/dist/gcc64-only/curve25519-x86_64-mingw.S
@@ -7,11 +7,11 @@ add_scalar_e:
   mov %rdx, %rsi
   mov %r8, %rdx
   ;# Clear registers to propagate the carry bit
-  xor %r8, %r8
-  xor %r9, %r9
-  xor %r10, %r10
-  xor %r11, %r11
-  xor %rax, %rax
+  xor %r8d, %r8d
+  xor %r9d, %r9d
+  xor %r10d, %r10d
+  xor %r11d, %r11d
+  xor %eax, %eax
   
   ;# Begin addition chain
   addq 0(%rsi), %rdx
@@ -52,7 +52,7 @@ fadd_e:
   cmovc %rdx, %rax
   
   ;# Step 2: Add carry*38 to the original sum
-  xor %rcx, %rcx
+  xor %ecx, %ecx
   add %rax, %r8
   adcx %rcx, %r9
   movq %r9, 8(%rdi)
@@ -176,7 +176,7 @@ fmul_e:
   ;# Compute src1[0] * src2
   movq 0(%rsi), %rdx
   mulxq 0(%rcx), %r8, %r9
-  xor %r10, %r10
+  xor %r10d, %r10d
   movq %r8, 0(%rdi)
   
   mulxq 8(%rcx), %r10, %r11
@@ -194,7 +194,7 @@ fmul_e:
   ;# Compute src1[1] * src2
   movq 8(%rsi), %rdx
   mulxq 0(%rcx), %r8, %r9
-  xor %r10, %r10
+  xor %r10d, %r10d
   adcxq 8(%rdi), %r8
   movq %r8, 8(%rdi)
   mulxq 8(%rcx), %r10, %r11
@@ -216,7 +216,7 @@ fmul_e:
   ;# Compute src1[2] * src2
   movq 16(%rsi), %rdx
   mulxq 0(%rcx), %r8, %r9
-  xor %r10, %r10
+  xor %r10d, %r10d
   adcxq 16(%rdi), %r8
   movq %r8, 16(%rdi)
   mulxq 8(%rcx), %r10, %r11
@@ -238,7 +238,7 @@ fmul_e:
   ;# Compute src1[3] * src2
   movq 24(%rsi), %rdx
   mulxq 0(%rcx), %r8, %r9
-  xor %r10, %r10
+  xor %r10d, %r10d
   adcxq 24(%rdi), %r8
   movq %r8, 24(%rdi)
   mulxq 8(%rcx), %r10, %r11
@@ -267,7 +267,7 @@ fmul_e:
   ;# Step 1: Compute dst + carry == tmp_hi * 38 + tmp_lo
   mov $38, %rdx
   mulxq 32(%rsi), %r8, %r13
-  xor %rcx, %rcx
+  xor %ecx, %ecx
   adoxq 0(%rsi), %r8
   mulxq 40(%rsi), %r9, %rbx
   adcx %r13, %r9
@@ -320,7 +320,7 @@ fmul2_e:
   ;# Compute src1[0] * src2
   movq 0(%rsi), %rdx
   mulxq 0(%rcx), %r8, %r9
-  xor %r10, %r10
+  xor %r10d, %r10d
   movq %r8, 0(%rdi)
   
   mulxq 8(%rcx), %r10, %r11
@@ -338,7 +338,7 @@ fmul2_e:
   ;# Compute src1[1] * src2
   movq 8(%rsi), %rdx
   mulxq 0(%rcx), %r8, %r9
-  xor %r10, %r10
+  xor %r10d, %r10d
   adcxq 8(%rdi), %r8
   movq %r8, 8(%rdi)
   mulxq 8(%rcx), %r10, %r11
@@ -360,7 +360,7 @@ fmul2_e:
   ;# Compute src1[2] * src2
   movq 16(%rsi), %rdx
   mulxq 0(%rcx), %r8, %r9
-  xor %r10, %r10
+  xor %r10d, %r10d
   adcxq 16(%rdi), %r8
   movq %r8, 16(%rdi)
   mulxq 8(%rcx), %r10, %r11
@@ -382,7 +382,7 @@ fmul2_e:
   ;# Compute src1[3] * src2
   movq 24(%rsi), %rdx
   mulxq 0(%rcx), %r8, %r9
-  xor %r10, %r10
+  xor %r10d, %r10d
   adcxq 24(%rdi), %r8
   movq %r8, 24(%rdi)
   mulxq 8(%rcx), %r10, %r11
@@ -407,7 +407,7 @@ fmul2_e:
   ;# Compute src1[0] * src2
   movq 32(%rsi), %rdx
   mulxq 32(%rcx), %r8, %r9
-  xor %r10, %r10
+  xor %r10d, %r10d
   movq %r8, 64(%rdi)
   
   mulxq 40(%rcx), %r10, %r11
@@ -425,7 +425,7 @@ fmul2_e:
   ;# Compute src1[1] * src2
   movq 40(%rsi), %rdx
   mulxq 32(%rcx), %r8, %r9
-  xor %r10, %r10
+  xor %r10d, %r10d
   adcxq 72(%rdi), %r8
   movq %r8, 72(%rdi)
   mulxq 40(%rcx), %r10, %r11
@@ -447,7 +447,7 @@ fmul2_e:
   ;# Compute src1[2] * src2
   movq 48(%rsi), %rdx
   mulxq 32(%rcx), %r8, %r9
-  xor %r10, %r10
+  xor %r10d, %r10d
   adcxq 80(%rdi), %r8
   movq %r8, 80(%rdi)
   mulxq 40(%rcx), %r10, %r11
@@ -469,7 +469,7 @@ fmul2_e:
   ;# Compute src1[3] * src2
   movq 56(%rsi), %rdx
   mulxq 32(%rcx), %r8, %r9
-  xor %r10, %r10
+  xor %r10d, %r10d
   adcxq 88(%rdi), %r8
   movq %r8, 88(%rdi)
   mulxq 40(%rcx), %r10, %r11
@@ -498,7 +498,7 @@ fmul2_e:
   ;# Step 1: Compute dst + carry == tmp_hi * 38 + tmp_lo
   mov $38, %rdx
   mulxq 32(%rsi), %r8, %r13
-  xor %rcx, %rcx
+  xor %ecx, %ecx
   adoxq 0(%rsi), %r8
   mulxq 40(%rsi), %r9, %rbx
   adcx %r13, %r9
@@ -531,7 +531,7 @@ fmul2_e:
   ;# Step 1: Compute dst + carry == tmp_hi * 38 + tmp_lo
   mov $38, %rdx
   mulxq 96(%rsi), %r8, %r13
-  xor %rcx, %rcx
+  xor %ecx, %ecx
   adoxq 64(%rsi), %r8
   mulxq 104(%rsi), %r9, %rbx
   adcx %r13, %r9
@@ -585,7 +585,7 @@ fsqr_e:
   movq 0(%rsi), %rdx
   ;# f[0]
   mulxq 8(%rsi), %r8, %r14
-  xor %r15, %r15
+  xor %r15d, %r15d
   ;# f[1]*f[0]
   mulxq 16(%rsi), %r9, %r10
   adcx %r14, %r9
@@ -609,7 +609,7 @@ fsqr_e:
   ;# f[2]*f[1]
   
   ;# Step 2: Compute two parallel carry chains
-  xor %r15, %r15
+  xor %r15d, %r15d
   adox %rax, %r10
   adcx %r8, %r8
   adox %rcx, %r11
@@ -667,7 +667,7 @@ fsqr_e:
   ;# Step 1: Compute dst + carry == tmp_hi * 38 + tmp_lo
   mov $38, %rdx
   mulxq 32(%rsi), %r8, %r13
-  xor %rcx, %rcx
+  xor %ecx, %ecx
   adoxq 0(%rsi), %r8
   mulxq 40(%rsi), %r9, %rbx
   adcx %r13, %r9
@@ -721,7 +721,7 @@ fsqr2_e:
   movq 0(%rsi), %rdx
   ;# f[0]
   mulxq 8(%rsi), %r8, %r14
-  xor %r15, %r15
+  xor %r15d, %r15d
   ;# f[1]*f[0]
   mulxq 16(%rsi), %r9, %r10
   adcx %r14, %r9
@@ -745,7 +745,7 @@ fsqr2_e:
   ;# f[2]*f[1]
   
   ;# Step 2: Compute two parallel carry chains
-  xor %r15, %r15
+  xor %r15d, %r15d
   adox %rax, %r10
   adcx %r8, %r8
   adox %rcx, %r11
@@ -800,7 +800,7 @@ fsqr2_e:
   movq 32(%rsi), %rdx
   ;# f[0]
   mulxq 40(%rsi), %r8, %r14
-  xor %r15, %r15
+  xor %r15d, %r15d
   ;# f[1]*f[0]
   mulxq 48(%rsi), %r9, %r10
   adcx %r14, %r9
@@ -824,7 +824,7 @@ fsqr2_e:
   ;# f[2]*f[1]
   
   ;# Step 2: Compute two parallel carry chains
-  xor %r15, %r15
+  xor %r15d, %r15d
   adox %rax, %r10
   adcx %r8, %r8
   adox %rcx, %r11
@@ -882,7 +882,7 @@ fsqr2_e:
   ;# Step 1: Compute dst + carry == tmp_hi * 38 + tmp_lo
   mov $38, %rdx
   mulxq 32(%rsi), %r8, %r13
-  xor %rcx, %rcx
+  xor %ecx, %ecx
   adoxq 0(%rsi), %r8
   mulxq 40(%rsi), %r9, %rbx
   adcx %r13, %r9
@@ -915,7 +915,7 @@ fsqr2_e:
   ;# Step 1: Compute dst + carry == tmp_hi * 38 + tmp_lo
   mov $38, %rdx
   mulxq 96(%rsi), %r8, %r13
-  xor %rcx, %rcx
+  xor %ecx, %ecx
   adoxq 64(%rsi), %r8
   mulxq 104(%rsi), %r9, %rbx
   adcx %r13, %r9

--- a/dist/gcc64-only/curve25519-x86_64-msvc.asm
+++ b/dist/gcc64-only/curve25519-x86_64-msvc.asm
@@ -7,11 +7,11 @@ add_scalar_e proc
   mov rsi, rdx
   mov rdx, r8
   ;# Clear registers to propagate the carry bit
-  xor r8, r8
-  xor r9, r9
-  xor r10, r10
-  xor r11, r11
-  xor rax, rax
+  xor r8d, r8d
+  xor r9d, r9d
+  xor r10d, r10d
+  xor r11d, r11d
+  xor eax, eax
   
   ;# Begin addition chain
   add rdx, qword ptr [rsi + 0]
@@ -52,7 +52,7 @@ fadd_e proc
   cmovc rax, rdx
   
   ;# Step 2: Add carry*38 to the original sum
-  xor rcx, rcx
+  xor ecx, ecx
   add r8, rax
   adcx r9, rcx
   mov qword ptr [rdi + 8], r9
@@ -176,7 +176,7 @@ fmul_e proc
   ;# Compute src1[0] * src2
   mov rdx, qword ptr [rsi + 0]
   mulx r9, r8, qword ptr [rcx + 0]
-  xor r10, r10
+  xor r10d, r10d
   mov qword ptr [rdi + 0], r8
   
   mulx r11, r10, qword ptr [rcx + 8]
@@ -194,7 +194,7 @@ fmul_e proc
   ;# Compute src1[1] * src2
   mov rdx, qword ptr [rsi + 8]
   mulx r9, r8, qword ptr [rcx + 0]
-  xor r10, r10
+  xor r10d, r10d
   adcx r8, qword ptr [rdi + 8]
   mov qword ptr [rdi + 8], r8
   mulx r11, r10, qword ptr [rcx + 8]
@@ -216,7 +216,7 @@ fmul_e proc
   ;# Compute src1[2] * src2
   mov rdx, qword ptr [rsi + 16]
   mulx r9, r8, qword ptr [rcx + 0]
-  xor r10, r10
+  xor r10d, r10d
   adcx r8, qword ptr [rdi + 16]
   mov qword ptr [rdi + 16], r8
   mulx r11, r10, qword ptr [rcx + 8]
@@ -238,7 +238,7 @@ fmul_e proc
   ;# Compute src1[3] * src2
   mov rdx, qword ptr [rsi + 24]
   mulx r9, r8, qword ptr [rcx + 0]
-  xor r10, r10
+  xor r10d, r10d
   adcx r8, qword ptr [rdi + 24]
   mov qword ptr [rdi + 24], r8
   mulx r11, r10, qword ptr [rcx + 8]
@@ -267,7 +267,7 @@ fmul_e proc
   ;# Step 1: Compute dst + carry == tmp_hi * 38 + tmp_lo
   mov rdx, 38
   mulx r13, r8, qword ptr [rsi + 32]
-  xor rcx, rcx
+  xor ecx, ecx
   adox r8, qword ptr [rsi + 0]
   mulx rbx, r9, qword ptr [rsi + 40]
   adcx r9, r13
@@ -320,7 +320,7 @@ fmul2_e proc
   ;# Compute src1[0] * src2
   mov rdx, qword ptr [rsi + 0]
   mulx r9, r8, qword ptr [rcx + 0]
-  xor r10, r10
+  xor r10d, r10d
   mov qword ptr [rdi + 0], r8
   
   mulx r11, r10, qword ptr [rcx + 8]
@@ -338,7 +338,7 @@ fmul2_e proc
   ;# Compute src1[1] * src2
   mov rdx, qword ptr [rsi + 8]
   mulx r9, r8, qword ptr [rcx + 0]
-  xor r10, r10
+  xor r10d, r10d
   adcx r8, qword ptr [rdi + 8]
   mov qword ptr [rdi + 8], r8
   mulx r11, r10, qword ptr [rcx + 8]
@@ -360,7 +360,7 @@ fmul2_e proc
   ;# Compute src1[2] * src2
   mov rdx, qword ptr [rsi + 16]
   mulx r9, r8, qword ptr [rcx + 0]
-  xor r10, r10
+  xor r10d, r10d
   adcx r8, qword ptr [rdi + 16]
   mov qword ptr [rdi + 16], r8
   mulx r11, r10, qword ptr [rcx + 8]
@@ -382,7 +382,7 @@ fmul2_e proc
   ;# Compute src1[3] * src2
   mov rdx, qword ptr [rsi + 24]
   mulx r9, r8, qword ptr [rcx + 0]
-  xor r10, r10
+  xor r10d, r10d
   adcx r8, qword ptr [rdi + 24]
   mov qword ptr [rdi + 24], r8
   mulx r11, r10, qword ptr [rcx + 8]
@@ -407,7 +407,7 @@ fmul2_e proc
   ;# Compute src1[0] * src2
   mov rdx, qword ptr [rsi + 32]
   mulx r9, r8, qword ptr [rcx + 32]
-  xor r10, r10
+  xor r10d, r10d
   mov qword ptr [rdi + 64], r8
   
   mulx r11, r10, qword ptr [rcx + 40]
@@ -425,7 +425,7 @@ fmul2_e proc
   ;# Compute src1[1] * src2
   mov rdx, qword ptr [rsi + 40]
   mulx r9, r8, qword ptr [rcx + 32]
-  xor r10, r10
+  xor r10d, r10d
   adcx r8, qword ptr [rdi + 72]
   mov qword ptr [rdi + 72], r8
   mulx r11, r10, qword ptr [rcx + 40]
@@ -447,7 +447,7 @@ fmul2_e proc
   ;# Compute src1[2] * src2
   mov rdx, qword ptr [rsi + 48]
   mulx r9, r8, qword ptr [rcx + 32]
-  xor r10, r10
+  xor r10d, r10d
   adcx r8, qword ptr [rdi + 80]
   mov qword ptr [rdi + 80], r8
   mulx r11, r10, qword ptr [rcx + 40]
@@ -469,7 +469,7 @@ fmul2_e proc
   ;# Compute src1[3] * src2
   mov rdx, qword ptr [rsi + 56]
   mulx r9, r8, qword ptr [rcx + 32]
-  xor r10, r10
+  xor r10d, r10d
   adcx r8, qword ptr [rdi + 88]
   mov qword ptr [rdi + 88], r8
   mulx r11, r10, qword ptr [rcx + 40]
@@ -498,7 +498,7 @@ fmul2_e proc
   ;# Step 1: Compute dst + carry == tmp_hi * 38 + tmp_lo
   mov rdx, 38
   mulx r13, r8, qword ptr [rsi + 32]
-  xor rcx, rcx
+  xor ecx, ecx
   adox r8, qword ptr [rsi + 0]
   mulx rbx, r9, qword ptr [rsi + 40]
   adcx r9, r13
@@ -531,7 +531,7 @@ fmul2_e proc
   ;# Step 1: Compute dst + carry == tmp_hi * 38 + tmp_lo
   mov rdx, 38
   mulx r13, r8, qword ptr [rsi + 96]
-  xor rcx, rcx
+  xor ecx, ecx
   adox r8, qword ptr [rsi + 64]
   mulx rbx, r9, qword ptr [rsi + 104]
   adcx r9, r13
@@ -585,7 +585,7 @@ fsqr_e proc
   mov rdx, qword ptr [rsi + 0]
   ;# f[0]
   mulx r14, r8, qword ptr [rsi + 8]
-  xor r15, r15
+  xor r15d, r15d
   ;# f[1]*f[0]
   mulx r10, r9, qword ptr [rsi + 16]
   adcx r9, r14
@@ -609,7 +609,7 @@ fsqr_e proc
   ;# f[2]*f[1]
   
   ;# Step 2: Compute two parallel carry chains
-  xor r15, r15
+  xor r15d, r15d
   adox r10, rax
   adcx r8, r8
   adox r11, rcx
@@ -667,7 +667,7 @@ fsqr_e proc
   ;# Step 1: Compute dst + carry == tmp_hi * 38 + tmp_lo
   mov rdx, 38
   mulx r13, r8, qword ptr [rsi + 32]
-  xor rcx, rcx
+  xor ecx, ecx
   adox r8, qword ptr [rsi + 0]
   mulx rbx, r9, qword ptr [rsi + 40]
   adcx r9, r13
@@ -721,7 +721,7 @@ fsqr2_e proc
   mov rdx, qword ptr [rsi + 0]
   ;# f[0]
   mulx r14, r8, qword ptr [rsi + 8]
-  xor r15, r15
+  xor r15d, r15d
   ;# f[1]*f[0]
   mulx r10, r9, qword ptr [rsi + 16]
   adcx r9, r14
@@ -745,7 +745,7 @@ fsqr2_e proc
   ;# f[2]*f[1]
   
   ;# Step 2: Compute two parallel carry chains
-  xor r15, r15
+  xor r15d, r15d
   adox r10, rax
   adcx r8, r8
   adox r11, rcx
@@ -800,7 +800,7 @@ fsqr2_e proc
   mov rdx, qword ptr [rsi + 32]
   ;# f[0]
   mulx r14, r8, qword ptr [rsi + 40]
-  xor r15, r15
+  xor r15d, r15d
   ;# f[1]*f[0]
   mulx r10, r9, qword ptr [rsi + 48]
   adcx r9, r14
@@ -824,7 +824,7 @@ fsqr2_e proc
   ;# f[2]*f[1]
   
   ;# Step 2: Compute two parallel carry chains
-  xor r15, r15
+  xor r15d, r15d
   adox r10, rax
   adcx r8, r8
   adox r11, rcx
@@ -882,7 +882,7 @@ fsqr2_e proc
   ;# Step 1: Compute dst + carry == tmp_hi * 38 + tmp_lo
   mov rdx, 38
   mulx r13, r8, qword ptr [rsi + 32]
-  xor rcx, rcx
+  xor ecx, ecx
   adox r8, qword ptr [rsi + 0]
   mulx rbx, r9, qword ptr [rsi + 40]
   adcx r9, r13
@@ -915,7 +915,7 @@ fsqr2_e proc
   ;# Step 1: Compute dst + carry == tmp_hi * 38 + tmp_lo
   mov rdx, 38
   mulx r13, r8, qword ptr [rsi + 96]
-  xor rcx, rcx
+  xor ecx, ecx
   adox r8, qword ptr [rsi + 64]
   mulx rbx, r9, qword ptr [rsi + 104]
   adcx r9, r13

--- a/dist/linux/curve25519-inline.h
+++ b/dist/linux/curve25519-inline.h
@@ -10,11 +10,11 @@ static inline uint64_t add_scalar (uint64_t *out, uint64_t *f1, uint64_t f2)
 
   asm volatile(
     // Clear registers to propagate the carry bit
-    "  xor %%r8, %%r8;"
-    "  xor %%r9, %%r9;"
-    "  xor %%r10, %%r10;"
-    "  xor %%r11, %%r11;"
-    "  xor %1, %1;"
+    "  xor %%r8d, %%r8d;"
+    "  xor %%r9d, %%r9d;"
+    "  xor %%r10d, %%r10d;"
+    "  xor %%r11d, %%r11d;"
+    "  xor %k1, %k1;"
 
     // Begin addition chain
     "  addq 0(%3), %0;"
@@ -58,7 +58,7 @@ static inline void fadd (uint64_t *out, uint64_t *f1, uint64_t *f2)
     "  cmovc %0, %%rax;"
 
     // Step 2: Add carry*38 to the original sum
-    "  xor %%rcx, %%rcx;"
+    "  xor %%ecx, %%ecx;"
     "  add %%rax, %%r8;"
     "  adcx %%rcx, %%r9;"
     "  movq %%r9, 8(%1);"
@@ -131,7 +131,7 @@ static inline void fmul (uint64_t *out, uint64_t *f1, uint64_t *f2, uint64_t *tm
 
     // Compute src1[0] * src2
     "  movq 0(%1), %%rdx;"
-    "  mulxq 0(%2), %%r8, %%r9;"       "  xor %%r10, %%r10;"     "  movq %%r8, 0(%3);"
+    "  mulxq 0(%2), %%r8, %%r9;"       "  xor %%r10d, %%r10d;"     "  movq %%r8, 0(%3);"
     "  mulxq 8(%2), %%r10, %%r11;"     "  adox %%r9, %%r10;"     "  movq %%r10, 8(%3);"
     "  mulxq 16(%2), %%rbx, %%r13;"    "  adox %%r11, %%rbx;"
     "  mulxq 24(%2), %%r14, %%rdx;"    "  adox %%r13, %%r14;"    "  mov $0, %%rax;"
@@ -139,7 +139,7 @@ static inline void fmul (uint64_t *out, uint64_t *f1, uint64_t *f2, uint64_t *tm
 
     // Compute src1[1] * src2
     "  movq 8(%1), %%rdx;"
-    "  mulxq 0(%2), %%r8, %%r9;"       "  xor %%r10, %%r10;"     "  adcxq 8(%3), %%r8;"    "  movq %%r8, 8(%3);"
+    "  mulxq 0(%2), %%r8, %%r9;"       "  xor %%r10d, %%r10d;"     "  adcxq 8(%3), %%r8;"    "  movq %%r8, 8(%3);"
     "  mulxq 8(%2), %%r10, %%r11;"     "  adox %%r9, %%r10;"     "  adcx %%rbx, %%r10;"    "  movq %%r10, 16(%3);"
     "  mulxq 16(%2), %%rbx, %%r13;"    "  adox %%r11, %%rbx;"    "  adcx %%r14, %%rbx;"    "  mov $0, %%r8;"
     "  mulxq 24(%2), %%r14, %%rdx;"    "  adox %%r13, %%r14;"    "  adcx %%rax, %%r14;"    "  mov $0, %%rax;"
@@ -148,7 +148,7 @@ static inline void fmul (uint64_t *out, uint64_t *f1, uint64_t *f2, uint64_t *tm
 
     // Compute src1[2] * src2
     "  movq 16(%1), %%rdx;"
-    "  mulxq 0(%2), %%r8, %%r9;"       "  xor %%r10, %%r10;"    "  adcxq 16(%3), %%r8;"    "  movq %%r8, 16(%3);"
+    "  mulxq 0(%2), %%r8, %%r9;"       "  xor %%r10d, %%r10d;"    "  adcxq 16(%3), %%r8;"    "  movq %%r8, 16(%3);"
     "  mulxq 8(%2), %%r10, %%r11;"     "  adox %%r9, %%r10;"     "  adcx %%rbx, %%r10;"    "  movq %%r10, 24(%3);"
     "  mulxq 16(%2), %%rbx, %%r13;"    "  adox %%r11, %%rbx;"    "  adcx %%r14, %%rbx;"    "  mov $0, %%r8;"
     "  mulxq 24(%2), %%r14, %%rdx;"    "  adox %%r13, %%r14;"    "  adcx %%rax, %%r14;"    "  mov $0, %%rax;"
@@ -157,7 +157,7 @@ static inline void fmul (uint64_t *out, uint64_t *f1, uint64_t *f2, uint64_t *tm
 
     // Compute src1[3] * src2
     "  movq 24(%1), %%rdx;"
-    "  mulxq 0(%2), %%r8, %%r9;"       "  xor %%r10, %%r10;"    "  adcxq 24(%3), %%r8;"    "  movq %%r8, 24(%3);"
+    "  mulxq 0(%2), %%r8, %%r9;"       "  xor %%r10d, %%r10d;"    "  adcxq 24(%3), %%r8;"    "  movq %%r8, 24(%3);"
     "  mulxq 8(%2), %%r10, %%r11;"     "  adox %%r9, %%r10;"     "  adcx %%rbx, %%r10;"    "  movq %%r10, 32(%3);"
     "  mulxq 16(%2), %%rbx, %%r13;"    "  adox %%r11, %%rbx;"    "  adcx %%r14, %%rbx;"    "  movq %%rbx, 40(%3);"    "  mov $0, %%r8;"
     "  mulxq 24(%2), %%r14, %%rdx;"    "  adox %%r13, %%r14;"    "  adcx %%rax, %%r14;"    "  movq %%r14, 48(%3);"    "  mov $0, %%rax;"
@@ -172,7 +172,7 @@ static inline void fmul (uint64_t *out, uint64_t *f1, uint64_t *f2, uint64_t *tm
     // Step 1: Compute dst + carry == tmp_hi * 38 + tmp_lo
     "  mov $38, %%rdx;"
     "  mulxq 32(%1), %%r8, %%r13;"
-    "  xor %2, %2;"
+    "  xor %k2, %k2;"
     "  adoxq 0(%1), %%r8;"
     "  mulxq 40(%1), %%r9, %%rbx;"
     "  adcx %%r13, %%r9;"
@@ -219,7 +219,7 @@ static inline void fmul2 (uint64_t *out, uint64_t *f1, uint64_t *f2, uint64_t *t
 
     // Compute src1[0] * src2
     "  movq 0(%1), %%rdx;"
-    "  mulxq 0(%2), %%r8, %%r9;"       "  xor %%r10, %%r10;"     "  movq %%r8, 0(%3);"
+    "  mulxq 0(%2), %%r8, %%r9;"       "  xor %%r10d, %%r10d;"     "  movq %%r8, 0(%3);"
     "  mulxq 8(%2), %%r10, %%r11;"     "  adox %%r9, %%r10;"     "  movq %%r10, 8(%3);"
     "  mulxq 16(%2), %%rbx, %%r13;"    "  adox %%r11, %%rbx;"
     "  mulxq 24(%2), %%r14, %%rdx;"    "  adox %%r13, %%r14;"    "  mov $0, %%rax;"
@@ -227,7 +227,7 @@ static inline void fmul2 (uint64_t *out, uint64_t *f1, uint64_t *f2, uint64_t *t
 
     // Compute src1[1] * src2
     "  movq 8(%1), %%rdx;"
-    "  mulxq 0(%2), %%r8, %%r9;"       "  xor %%r10, %%r10;"     "  adcxq 8(%3), %%r8;"    "  movq %%r8, 8(%3);"
+    "  mulxq 0(%2), %%r8, %%r9;"       "  xor %%r10d, %%r10d;"     "  adcxq 8(%3), %%r8;"    "  movq %%r8, 8(%3);"
     "  mulxq 8(%2), %%r10, %%r11;"     "  adox %%r9, %%r10;"     "  adcx %%rbx, %%r10;"    "  movq %%r10, 16(%3);"
     "  mulxq 16(%2), %%rbx, %%r13;"    "  adox %%r11, %%rbx;"    "  adcx %%r14, %%rbx;"    "  mov $0, %%r8;"
     "  mulxq 24(%2), %%r14, %%rdx;"    "  adox %%r13, %%r14;"    "  adcx %%rax, %%r14;"    "  mov $0, %%rax;"
@@ -236,7 +236,7 @@ static inline void fmul2 (uint64_t *out, uint64_t *f1, uint64_t *f2, uint64_t *t
 
     // Compute src1[2] * src2
     "  movq 16(%1), %%rdx;"
-    "  mulxq 0(%2), %%r8, %%r9;"       "  xor %%r10, %%r10;"    "  adcxq 16(%3), %%r8;"    "  movq %%r8, 16(%3);"
+    "  mulxq 0(%2), %%r8, %%r9;"       "  xor %%r10d, %%r10d;"    "  adcxq 16(%3), %%r8;"    "  movq %%r8, 16(%3);"
     "  mulxq 8(%2), %%r10, %%r11;"     "  adox %%r9, %%r10;"     "  adcx %%rbx, %%r10;"    "  movq %%r10, 24(%3);"
     "  mulxq 16(%2), %%rbx, %%r13;"    "  adox %%r11, %%rbx;"    "  adcx %%r14, %%rbx;"    "  mov $0, %%r8;"
     "  mulxq 24(%2), %%r14, %%rdx;"    "  adox %%r13, %%r14;"    "  adcx %%rax, %%r14;"    "  mov $0, %%rax;"
@@ -245,7 +245,7 @@ static inline void fmul2 (uint64_t *out, uint64_t *f1, uint64_t *f2, uint64_t *t
 
     // Compute src1[3] * src2
     "  movq 24(%1), %%rdx;"
-    "  mulxq 0(%2), %%r8, %%r9;"       "  xor %%r10, %%r10;"    "  adcxq 24(%3), %%r8;"    "  movq %%r8, 24(%3);"
+    "  mulxq 0(%2), %%r8, %%r9;"       "  xor %%r10d, %%r10d;"    "  adcxq 24(%3), %%r8;"    "  movq %%r8, 24(%3);"
     "  mulxq 8(%2), %%r10, %%r11;"     "  adox %%r9, %%r10;"     "  adcx %%rbx, %%r10;"    "  movq %%r10, 32(%3);"
     "  mulxq 16(%2), %%rbx, %%r13;"    "  adox %%r11, %%rbx;"    "  adcx %%r14, %%rbx;"    "  movq %%rbx, 40(%3);"    "  mov $0, %%r8;"
     "  mulxq 24(%2), %%r14, %%rdx;"    "  adox %%r13, %%r14;"    "  adcx %%rax, %%r14;"    "  movq %%r14, 48(%3);"    "  mov $0, %%rax;"
@@ -255,7 +255,7 @@ static inline void fmul2 (uint64_t *out, uint64_t *f1, uint64_t *f2, uint64_t *t
 
     // Compute src1[0] * src2
     "  movq 32(%1), %%rdx;"
-    "  mulxq 32(%2), %%r8, %%r9;"       "  xor %%r10, %%r10;"     "  movq %%r8, 64(%3);"
+    "  mulxq 32(%2), %%r8, %%r9;"       "  xor %%r10d, %%r10d;"     "  movq %%r8, 64(%3);"
     "  mulxq 40(%2), %%r10, %%r11;"     "  adox %%r9, %%r10;"     "  movq %%r10, 72(%3);"
     "  mulxq 48(%2), %%rbx, %%r13;"    "  adox %%r11, %%rbx;"
     "  mulxq 56(%2), %%r14, %%rdx;"    "  adox %%r13, %%r14;"    "  mov $0, %%rax;"
@@ -263,7 +263,7 @@ static inline void fmul2 (uint64_t *out, uint64_t *f1, uint64_t *f2, uint64_t *t
 
     // Compute src1[1] * src2
     "  movq 40(%1), %%rdx;"
-    "  mulxq 32(%2), %%r8, %%r9;"       "  xor %%r10, %%r10;"     "  adcxq 72(%3), %%r8;"    "  movq %%r8, 72(%3);"
+    "  mulxq 32(%2), %%r8, %%r9;"       "  xor %%r10d, %%r10d;"     "  adcxq 72(%3), %%r8;"    "  movq %%r8, 72(%3);"
     "  mulxq 40(%2), %%r10, %%r11;"     "  adox %%r9, %%r10;"     "  adcx %%rbx, %%r10;"    "  movq %%r10, 80(%3);"
     "  mulxq 48(%2), %%rbx, %%r13;"    "  adox %%r11, %%rbx;"    "  adcx %%r14, %%rbx;"    "  mov $0, %%r8;"
     "  mulxq 56(%2), %%r14, %%rdx;"    "  adox %%r13, %%r14;"    "  adcx %%rax, %%r14;"    "  mov $0, %%rax;"
@@ -272,7 +272,7 @@ static inline void fmul2 (uint64_t *out, uint64_t *f1, uint64_t *f2, uint64_t *t
 
     // Compute src1[2] * src2
     "  movq 48(%1), %%rdx;"
-    "  mulxq 32(%2), %%r8, %%r9;"       "  xor %%r10, %%r10;"    "  adcxq 80(%3), %%r8;"    "  movq %%r8, 80(%3);"
+    "  mulxq 32(%2), %%r8, %%r9;"       "  xor %%r10d, %%r10d;"    "  adcxq 80(%3), %%r8;"    "  movq %%r8, 80(%3);"
     "  mulxq 40(%2), %%r10, %%r11;"     "  adox %%r9, %%r10;"     "  adcx %%rbx, %%r10;"    "  movq %%r10, 88(%3);"
     "  mulxq 48(%2), %%rbx, %%r13;"    "  adox %%r11, %%rbx;"    "  adcx %%r14, %%rbx;"    "  mov $0, %%r8;"
     "  mulxq 56(%2), %%r14, %%rdx;"    "  adox %%r13, %%r14;"    "  adcx %%rax, %%r14;"    "  mov $0, %%rax;"
@@ -281,7 +281,7 @@ static inline void fmul2 (uint64_t *out, uint64_t *f1, uint64_t *f2, uint64_t *t
 
     // Compute src1[3] * src2
     "  movq 56(%1), %%rdx;"
-    "  mulxq 32(%2), %%r8, %%r9;"       "  xor %%r10, %%r10;"    "  adcxq 88(%3), %%r8;"    "  movq %%r8, 88(%3);"
+    "  mulxq 32(%2), %%r8, %%r9;"       "  xor %%r10d, %%r10d;"    "  adcxq 88(%3), %%r8;"    "  movq %%r8, 88(%3);"
     "  mulxq 40(%2), %%r10, %%r11;"     "  adox %%r9, %%r10;"     "  adcx %%rbx, %%r10;"    "  movq %%r10, 96(%3);"
     "  mulxq 48(%2), %%rbx, %%r13;"    "  adox %%r11, %%rbx;"    "  adcx %%r14, %%rbx;"    "  movq %%rbx, 104(%3);"    "  mov $0, %%r8;"
     "  mulxq 56(%2), %%r14, %%rdx;"    "  adox %%r13, %%r14;"    "  adcx %%rax, %%r14;"    "  movq %%r14, 112(%3);"    "  mov $0, %%rax;"
@@ -296,7 +296,7 @@ static inline void fmul2 (uint64_t *out, uint64_t *f1, uint64_t *f2, uint64_t *t
     // Step 1: Compute dst + carry == tmp_hi * 38 + tmp_lo
     "  mov $38, %%rdx;"
     "  mulxq 32(%1), %%r8, %%r13;"
-    "  xor %2, %2;"
+    "  xor %k2, %k2;"
     "  adoxq 0(%1), %%r8;"
     "  mulxq 40(%1), %%r9, %%rbx;"
     "  adcx %%r13, %%r9;"
@@ -329,7 +329,7 @@ static inline void fmul2 (uint64_t *out, uint64_t *f1, uint64_t *f2, uint64_t *t
     // Step 1: Compute dst + carry == tmp_hi * 38 + tmp_lo
     "  mov $38, %%rdx;"
     "  mulxq 96(%1), %%r8, %%r13;"
-    "  xor %2, %2;"
+    "  xor %k2, %k2;"
     "  adoxq 64(%1), %%r8;"
     "  mulxq 104(%1), %%r9, %%rbx;"
     "  adcx %%r13, %%r9;"
@@ -502,7 +502,7 @@ static inline void fsqr (uint64_t *out, uint64_t *f, uint64_t *tmp)
 
     // Step 1: Compute all partial products
     "  movq 0(%1), %%rdx;"                                       // f[0]
-    "  mulxq 8(%1), %%r8, %%r14;"      "  xor %%r15, %%r15;"     // f[1]*f[0]
+    "  mulxq 8(%1), %%r8, %%r14;"      "  xor %%r15d, %%r15d;"     // f[1]*f[0]
     "  mulxq 16(%1), %%r9, %%r10;"     "  adcx %%r14, %%r9;"     // f[2]*f[0]
     "  mulxq 24(%1), %%rax, %%rcx;"    "  adcx %%rax, %%r10;"    // f[3]*f[0]
     "  movq 24(%1), %%rdx;"                                      // f[3]
@@ -512,7 +512,7 @@ static inline void fsqr (uint64_t *out, uint64_t *f, uint64_t *tmp)
     "  mulxq 16(%1), %%rax, %%rcx;"    "  mov $0, %%r14;"        // f[2]*f[1]
 
     // Step 2: Compute two parallel carry chains
-    "  xor %%r15, %%r15;"
+    "  xor %%r15d, %%r15d;"
     "  adox %%rax, %%r10;"
     "  adcx %%r8, %%r8;"
     "  adox %%rcx, %%r11;"
@@ -549,7 +549,7 @@ static inline void fsqr (uint64_t *out, uint64_t *f, uint64_t *tmp)
     // Step 1: Compute dst + carry == tmp_hi * 38 + tmp_lo
     "  mov $38, %%rdx;"
     "  mulxq 32(%1), %%r8, %%r13;"
-    "  xor %%rcx, %%rcx;"
+    "  xor %%ecx, %%ecx;"
     "  adoxq 0(%1), %%r8;"
     "  mulxq 40(%1), %%r9, %%rbx;"
     "  adcx %%r13, %%r9;"
@@ -593,7 +593,7 @@ static inline void fsqr2 (uint64_t *out, uint64_t *f, uint64_t *tmp)
   asm volatile(
     // Step 1: Compute all partial products
     "  movq 0(%1), %%rdx;"                                       // f[0]
-    "  mulxq 8(%1), %%r8, %%r14;"      "  xor %%r15, %%r15;"     // f[1]*f[0]
+    "  mulxq 8(%1), %%r8, %%r14;"      "  xor %%r15d, %%r15d;"     // f[1]*f[0]
     "  mulxq 16(%1), %%r9, %%r10;"     "  adcx %%r14, %%r9;"     // f[2]*f[0]
     "  mulxq 24(%1), %%rax, %%rcx;"    "  adcx %%rax, %%r10;"    // f[3]*f[0]
     "  movq 24(%1), %%rdx;"                                      // f[3]
@@ -603,7 +603,7 @@ static inline void fsqr2 (uint64_t *out, uint64_t *f, uint64_t *tmp)
     "  mulxq 16(%1), %%rax, %%rcx;"    "  mov $0, %%r14;"        // f[2]*f[1]
 
     // Step 2: Compute two parallel carry chains
-    "  xor %%r15, %%r15;"
+    "  xor %%r15d, %%r15d;"
     "  adox %%rax, %%r10;"
     "  adcx %%r8, %%r8;"
     "  adox %%rcx, %%r11;"
@@ -633,7 +633,7 @@ static inline void fsqr2 (uint64_t *out, uint64_t *f, uint64_t *tmp)
 
     // Step 1: Compute all partial products
     "  movq 32(%1), %%rdx;"                                       // f[0]
-    "  mulxq 40(%1), %%r8, %%r14;"      "  xor %%r15, %%r15;"     // f[1]*f[0]
+    "  mulxq 40(%1), %%r8, %%r14;"      "  xor %%r15d, %%r15d;"     // f[1]*f[0]
     "  mulxq 48(%1), %%r9, %%r10;"     "  adcx %%r14, %%r9;"     // f[2]*f[0]
     "  mulxq 56(%1), %%rax, %%rcx;"    "  adcx %%rax, %%r10;"    // f[3]*f[0]
     "  movq 56(%1), %%rdx;"                                      // f[3]
@@ -643,7 +643,7 @@ static inline void fsqr2 (uint64_t *out, uint64_t *f, uint64_t *tmp)
     "  mulxq 48(%1), %%rax, %%rcx;"    "  mov $0, %%r14;"        // f[2]*f[1]
 
     // Step 2: Compute two parallel carry chains
-    "  xor %%r15, %%r15;"
+    "  xor %%r15d, %%r15d;"
     "  adox %%rax, %%r10;"
     "  adcx %%r8, %%r8;"
     "  adox %%rcx, %%r11;"
@@ -678,7 +678,7 @@ static inline void fsqr2 (uint64_t *out, uint64_t *f, uint64_t *tmp)
     // Step 1: Compute dst + carry == tmp_hi * 38 + tmp_lo
     "  mov $38, %%rdx;"
     "  mulxq 32(%1), %%r8, %%r13;"
-    "  xor %%rcx, %%rcx;"
+    "  xor %%ecx, %%ecx;"
     "  adoxq 0(%1), %%r8;"
     "  mulxq 40(%1), %%r9, %%rbx;"
     "  adcx %%r13, %%r9;"
@@ -711,7 +711,7 @@ static inline void fsqr2 (uint64_t *out, uint64_t *f, uint64_t *tmp)
     // Step 1: Compute dst + carry == tmp_hi * 38 + tmp_lo
     "  mov $38, %%rdx;"
     "  mulxq 96(%1), %%r8, %%r13;"
-    "  xor %%rcx, %%rcx;"
+    "  xor %%ecx, %%ecx;"
     "  adoxq 64(%1), %%r8;"
     "  mulxq 104(%1), %%r9, %%rbx;"
     "  adcx %%r13, %%r9;"

--- a/dist/linux/curve25519-x86_64-darwin.S
+++ b/dist/linux/curve25519-x86_64-darwin.S
@@ -4,11 +4,11 @@ _add_scalar_e:
   push %rdi
   push %rsi
   ;# Clear registers to propagate the carry bit
-  xor %r8, %r8
-  xor %r9, %r9
-  xor %r10, %r10
-  xor %r11, %r11
-  xor %rax, %rax
+  xor %r8d, %r8d
+  xor %r9d, %r9d
+  xor %r10d, %r10d
+  xor %r11d, %r11d
+  xor %eax, %eax
   
   ;# Begin addition chain
   addq 0(%rsi), %rdx
@@ -44,7 +44,7 @@ _fadd_e:
   cmovc %rdx, %rax
   
   ;# Step 2: Add carry*38 to the original sum
-  xor %rcx, %rcx
+  xor %ecx, %ecx
   add %rax, %r8
   adcx %rcx, %r9
   movq %r9, 8(%rdi)
@@ -149,7 +149,7 @@ _fmul_e:
   ;# Compute src1[0] * src2
   movq 0(%rsi), %rdx
   mulxq 0(%rcx), %r8, %r9
-  xor %r10, %r10
+  xor %r10d, %r10d
   movq %r8, 0(%rdi)
   
   mulxq 8(%rcx), %r10, %r11
@@ -167,7 +167,7 @@ _fmul_e:
   ;# Compute src1[1] * src2
   movq 8(%rsi), %rdx
   mulxq 0(%rcx), %r8, %r9
-  xor %r10, %r10
+  xor %r10d, %r10d
   adcxq 8(%rdi), %r8
   movq %r8, 8(%rdi)
   mulxq 8(%rcx), %r10, %r11
@@ -189,7 +189,7 @@ _fmul_e:
   ;# Compute src1[2] * src2
   movq 16(%rsi), %rdx
   mulxq 0(%rcx), %r8, %r9
-  xor %r10, %r10
+  xor %r10d, %r10d
   adcxq 16(%rdi), %r8
   movq %r8, 16(%rdi)
   mulxq 8(%rcx), %r10, %r11
@@ -211,7 +211,7 @@ _fmul_e:
   ;# Compute src1[3] * src2
   movq 24(%rsi), %rdx
   mulxq 0(%rcx), %r8, %r9
-  xor %r10, %r10
+  xor %r10d, %r10d
   adcxq 24(%rdi), %r8
   movq %r8, 24(%rdi)
   mulxq 8(%rcx), %r10, %r11
@@ -240,7 +240,7 @@ _fmul_e:
   ;# Step 1: Compute dst + carry == tmp_hi * 38 + tmp_lo
   mov $38, %rdx
   mulxq 32(%rsi), %r8, %r13
-  xor %rcx, %rcx
+  xor %ecx, %ecx
   adoxq 0(%rsi), %r8
   mulxq 40(%rsi), %r9, %rbx
   adcx %r13, %r9
@@ -286,7 +286,7 @@ _fmul2_e:
   ;# Compute src1[0] * src2
   movq 0(%rsi), %rdx
   mulxq 0(%rcx), %r8, %r9
-  xor %r10, %r10
+  xor %r10d, %r10d
   movq %r8, 0(%rdi)
   
   mulxq 8(%rcx), %r10, %r11
@@ -304,7 +304,7 @@ _fmul2_e:
   ;# Compute src1[1] * src2
   movq 8(%rsi), %rdx
   mulxq 0(%rcx), %r8, %r9
-  xor %r10, %r10
+  xor %r10d, %r10d
   adcxq 8(%rdi), %r8
   movq %r8, 8(%rdi)
   mulxq 8(%rcx), %r10, %r11
@@ -326,7 +326,7 @@ _fmul2_e:
   ;# Compute src1[2] * src2
   movq 16(%rsi), %rdx
   mulxq 0(%rcx), %r8, %r9
-  xor %r10, %r10
+  xor %r10d, %r10d
   adcxq 16(%rdi), %r8
   movq %r8, 16(%rdi)
   mulxq 8(%rcx), %r10, %r11
@@ -348,7 +348,7 @@ _fmul2_e:
   ;# Compute src1[3] * src2
   movq 24(%rsi), %rdx
   mulxq 0(%rcx), %r8, %r9
-  xor %r10, %r10
+  xor %r10d, %r10d
   adcxq 24(%rdi), %r8
   movq %r8, 24(%rdi)
   mulxq 8(%rcx), %r10, %r11
@@ -373,7 +373,7 @@ _fmul2_e:
   ;# Compute src1[0] * src2
   movq 32(%rsi), %rdx
   mulxq 32(%rcx), %r8, %r9
-  xor %r10, %r10
+  xor %r10d, %r10d
   movq %r8, 64(%rdi)
   
   mulxq 40(%rcx), %r10, %r11
@@ -391,7 +391,7 @@ _fmul2_e:
   ;# Compute src1[1] * src2
   movq 40(%rsi), %rdx
   mulxq 32(%rcx), %r8, %r9
-  xor %r10, %r10
+  xor %r10d, %r10d
   adcxq 72(%rdi), %r8
   movq %r8, 72(%rdi)
   mulxq 40(%rcx), %r10, %r11
@@ -413,7 +413,7 @@ _fmul2_e:
   ;# Compute src1[2] * src2
   movq 48(%rsi), %rdx
   mulxq 32(%rcx), %r8, %r9
-  xor %r10, %r10
+  xor %r10d, %r10d
   adcxq 80(%rdi), %r8
   movq %r8, 80(%rdi)
   mulxq 40(%rcx), %r10, %r11
@@ -435,7 +435,7 @@ _fmul2_e:
   ;# Compute src1[3] * src2
   movq 56(%rsi), %rdx
   mulxq 32(%rcx), %r8, %r9
-  xor %r10, %r10
+  xor %r10d, %r10d
   adcxq 88(%rdi), %r8
   movq %r8, 88(%rdi)
   mulxq 40(%rcx), %r10, %r11
@@ -464,7 +464,7 @@ _fmul2_e:
   ;# Step 1: Compute dst + carry == tmp_hi * 38 + tmp_lo
   mov $38, %rdx
   mulxq 32(%rsi), %r8, %r13
-  xor %rcx, %rcx
+  xor %ecx, %ecx
   adoxq 0(%rsi), %r8
   mulxq 40(%rsi), %r9, %rbx
   adcx %r13, %r9
@@ -497,7 +497,7 @@ _fmul2_e:
   ;# Step 1: Compute dst + carry == tmp_hi * 38 + tmp_lo
   mov $38, %rdx
   mulxq 96(%rsi), %r8, %r13
-  xor %rcx, %rcx
+  xor %ecx, %ecx
   adoxq 64(%rsi), %r8
   mulxq 104(%rsi), %r9, %rbx
   adcx %r13, %r9
@@ -545,7 +545,7 @@ _fsqr_e:
   movq 0(%rsi), %rdx
   ;# f[0]
   mulxq 8(%rsi), %r8, %r14
-  xor %r15, %r15
+  xor %r15d, %r15d
   ;# f[1]*f[0]
   mulxq 16(%rsi), %r9, %r10
   adcx %r14, %r9
@@ -569,7 +569,7 @@ _fsqr_e:
   ;# f[2]*f[1]
   
   ;# Step 2: Compute two parallel carry chains
-  xor %r15, %r15
+  xor %r15d, %r15d
   adox %rax, %r10
   adcx %r8, %r8
   adox %rcx, %r11
@@ -627,7 +627,7 @@ _fsqr_e:
   ;# Step 1: Compute dst + carry == tmp_hi * 38 + tmp_lo
   mov $38, %rdx
   mulxq 32(%rsi), %r8, %r13
-  xor %rcx, %rcx
+  xor %ecx, %ecx
   adoxq 0(%rsi), %r8
   mulxq 40(%rsi), %r9, %rbx
   adcx %r13, %r9
@@ -675,7 +675,7 @@ _fsqr2_e:
   movq 0(%rsi), %rdx
   ;# f[0]
   mulxq 8(%rsi), %r8, %r14
-  xor %r15, %r15
+  xor %r15d, %r15d
   ;# f[1]*f[0]
   mulxq 16(%rsi), %r9, %r10
   adcx %r14, %r9
@@ -699,7 +699,7 @@ _fsqr2_e:
   ;# f[2]*f[1]
   
   ;# Step 2: Compute two parallel carry chains
-  xor %r15, %r15
+  xor %r15d, %r15d
   adox %rax, %r10
   adcx %r8, %r8
   adox %rcx, %r11
@@ -754,7 +754,7 @@ _fsqr2_e:
   movq 32(%rsi), %rdx
   ;# f[0]
   mulxq 40(%rsi), %r8, %r14
-  xor %r15, %r15
+  xor %r15d, %r15d
   ;# f[1]*f[0]
   mulxq 48(%rsi), %r9, %r10
   adcx %r14, %r9
@@ -778,7 +778,7 @@ _fsqr2_e:
   ;# f[2]*f[1]
   
   ;# Step 2: Compute two parallel carry chains
-  xor %r15, %r15
+  xor %r15d, %r15d
   adox %rax, %r10
   adcx %r8, %r8
   adox %rcx, %r11
@@ -836,7 +836,7 @@ _fsqr2_e:
   ;# Step 1: Compute dst + carry == tmp_hi * 38 + tmp_lo
   mov $38, %rdx
   mulxq 32(%rsi), %r8, %r13
-  xor %rcx, %rcx
+  xor %ecx, %ecx
   adoxq 0(%rsi), %r8
   mulxq 40(%rsi), %r9, %rbx
   adcx %r13, %r9
@@ -869,7 +869,7 @@ _fsqr2_e:
   ;# Step 1: Compute dst + carry == tmp_hi * 38 + tmp_lo
   mov $38, %rdx
   mulxq 96(%rsi), %r8, %r13
-  xor %rcx, %rcx
+  xor %ecx, %ecx
   adoxq 64(%rsi), %r8
   mulxq 104(%rsi), %r9, %rbx
   adcx %r13, %r9

--- a/dist/linux/curve25519-x86_64-linux.S
+++ b/dist/linux/curve25519-x86_64-linux.S
@@ -4,11 +4,11 @@ add_scalar_e:
   push %rdi
   push %rsi
   ;# Clear registers to propagate the carry bit
-  xor %r8, %r8
-  xor %r9, %r9
-  xor %r10, %r10
-  xor %r11, %r11
-  xor %rax, %rax
+  xor %r8d, %r8d
+  xor %r9d, %r9d
+  xor %r10d, %r10d
+  xor %r11d, %r11d
+  xor %eax, %eax
   
   ;# Begin addition chain
   addq 0(%rsi), %rdx
@@ -44,7 +44,7 @@ fadd_e:
   cmovc %rdx, %rax
   
   ;# Step 2: Add carry*38 to the original sum
-  xor %rcx, %rcx
+  xor %ecx, %ecx
   add %rax, %r8
   adcx %rcx, %r9
   movq %r9, 8(%rdi)
@@ -149,7 +149,7 @@ fmul_e:
   ;# Compute src1[0] * src2
   movq 0(%rsi), %rdx
   mulxq 0(%rcx), %r8, %r9
-  xor %r10, %r10
+  xor %r10d, %r10d
   movq %r8, 0(%rdi)
   
   mulxq 8(%rcx), %r10, %r11
@@ -167,7 +167,7 @@ fmul_e:
   ;# Compute src1[1] * src2
   movq 8(%rsi), %rdx
   mulxq 0(%rcx), %r8, %r9
-  xor %r10, %r10
+  xor %r10d, %r10d
   adcxq 8(%rdi), %r8
   movq %r8, 8(%rdi)
   mulxq 8(%rcx), %r10, %r11
@@ -189,7 +189,7 @@ fmul_e:
   ;# Compute src1[2] * src2
   movq 16(%rsi), %rdx
   mulxq 0(%rcx), %r8, %r9
-  xor %r10, %r10
+  xor %r10d, %r10d
   adcxq 16(%rdi), %r8
   movq %r8, 16(%rdi)
   mulxq 8(%rcx), %r10, %r11
@@ -211,7 +211,7 @@ fmul_e:
   ;# Compute src1[3] * src2
   movq 24(%rsi), %rdx
   mulxq 0(%rcx), %r8, %r9
-  xor %r10, %r10
+  xor %r10d, %r10d
   adcxq 24(%rdi), %r8
   movq %r8, 24(%rdi)
   mulxq 8(%rcx), %r10, %r11
@@ -240,7 +240,7 @@ fmul_e:
   ;# Step 1: Compute dst + carry == tmp_hi * 38 + tmp_lo
   mov $38, %rdx
   mulxq 32(%rsi), %r8, %r13
-  xor %rcx, %rcx
+  xor %ecx, %ecx
   adoxq 0(%rsi), %r8
   mulxq 40(%rsi), %r9, %rbx
   adcx %r13, %r9
@@ -286,7 +286,7 @@ fmul2_e:
   ;# Compute src1[0] * src2
   movq 0(%rsi), %rdx
   mulxq 0(%rcx), %r8, %r9
-  xor %r10, %r10
+  xor %r10d, %r10d
   movq %r8, 0(%rdi)
   
   mulxq 8(%rcx), %r10, %r11
@@ -304,7 +304,7 @@ fmul2_e:
   ;# Compute src1[1] * src2
   movq 8(%rsi), %rdx
   mulxq 0(%rcx), %r8, %r9
-  xor %r10, %r10
+  xor %r10d, %r10d
   adcxq 8(%rdi), %r8
   movq %r8, 8(%rdi)
   mulxq 8(%rcx), %r10, %r11
@@ -326,7 +326,7 @@ fmul2_e:
   ;# Compute src1[2] * src2
   movq 16(%rsi), %rdx
   mulxq 0(%rcx), %r8, %r9
-  xor %r10, %r10
+  xor %r10d, %r10d
   adcxq 16(%rdi), %r8
   movq %r8, 16(%rdi)
   mulxq 8(%rcx), %r10, %r11
@@ -348,7 +348,7 @@ fmul2_e:
   ;# Compute src1[3] * src2
   movq 24(%rsi), %rdx
   mulxq 0(%rcx), %r8, %r9
-  xor %r10, %r10
+  xor %r10d, %r10d
   adcxq 24(%rdi), %r8
   movq %r8, 24(%rdi)
   mulxq 8(%rcx), %r10, %r11
@@ -373,7 +373,7 @@ fmul2_e:
   ;# Compute src1[0] * src2
   movq 32(%rsi), %rdx
   mulxq 32(%rcx), %r8, %r9
-  xor %r10, %r10
+  xor %r10d, %r10d
   movq %r8, 64(%rdi)
   
   mulxq 40(%rcx), %r10, %r11
@@ -391,7 +391,7 @@ fmul2_e:
   ;# Compute src1[1] * src2
   movq 40(%rsi), %rdx
   mulxq 32(%rcx), %r8, %r9
-  xor %r10, %r10
+  xor %r10d, %r10d
   adcxq 72(%rdi), %r8
   movq %r8, 72(%rdi)
   mulxq 40(%rcx), %r10, %r11
@@ -413,7 +413,7 @@ fmul2_e:
   ;# Compute src1[2] * src2
   movq 48(%rsi), %rdx
   mulxq 32(%rcx), %r8, %r9
-  xor %r10, %r10
+  xor %r10d, %r10d
   adcxq 80(%rdi), %r8
   movq %r8, 80(%rdi)
   mulxq 40(%rcx), %r10, %r11
@@ -435,7 +435,7 @@ fmul2_e:
   ;# Compute src1[3] * src2
   movq 56(%rsi), %rdx
   mulxq 32(%rcx), %r8, %r9
-  xor %r10, %r10
+  xor %r10d, %r10d
   adcxq 88(%rdi), %r8
   movq %r8, 88(%rdi)
   mulxq 40(%rcx), %r10, %r11
@@ -464,7 +464,7 @@ fmul2_e:
   ;# Step 1: Compute dst + carry == tmp_hi * 38 + tmp_lo
   mov $38, %rdx
   mulxq 32(%rsi), %r8, %r13
-  xor %rcx, %rcx
+  xor %ecx, %ecx
   adoxq 0(%rsi), %r8
   mulxq 40(%rsi), %r9, %rbx
   adcx %r13, %r9
@@ -497,7 +497,7 @@ fmul2_e:
   ;# Step 1: Compute dst + carry == tmp_hi * 38 + tmp_lo
   mov $38, %rdx
   mulxq 96(%rsi), %r8, %r13
-  xor %rcx, %rcx
+  xor %ecx, %ecx
   adoxq 64(%rsi), %r8
   mulxq 104(%rsi), %r9, %rbx
   adcx %r13, %r9
@@ -545,7 +545,7 @@ fsqr_e:
   movq 0(%rsi), %rdx
   ;# f[0]
   mulxq 8(%rsi), %r8, %r14
-  xor %r15, %r15
+  xor %r15d, %r15d
   ;# f[1]*f[0]
   mulxq 16(%rsi), %r9, %r10
   adcx %r14, %r9
@@ -569,7 +569,7 @@ fsqr_e:
   ;# f[2]*f[1]
   
   ;# Step 2: Compute two parallel carry chains
-  xor %r15, %r15
+  xor %r15d, %r15d
   adox %rax, %r10
   adcx %r8, %r8
   adox %rcx, %r11
@@ -627,7 +627,7 @@ fsqr_e:
   ;# Step 1: Compute dst + carry == tmp_hi * 38 + tmp_lo
   mov $38, %rdx
   mulxq 32(%rsi), %r8, %r13
-  xor %rcx, %rcx
+  xor %ecx, %ecx
   adoxq 0(%rsi), %r8
   mulxq 40(%rsi), %r9, %rbx
   adcx %r13, %r9
@@ -675,7 +675,7 @@ fsqr2_e:
   movq 0(%rsi), %rdx
   ;# f[0]
   mulxq 8(%rsi), %r8, %r14
-  xor %r15, %r15
+  xor %r15d, %r15d
   ;# f[1]*f[0]
   mulxq 16(%rsi), %r9, %r10
   adcx %r14, %r9
@@ -699,7 +699,7 @@ fsqr2_e:
   ;# f[2]*f[1]
   
   ;# Step 2: Compute two parallel carry chains
-  xor %r15, %r15
+  xor %r15d, %r15d
   adox %rax, %r10
   adcx %r8, %r8
   adox %rcx, %r11
@@ -754,7 +754,7 @@ fsqr2_e:
   movq 32(%rsi), %rdx
   ;# f[0]
   mulxq 40(%rsi), %r8, %r14
-  xor %r15, %r15
+  xor %r15d, %r15d
   ;# f[1]*f[0]
   mulxq 48(%rsi), %r9, %r10
   adcx %r14, %r9
@@ -778,7 +778,7 @@ fsqr2_e:
   ;# f[2]*f[1]
   
   ;# Step 2: Compute two parallel carry chains
-  xor %r15, %r15
+  xor %r15d, %r15d
   adox %rax, %r10
   adcx %r8, %r8
   adox %rcx, %r11
@@ -836,7 +836,7 @@ fsqr2_e:
   ;# Step 1: Compute dst + carry == tmp_hi * 38 + tmp_lo
   mov $38, %rdx
   mulxq 32(%rsi), %r8, %r13
-  xor %rcx, %rcx
+  xor %ecx, %ecx
   adoxq 0(%rsi), %r8
   mulxq 40(%rsi), %r9, %rbx
   adcx %r13, %r9
@@ -869,7 +869,7 @@ fsqr2_e:
   ;# Step 1: Compute dst + carry == tmp_hi * 38 + tmp_lo
   mov $38, %rdx
   mulxq 96(%rsi), %r8, %r13
-  xor %rcx, %rcx
+  xor %ecx, %ecx
   adoxq 64(%rsi), %r8
   mulxq 104(%rsi), %r9, %rbx
   adcx %r13, %r9

--- a/dist/linux/curve25519-x86_64-mingw.S
+++ b/dist/linux/curve25519-x86_64-mingw.S
@@ -7,11 +7,11 @@ add_scalar_e:
   mov %rdx, %rsi
   mov %r8, %rdx
   ;# Clear registers to propagate the carry bit
-  xor %r8, %r8
-  xor %r9, %r9
-  xor %r10, %r10
-  xor %r11, %r11
-  xor %rax, %rax
+  xor %r8d, %r8d
+  xor %r9d, %r9d
+  xor %r10d, %r10d
+  xor %r11d, %r11d
+  xor %eax, %eax
   
   ;# Begin addition chain
   addq 0(%rsi), %rdx
@@ -52,7 +52,7 @@ fadd_e:
   cmovc %rdx, %rax
   
   ;# Step 2: Add carry*38 to the original sum
-  xor %rcx, %rcx
+  xor %ecx, %ecx
   add %rax, %r8
   adcx %rcx, %r9
   movq %r9, 8(%rdi)
@@ -176,7 +176,7 @@ fmul_e:
   ;# Compute src1[0] * src2
   movq 0(%rsi), %rdx
   mulxq 0(%rcx), %r8, %r9
-  xor %r10, %r10
+  xor %r10d, %r10d
   movq %r8, 0(%rdi)
   
   mulxq 8(%rcx), %r10, %r11
@@ -194,7 +194,7 @@ fmul_e:
   ;# Compute src1[1] * src2
   movq 8(%rsi), %rdx
   mulxq 0(%rcx), %r8, %r9
-  xor %r10, %r10
+  xor %r10d, %r10d
   adcxq 8(%rdi), %r8
   movq %r8, 8(%rdi)
   mulxq 8(%rcx), %r10, %r11
@@ -216,7 +216,7 @@ fmul_e:
   ;# Compute src1[2] * src2
   movq 16(%rsi), %rdx
   mulxq 0(%rcx), %r8, %r9
-  xor %r10, %r10
+  xor %r10d, %r10d
   adcxq 16(%rdi), %r8
   movq %r8, 16(%rdi)
   mulxq 8(%rcx), %r10, %r11
@@ -238,7 +238,7 @@ fmul_e:
   ;# Compute src1[3] * src2
   movq 24(%rsi), %rdx
   mulxq 0(%rcx), %r8, %r9
-  xor %r10, %r10
+  xor %r10d, %r10d
   adcxq 24(%rdi), %r8
   movq %r8, 24(%rdi)
   mulxq 8(%rcx), %r10, %r11
@@ -267,7 +267,7 @@ fmul_e:
   ;# Step 1: Compute dst + carry == tmp_hi * 38 + tmp_lo
   mov $38, %rdx
   mulxq 32(%rsi), %r8, %r13
-  xor %rcx, %rcx
+  xor %ecx, %ecx
   adoxq 0(%rsi), %r8
   mulxq 40(%rsi), %r9, %rbx
   adcx %r13, %r9
@@ -320,7 +320,7 @@ fmul2_e:
   ;# Compute src1[0] * src2
   movq 0(%rsi), %rdx
   mulxq 0(%rcx), %r8, %r9
-  xor %r10, %r10
+  xor %r10d, %r10d
   movq %r8, 0(%rdi)
   
   mulxq 8(%rcx), %r10, %r11
@@ -338,7 +338,7 @@ fmul2_e:
   ;# Compute src1[1] * src2
   movq 8(%rsi), %rdx
   mulxq 0(%rcx), %r8, %r9
-  xor %r10, %r10
+  xor %r10d, %r10d
   adcxq 8(%rdi), %r8
   movq %r8, 8(%rdi)
   mulxq 8(%rcx), %r10, %r11
@@ -360,7 +360,7 @@ fmul2_e:
   ;# Compute src1[2] * src2
   movq 16(%rsi), %rdx
   mulxq 0(%rcx), %r8, %r9
-  xor %r10, %r10
+  xor %r10d, %r10d
   adcxq 16(%rdi), %r8
   movq %r8, 16(%rdi)
   mulxq 8(%rcx), %r10, %r11
@@ -382,7 +382,7 @@ fmul2_e:
   ;# Compute src1[3] * src2
   movq 24(%rsi), %rdx
   mulxq 0(%rcx), %r8, %r9
-  xor %r10, %r10
+  xor %r10d, %r10d
   adcxq 24(%rdi), %r8
   movq %r8, 24(%rdi)
   mulxq 8(%rcx), %r10, %r11
@@ -407,7 +407,7 @@ fmul2_e:
   ;# Compute src1[0] * src2
   movq 32(%rsi), %rdx
   mulxq 32(%rcx), %r8, %r9
-  xor %r10, %r10
+  xor %r10d, %r10d
   movq %r8, 64(%rdi)
   
   mulxq 40(%rcx), %r10, %r11
@@ -425,7 +425,7 @@ fmul2_e:
   ;# Compute src1[1] * src2
   movq 40(%rsi), %rdx
   mulxq 32(%rcx), %r8, %r9
-  xor %r10, %r10
+  xor %r10d, %r10d
   adcxq 72(%rdi), %r8
   movq %r8, 72(%rdi)
   mulxq 40(%rcx), %r10, %r11
@@ -447,7 +447,7 @@ fmul2_e:
   ;# Compute src1[2] * src2
   movq 48(%rsi), %rdx
   mulxq 32(%rcx), %r8, %r9
-  xor %r10, %r10
+  xor %r10d, %r10d
   adcxq 80(%rdi), %r8
   movq %r8, 80(%rdi)
   mulxq 40(%rcx), %r10, %r11
@@ -469,7 +469,7 @@ fmul2_e:
   ;# Compute src1[3] * src2
   movq 56(%rsi), %rdx
   mulxq 32(%rcx), %r8, %r9
-  xor %r10, %r10
+  xor %r10d, %r10d
   adcxq 88(%rdi), %r8
   movq %r8, 88(%rdi)
   mulxq 40(%rcx), %r10, %r11
@@ -498,7 +498,7 @@ fmul2_e:
   ;# Step 1: Compute dst + carry == tmp_hi * 38 + tmp_lo
   mov $38, %rdx
   mulxq 32(%rsi), %r8, %r13
-  xor %rcx, %rcx
+  xor %ecx, %ecx
   adoxq 0(%rsi), %r8
   mulxq 40(%rsi), %r9, %rbx
   adcx %r13, %r9
@@ -531,7 +531,7 @@ fmul2_e:
   ;# Step 1: Compute dst + carry == tmp_hi * 38 + tmp_lo
   mov $38, %rdx
   mulxq 96(%rsi), %r8, %r13
-  xor %rcx, %rcx
+  xor %ecx, %ecx
   adoxq 64(%rsi), %r8
   mulxq 104(%rsi), %r9, %rbx
   adcx %r13, %r9
@@ -585,7 +585,7 @@ fsqr_e:
   movq 0(%rsi), %rdx
   ;# f[0]
   mulxq 8(%rsi), %r8, %r14
-  xor %r15, %r15
+  xor %r15d, %r15d
   ;# f[1]*f[0]
   mulxq 16(%rsi), %r9, %r10
   adcx %r14, %r9
@@ -609,7 +609,7 @@ fsqr_e:
   ;# f[2]*f[1]
   
   ;# Step 2: Compute two parallel carry chains
-  xor %r15, %r15
+  xor %r15d, %r15d
   adox %rax, %r10
   adcx %r8, %r8
   adox %rcx, %r11
@@ -667,7 +667,7 @@ fsqr_e:
   ;# Step 1: Compute dst + carry == tmp_hi * 38 + tmp_lo
   mov $38, %rdx
   mulxq 32(%rsi), %r8, %r13
-  xor %rcx, %rcx
+  xor %ecx, %ecx
   adoxq 0(%rsi), %r8
   mulxq 40(%rsi), %r9, %rbx
   adcx %r13, %r9
@@ -721,7 +721,7 @@ fsqr2_e:
   movq 0(%rsi), %rdx
   ;# f[0]
   mulxq 8(%rsi), %r8, %r14
-  xor %r15, %r15
+  xor %r15d, %r15d
   ;# f[1]*f[0]
   mulxq 16(%rsi), %r9, %r10
   adcx %r14, %r9
@@ -745,7 +745,7 @@ fsqr2_e:
   ;# f[2]*f[1]
   
   ;# Step 2: Compute two parallel carry chains
-  xor %r15, %r15
+  xor %r15d, %r15d
   adox %rax, %r10
   adcx %r8, %r8
   adox %rcx, %r11
@@ -800,7 +800,7 @@ fsqr2_e:
   movq 32(%rsi), %rdx
   ;# f[0]
   mulxq 40(%rsi), %r8, %r14
-  xor %r15, %r15
+  xor %r15d, %r15d
   ;# f[1]*f[0]
   mulxq 48(%rsi), %r9, %r10
   adcx %r14, %r9
@@ -824,7 +824,7 @@ fsqr2_e:
   ;# f[2]*f[1]
   
   ;# Step 2: Compute two parallel carry chains
-  xor %r15, %r15
+  xor %r15d, %r15d
   adox %rax, %r10
   adcx %r8, %r8
   adox %rcx, %r11
@@ -882,7 +882,7 @@ fsqr2_e:
   ;# Step 1: Compute dst + carry == tmp_hi * 38 + tmp_lo
   mov $38, %rdx
   mulxq 32(%rsi), %r8, %r13
-  xor %rcx, %rcx
+  xor %ecx, %ecx
   adoxq 0(%rsi), %r8
   mulxq 40(%rsi), %r9, %rbx
   adcx %r13, %r9
@@ -915,7 +915,7 @@ fsqr2_e:
   ;# Step 1: Compute dst + carry == tmp_hi * 38 + tmp_lo
   mov $38, %rdx
   mulxq 96(%rsi), %r8, %r13
-  xor %rcx, %rcx
+  xor %ecx, %ecx
   adoxq 64(%rsi), %r8
   mulxq 104(%rsi), %r9, %rbx
   adcx %r13, %r9

--- a/dist/linux/curve25519-x86_64-msvc.asm
+++ b/dist/linux/curve25519-x86_64-msvc.asm
@@ -7,11 +7,11 @@ add_scalar_e proc
   mov rsi, rdx
   mov rdx, r8
   ;# Clear registers to propagate the carry bit
-  xor r8, r8
-  xor r9, r9
-  xor r10, r10
-  xor r11, r11
-  xor rax, rax
+  xor r8d, r8d
+  xor r9d, r9d
+  xor r10d, r10d
+  xor r11d, r11d
+  xor eax, eax
   
   ;# Begin addition chain
   add rdx, qword ptr [rsi + 0]
@@ -52,7 +52,7 @@ fadd_e proc
   cmovc rax, rdx
   
   ;# Step 2: Add carry*38 to the original sum
-  xor rcx, rcx
+  xor ecx, ecx
   add r8, rax
   adcx r9, rcx
   mov qword ptr [rdi + 8], r9
@@ -176,7 +176,7 @@ fmul_e proc
   ;# Compute src1[0] * src2
   mov rdx, qword ptr [rsi + 0]
   mulx r9, r8, qword ptr [rcx + 0]
-  xor r10, r10
+  xor r10d, r10d
   mov qword ptr [rdi + 0], r8
   
   mulx r11, r10, qword ptr [rcx + 8]
@@ -194,7 +194,7 @@ fmul_e proc
   ;# Compute src1[1] * src2
   mov rdx, qword ptr [rsi + 8]
   mulx r9, r8, qword ptr [rcx + 0]
-  xor r10, r10
+  xor r10d, r10d
   adcx r8, qword ptr [rdi + 8]
   mov qword ptr [rdi + 8], r8
   mulx r11, r10, qword ptr [rcx + 8]
@@ -216,7 +216,7 @@ fmul_e proc
   ;# Compute src1[2] * src2
   mov rdx, qword ptr [rsi + 16]
   mulx r9, r8, qword ptr [rcx + 0]
-  xor r10, r10
+  xor r10d, r10d
   adcx r8, qword ptr [rdi + 16]
   mov qword ptr [rdi + 16], r8
   mulx r11, r10, qword ptr [rcx + 8]
@@ -238,7 +238,7 @@ fmul_e proc
   ;# Compute src1[3] * src2
   mov rdx, qword ptr [rsi + 24]
   mulx r9, r8, qword ptr [rcx + 0]
-  xor r10, r10
+  xor r10d, r10d
   adcx r8, qword ptr [rdi + 24]
   mov qword ptr [rdi + 24], r8
   mulx r11, r10, qword ptr [rcx + 8]
@@ -267,7 +267,7 @@ fmul_e proc
   ;# Step 1: Compute dst + carry == tmp_hi * 38 + tmp_lo
   mov rdx, 38
   mulx r13, r8, qword ptr [rsi + 32]
-  xor rcx, rcx
+  xor ecx, ecx
   adox r8, qword ptr [rsi + 0]
   mulx rbx, r9, qword ptr [rsi + 40]
   adcx r9, r13
@@ -320,7 +320,7 @@ fmul2_e proc
   ;# Compute src1[0] * src2
   mov rdx, qword ptr [rsi + 0]
   mulx r9, r8, qword ptr [rcx + 0]
-  xor r10, r10
+  xor r10d, r10d
   mov qword ptr [rdi + 0], r8
   
   mulx r11, r10, qword ptr [rcx + 8]
@@ -338,7 +338,7 @@ fmul2_e proc
   ;# Compute src1[1] * src2
   mov rdx, qword ptr [rsi + 8]
   mulx r9, r8, qword ptr [rcx + 0]
-  xor r10, r10
+  xor r10d, r10d
   adcx r8, qword ptr [rdi + 8]
   mov qword ptr [rdi + 8], r8
   mulx r11, r10, qword ptr [rcx + 8]
@@ -360,7 +360,7 @@ fmul2_e proc
   ;# Compute src1[2] * src2
   mov rdx, qword ptr [rsi + 16]
   mulx r9, r8, qword ptr [rcx + 0]
-  xor r10, r10
+  xor r10d, r10d
   adcx r8, qword ptr [rdi + 16]
   mov qword ptr [rdi + 16], r8
   mulx r11, r10, qword ptr [rcx + 8]
@@ -382,7 +382,7 @@ fmul2_e proc
   ;# Compute src1[3] * src2
   mov rdx, qword ptr [rsi + 24]
   mulx r9, r8, qword ptr [rcx + 0]
-  xor r10, r10
+  xor r10d, r10d
   adcx r8, qword ptr [rdi + 24]
   mov qword ptr [rdi + 24], r8
   mulx r11, r10, qword ptr [rcx + 8]
@@ -407,7 +407,7 @@ fmul2_e proc
   ;# Compute src1[0] * src2
   mov rdx, qword ptr [rsi + 32]
   mulx r9, r8, qword ptr [rcx + 32]
-  xor r10, r10
+  xor r10d, r10d
   mov qword ptr [rdi + 64], r8
   
   mulx r11, r10, qword ptr [rcx + 40]
@@ -425,7 +425,7 @@ fmul2_e proc
   ;# Compute src1[1] * src2
   mov rdx, qword ptr [rsi + 40]
   mulx r9, r8, qword ptr [rcx + 32]
-  xor r10, r10
+  xor r10d, r10d
   adcx r8, qword ptr [rdi + 72]
   mov qword ptr [rdi + 72], r8
   mulx r11, r10, qword ptr [rcx + 40]
@@ -447,7 +447,7 @@ fmul2_e proc
   ;# Compute src1[2] * src2
   mov rdx, qword ptr [rsi + 48]
   mulx r9, r8, qword ptr [rcx + 32]
-  xor r10, r10
+  xor r10d, r10d
   adcx r8, qword ptr [rdi + 80]
   mov qword ptr [rdi + 80], r8
   mulx r11, r10, qword ptr [rcx + 40]
@@ -469,7 +469,7 @@ fmul2_e proc
   ;# Compute src1[3] * src2
   mov rdx, qword ptr [rsi + 56]
   mulx r9, r8, qword ptr [rcx + 32]
-  xor r10, r10
+  xor r10d, r10d
   adcx r8, qword ptr [rdi + 88]
   mov qword ptr [rdi + 88], r8
   mulx r11, r10, qword ptr [rcx + 40]
@@ -498,7 +498,7 @@ fmul2_e proc
   ;# Step 1: Compute dst + carry == tmp_hi * 38 + tmp_lo
   mov rdx, 38
   mulx r13, r8, qword ptr [rsi + 32]
-  xor rcx, rcx
+  xor ecx, ecx
   adox r8, qword ptr [rsi + 0]
   mulx rbx, r9, qword ptr [rsi + 40]
   adcx r9, r13
@@ -531,7 +531,7 @@ fmul2_e proc
   ;# Step 1: Compute dst + carry == tmp_hi * 38 + tmp_lo
   mov rdx, 38
   mulx r13, r8, qword ptr [rsi + 96]
-  xor rcx, rcx
+  xor ecx, ecx
   adox r8, qword ptr [rsi + 64]
   mulx rbx, r9, qword ptr [rsi + 104]
   adcx r9, r13
@@ -585,7 +585,7 @@ fsqr_e proc
   mov rdx, qword ptr [rsi + 0]
   ;# f[0]
   mulx r14, r8, qword ptr [rsi + 8]
-  xor r15, r15
+  xor r15d, r15d
   ;# f[1]*f[0]
   mulx r10, r9, qword ptr [rsi + 16]
   adcx r9, r14
@@ -609,7 +609,7 @@ fsqr_e proc
   ;# f[2]*f[1]
   
   ;# Step 2: Compute two parallel carry chains
-  xor r15, r15
+  xor r15d, r15d
   adox r10, rax
   adcx r8, r8
   adox r11, rcx
@@ -667,7 +667,7 @@ fsqr_e proc
   ;# Step 1: Compute dst + carry == tmp_hi * 38 + tmp_lo
   mov rdx, 38
   mulx r13, r8, qword ptr [rsi + 32]
-  xor rcx, rcx
+  xor ecx, ecx
   adox r8, qword ptr [rsi + 0]
   mulx rbx, r9, qword ptr [rsi + 40]
   adcx r9, r13
@@ -721,7 +721,7 @@ fsqr2_e proc
   mov rdx, qword ptr [rsi + 0]
   ;# f[0]
   mulx r14, r8, qword ptr [rsi + 8]
-  xor r15, r15
+  xor r15d, r15d
   ;# f[1]*f[0]
   mulx r10, r9, qword ptr [rsi + 16]
   adcx r9, r14
@@ -745,7 +745,7 @@ fsqr2_e proc
   ;# f[2]*f[1]
   
   ;# Step 2: Compute two parallel carry chains
-  xor r15, r15
+  xor r15d, r15d
   adox r10, rax
   adcx r8, r8
   adox r11, rcx
@@ -800,7 +800,7 @@ fsqr2_e proc
   mov rdx, qword ptr [rsi + 32]
   ;# f[0]
   mulx r14, r8, qword ptr [rsi + 40]
-  xor r15, r15
+  xor r15d, r15d
   ;# f[1]*f[0]
   mulx r10, r9, qword ptr [rsi + 48]
   adcx r9, r14
@@ -824,7 +824,7 @@ fsqr2_e proc
   ;# f[2]*f[1]
   
   ;# Step 2: Compute two parallel carry chains
-  xor r15, r15
+  xor r15d, r15d
   adox r10, rax
   adcx r8, r8
   adox r11, rcx
@@ -882,7 +882,7 @@ fsqr2_e proc
   ;# Step 1: Compute dst + carry == tmp_hi * 38 + tmp_lo
   mov rdx, 38
   mulx r13, r8, qword ptr [rsi + 32]
-  xor rcx, rcx
+  xor ecx, ecx
   adox r8, qword ptr [rsi + 0]
   mulx rbx, r9, qword ptr [rsi + 40]
   adcx r9, r13
@@ -915,7 +915,7 @@ fsqr2_e proc
   ;# Step 1: Compute dst + carry == tmp_hi * 38 + tmp_lo
   mov rdx, 38
   mulx r13, r8, qword ptr [rsi + 96]
-  xor rcx, rcx
+  xor ecx, ecx
   adox r8, qword ptr [rsi + 64]
   mulx rbx, r9, qword ptr [rsi + 104]
   adcx r9, r13

--- a/dist/mitls/curve25519-inline.h
+++ b/dist/mitls/curve25519-inline.h
@@ -10,11 +10,11 @@ static inline uint64_t add_scalar (uint64_t *out, uint64_t *f1, uint64_t f2)
 
   asm volatile(
     // Clear registers to propagate the carry bit
-    "  xor %%r8, %%r8;"
-    "  xor %%r9, %%r9;"
-    "  xor %%r10, %%r10;"
-    "  xor %%r11, %%r11;"
-    "  xor %1, %1;"
+    "  xor %%r8d, %%r8d;"
+    "  xor %%r9d, %%r9d;"
+    "  xor %%r10d, %%r10d;"
+    "  xor %%r11d, %%r11d;"
+    "  xor %k1, %k1;"
 
     // Begin addition chain
     "  addq 0(%3), %0;"
@@ -58,7 +58,7 @@ static inline void fadd (uint64_t *out, uint64_t *f1, uint64_t *f2)
     "  cmovc %0, %%rax;"
 
     // Step 2: Add carry*38 to the original sum
-    "  xor %%rcx, %%rcx;"
+    "  xor %%ecx, %%ecx;"
     "  add %%rax, %%r8;"
     "  adcx %%rcx, %%r9;"
     "  movq %%r9, 8(%1);"
@@ -131,7 +131,7 @@ static inline void fmul (uint64_t *out, uint64_t *f1, uint64_t *f2, uint64_t *tm
 
     // Compute src1[0] * src2
     "  movq 0(%1), %%rdx;"
-    "  mulxq 0(%2), %%r8, %%r9;"       "  xor %%r10, %%r10;"     "  movq %%r8, 0(%3);"
+    "  mulxq 0(%2), %%r8, %%r9;"       "  xor %%r10d, %%r10d;"     "  movq %%r8, 0(%3);"
     "  mulxq 8(%2), %%r10, %%r11;"     "  adox %%r9, %%r10;"     "  movq %%r10, 8(%3);"
     "  mulxq 16(%2), %%rbx, %%r13;"    "  adox %%r11, %%rbx;"
     "  mulxq 24(%2), %%r14, %%rdx;"    "  adox %%r13, %%r14;"    "  mov $0, %%rax;"
@@ -139,7 +139,7 @@ static inline void fmul (uint64_t *out, uint64_t *f1, uint64_t *f2, uint64_t *tm
 
     // Compute src1[1] * src2
     "  movq 8(%1), %%rdx;"
-    "  mulxq 0(%2), %%r8, %%r9;"       "  xor %%r10, %%r10;"     "  adcxq 8(%3), %%r8;"    "  movq %%r8, 8(%3);"
+    "  mulxq 0(%2), %%r8, %%r9;"       "  xor %%r10d, %%r10d;"     "  adcxq 8(%3), %%r8;"    "  movq %%r8, 8(%3);"
     "  mulxq 8(%2), %%r10, %%r11;"     "  adox %%r9, %%r10;"     "  adcx %%rbx, %%r10;"    "  movq %%r10, 16(%3);"
     "  mulxq 16(%2), %%rbx, %%r13;"    "  adox %%r11, %%rbx;"    "  adcx %%r14, %%rbx;"    "  mov $0, %%r8;"
     "  mulxq 24(%2), %%r14, %%rdx;"    "  adox %%r13, %%r14;"    "  adcx %%rax, %%r14;"    "  mov $0, %%rax;"
@@ -148,7 +148,7 @@ static inline void fmul (uint64_t *out, uint64_t *f1, uint64_t *f2, uint64_t *tm
 
     // Compute src1[2] * src2
     "  movq 16(%1), %%rdx;"
-    "  mulxq 0(%2), %%r8, %%r9;"       "  xor %%r10, %%r10;"    "  adcxq 16(%3), %%r8;"    "  movq %%r8, 16(%3);"
+    "  mulxq 0(%2), %%r8, %%r9;"       "  xor %%r10d, %%r10d;"    "  adcxq 16(%3), %%r8;"    "  movq %%r8, 16(%3);"
     "  mulxq 8(%2), %%r10, %%r11;"     "  adox %%r9, %%r10;"     "  adcx %%rbx, %%r10;"    "  movq %%r10, 24(%3);"
     "  mulxq 16(%2), %%rbx, %%r13;"    "  adox %%r11, %%rbx;"    "  adcx %%r14, %%rbx;"    "  mov $0, %%r8;"
     "  mulxq 24(%2), %%r14, %%rdx;"    "  adox %%r13, %%r14;"    "  adcx %%rax, %%r14;"    "  mov $0, %%rax;"
@@ -157,7 +157,7 @@ static inline void fmul (uint64_t *out, uint64_t *f1, uint64_t *f2, uint64_t *tm
 
     // Compute src1[3] * src2
     "  movq 24(%1), %%rdx;"
-    "  mulxq 0(%2), %%r8, %%r9;"       "  xor %%r10, %%r10;"    "  adcxq 24(%3), %%r8;"    "  movq %%r8, 24(%3);"
+    "  mulxq 0(%2), %%r8, %%r9;"       "  xor %%r10d, %%r10d;"    "  adcxq 24(%3), %%r8;"    "  movq %%r8, 24(%3);"
     "  mulxq 8(%2), %%r10, %%r11;"     "  adox %%r9, %%r10;"     "  adcx %%rbx, %%r10;"    "  movq %%r10, 32(%3);"
     "  mulxq 16(%2), %%rbx, %%r13;"    "  adox %%r11, %%rbx;"    "  adcx %%r14, %%rbx;"    "  movq %%rbx, 40(%3);"    "  mov $0, %%r8;"
     "  mulxq 24(%2), %%r14, %%rdx;"    "  adox %%r13, %%r14;"    "  adcx %%rax, %%r14;"    "  movq %%r14, 48(%3);"    "  mov $0, %%rax;"
@@ -172,7 +172,7 @@ static inline void fmul (uint64_t *out, uint64_t *f1, uint64_t *f2, uint64_t *tm
     // Step 1: Compute dst + carry == tmp_hi * 38 + tmp_lo
     "  mov $38, %%rdx;"
     "  mulxq 32(%1), %%r8, %%r13;"
-    "  xor %2, %2;"
+    "  xor %k2, %k2;"
     "  adoxq 0(%1), %%r8;"
     "  mulxq 40(%1), %%r9, %%rbx;"
     "  adcx %%r13, %%r9;"
@@ -219,7 +219,7 @@ static inline void fmul2 (uint64_t *out, uint64_t *f1, uint64_t *f2, uint64_t *t
 
     // Compute src1[0] * src2
     "  movq 0(%1), %%rdx;"
-    "  mulxq 0(%2), %%r8, %%r9;"       "  xor %%r10, %%r10;"     "  movq %%r8, 0(%3);"
+    "  mulxq 0(%2), %%r8, %%r9;"       "  xor %%r10d, %%r10d;"     "  movq %%r8, 0(%3);"
     "  mulxq 8(%2), %%r10, %%r11;"     "  adox %%r9, %%r10;"     "  movq %%r10, 8(%3);"
     "  mulxq 16(%2), %%rbx, %%r13;"    "  adox %%r11, %%rbx;"
     "  mulxq 24(%2), %%r14, %%rdx;"    "  adox %%r13, %%r14;"    "  mov $0, %%rax;"
@@ -227,7 +227,7 @@ static inline void fmul2 (uint64_t *out, uint64_t *f1, uint64_t *f2, uint64_t *t
 
     // Compute src1[1] * src2
     "  movq 8(%1), %%rdx;"
-    "  mulxq 0(%2), %%r8, %%r9;"       "  xor %%r10, %%r10;"     "  adcxq 8(%3), %%r8;"    "  movq %%r8, 8(%3);"
+    "  mulxq 0(%2), %%r8, %%r9;"       "  xor %%r10d, %%r10d;"     "  adcxq 8(%3), %%r8;"    "  movq %%r8, 8(%3);"
     "  mulxq 8(%2), %%r10, %%r11;"     "  adox %%r9, %%r10;"     "  adcx %%rbx, %%r10;"    "  movq %%r10, 16(%3);"
     "  mulxq 16(%2), %%rbx, %%r13;"    "  adox %%r11, %%rbx;"    "  adcx %%r14, %%rbx;"    "  mov $0, %%r8;"
     "  mulxq 24(%2), %%r14, %%rdx;"    "  adox %%r13, %%r14;"    "  adcx %%rax, %%r14;"    "  mov $0, %%rax;"
@@ -236,7 +236,7 @@ static inline void fmul2 (uint64_t *out, uint64_t *f1, uint64_t *f2, uint64_t *t
 
     // Compute src1[2] * src2
     "  movq 16(%1), %%rdx;"
-    "  mulxq 0(%2), %%r8, %%r9;"       "  xor %%r10, %%r10;"    "  adcxq 16(%3), %%r8;"    "  movq %%r8, 16(%3);"
+    "  mulxq 0(%2), %%r8, %%r9;"       "  xor %%r10d, %%r10d;"    "  adcxq 16(%3), %%r8;"    "  movq %%r8, 16(%3);"
     "  mulxq 8(%2), %%r10, %%r11;"     "  adox %%r9, %%r10;"     "  adcx %%rbx, %%r10;"    "  movq %%r10, 24(%3);"
     "  mulxq 16(%2), %%rbx, %%r13;"    "  adox %%r11, %%rbx;"    "  adcx %%r14, %%rbx;"    "  mov $0, %%r8;"
     "  mulxq 24(%2), %%r14, %%rdx;"    "  adox %%r13, %%r14;"    "  adcx %%rax, %%r14;"    "  mov $0, %%rax;"
@@ -245,7 +245,7 @@ static inline void fmul2 (uint64_t *out, uint64_t *f1, uint64_t *f2, uint64_t *t
 
     // Compute src1[3] * src2
     "  movq 24(%1), %%rdx;"
-    "  mulxq 0(%2), %%r8, %%r9;"       "  xor %%r10, %%r10;"    "  adcxq 24(%3), %%r8;"    "  movq %%r8, 24(%3);"
+    "  mulxq 0(%2), %%r8, %%r9;"       "  xor %%r10d, %%r10d;"    "  adcxq 24(%3), %%r8;"    "  movq %%r8, 24(%3);"
     "  mulxq 8(%2), %%r10, %%r11;"     "  adox %%r9, %%r10;"     "  adcx %%rbx, %%r10;"    "  movq %%r10, 32(%3);"
     "  mulxq 16(%2), %%rbx, %%r13;"    "  adox %%r11, %%rbx;"    "  adcx %%r14, %%rbx;"    "  movq %%rbx, 40(%3);"    "  mov $0, %%r8;"
     "  mulxq 24(%2), %%r14, %%rdx;"    "  adox %%r13, %%r14;"    "  adcx %%rax, %%r14;"    "  movq %%r14, 48(%3);"    "  mov $0, %%rax;"
@@ -255,7 +255,7 @@ static inline void fmul2 (uint64_t *out, uint64_t *f1, uint64_t *f2, uint64_t *t
 
     // Compute src1[0] * src2
     "  movq 32(%1), %%rdx;"
-    "  mulxq 32(%2), %%r8, %%r9;"       "  xor %%r10, %%r10;"     "  movq %%r8, 64(%3);"
+    "  mulxq 32(%2), %%r8, %%r9;"       "  xor %%r10d, %%r10d;"     "  movq %%r8, 64(%3);"
     "  mulxq 40(%2), %%r10, %%r11;"     "  adox %%r9, %%r10;"     "  movq %%r10, 72(%3);"
     "  mulxq 48(%2), %%rbx, %%r13;"    "  adox %%r11, %%rbx;"
     "  mulxq 56(%2), %%r14, %%rdx;"    "  adox %%r13, %%r14;"    "  mov $0, %%rax;"
@@ -263,7 +263,7 @@ static inline void fmul2 (uint64_t *out, uint64_t *f1, uint64_t *f2, uint64_t *t
 
     // Compute src1[1] * src2
     "  movq 40(%1), %%rdx;"
-    "  mulxq 32(%2), %%r8, %%r9;"       "  xor %%r10, %%r10;"     "  adcxq 72(%3), %%r8;"    "  movq %%r8, 72(%3);"
+    "  mulxq 32(%2), %%r8, %%r9;"       "  xor %%r10d, %%r10d;"     "  adcxq 72(%3), %%r8;"    "  movq %%r8, 72(%3);"
     "  mulxq 40(%2), %%r10, %%r11;"     "  adox %%r9, %%r10;"     "  adcx %%rbx, %%r10;"    "  movq %%r10, 80(%3);"
     "  mulxq 48(%2), %%rbx, %%r13;"    "  adox %%r11, %%rbx;"    "  adcx %%r14, %%rbx;"    "  mov $0, %%r8;"
     "  mulxq 56(%2), %%r14, %%rdx;"    "  adox %%r13, %%r14;"    "  adcx %%rax, %%r14;"    "  mov $0, %%rax;"
@@ -272,7 +272,7 @@ static inline void fmul2 (uint64_t *out, uint64_t *f1, uint64_t *f2, uint64_t *t
 
     // Compute src1[2] * src2
     "  movq 48(%1), %%rdx;"
-    "  mulxq 32(%2), %%r8, %%r9;"       "  xor %%r10, %%r10;"    "  adcxq 80(%3), %%r8;"    "  movq %%r8, 80(%3);"
+    "  mulxq 32(%2), %%r8, %%r9;"       "  xor %%r10d, %%r10d;"    "  adcxq 80(%3), %%r8;"    "  movq %%r8, 80(%3);"
     "  mulxq 40(%2), %%r10, %%r11;"     "  adox %%r9, %%r10;"     "  adcx %%rbx, %%r10;"    "  movq %%r10, 88(%3);"
     "  mulxq 48(%2), %%rbx, %%r13;"    "  adox %%r11, %%rbx;"    "  adcx %%r14, %%rbx;"    "  mov $0, %%r8;"
     "  mulxq 56(%2), %%r14, %%rdx;"    "  adox %%r13, %%r14;"    "  adcx %%rax, %%r14;"    "  mov $0, %%rax;"
@@ -281,7 +281,7 @@ static inline void fmul2 (uint64_t *out, uint64_t *f1, uint64_t *f2, uint64_t *t
 
     // Compute src1[3] * src2
     "  movq 56(%1), %%rdx;"
-    "  mulxq 32(%2), %%r8, %%r9;"       "  xor %%r10, %%r10;"    "  adcxq 88(%3), %%r8;"    "  movq %%r8, 88(%3);"
+    "  mulxq 32(%2), %%r8, %%r9;"       "  xor %%r10d, %%r10d;"    "  adcxq 88(%3), %%r8;"    "  movq %%r8, 88(%3);"
     "  mulxq 40(%2), %%r10, %%r11;"     "  adox %%r9, %%r10;"     "  adcx %%rbx, %%r10;"    "  movq %%r10, 96(%3);"
     "  mulxq 48(%2), %%rbx, %%r13;"    "  adox %%r11, %%rbx;"    "  adcx %%r14, %%rbx;"    "  movq %%rbx, 104(%3);"    "  mov $0, %%r8;"
     "  mulxq 56(%2), %%r14, %%rdx;"    "  adox %%r13, %%r14;"    "  adcx %%rax, %%r14;"    "  movq %%r14, 112(%3);"    "  mov $0, %%rax;"
@@ -296,7 +296,7 @@ static inline void fmul2 (uint64_t *out, uint64_t *f1, uint64_t *f2, uint64_t *t
     // Step 1: Compute dst + carry == tmp_hi * 38 + tmp_lo
     "  mov $38, %%rdx;"
     "  mulxq 32(%1), %%r8, %%r13;"
-    "  xor %2, %2;"
+    "  xor %k2, %k2;"
     "  adoxq 0(%1), %%r8;"
     "  mulxq 40(%1), %%r9, %%rbx;"
     "  adcx %%r13, %%r9;"
@@ -329,7 +329,7 @@ static inline void fmul2 (uint64_t *out, uint64_t *f1, uint64_t *f2, uint64_t *t
     // Step 1: Compute dst + carry == tmp_hi * 38 + tmp_lo
     "  mov $38, %%rdx;"
     "  mulxq 96(%1), %%r8, %%r13;"
-    "  xor %2, %2;"
+    "  xor %k2, %k2;"
     "  adoxq 64(%1), %%r8;"
     "  mulxq 104(%1), %%r9, %%rbx;"
     "  adcx %%r13, %%r9;"
@@ -502,7 +502,7 @@ static inline void fsqr (uint64_t *out, uint64_t *f, uint64_t *tmp)
 
     // Step 1: Compute all partial products
     "  movq 0(%1), %%rdx;"                                       // f[0]
-    "  mulxq 8(%1), %%r8, %%r14;"      "  xor %%r15, %%r15;"     // f[1]*f[0]
+    "  mulxq 8(%1), %%r8, %%r14;"      "  xor %%r15d, %%r15d;"     // f[1]*f[0]
     "  mulxq 16(%1), %%r9, %%r10;"     "  adcx %%r14, %%r9;"     // f[2]*f[0]
     "  mulxq 24(%1), %%rax, %%rcx;"    "  adcx %%rax, %%r10;"    // f[3]*f[0]
     "  movq 24(%1), %%rdx;"                                      // f[3]
@@ -512,7 +512,7 @@ static inline void fsqr (uint64_t *out, uint64_t *f, uint64_t *tmp)
     "  mulxq 16(%1), %%rax, %%rcx;"    "  mov $0, %%r14;"        // f[2]*f[1]
 
     // Step 2: Compute two parallel carry chains
-    "  xor %%r15, %%r15;"
+    "  xor %%r15d, %%r15d;"
     "  adox %%rax, %%r10;"
     "  adcx %%r8, %%r8;"
     "  adox %%rcx, %%r11;"
@@ -549,7 +549,7 @@ static inline void fsqr (uint64_t *out, uint64_t *f, uint64_t *tmp)
     // Step 1: Compute dst + carry == tmp_hi * 38 + tmp_lo
     "  mov $38, %%rdx;"
     "  mulxq 32(%1), %%r8, %%r13;"
-    "  xor %%rcx, %%rcx;"
+    "  xor %%ecx, %%ecx;"
     "  adoxq 0(%1), %%r8;"
     "  mulxq 40(%1), %%r9, %%rbx;"
     "  adcx %%r13, %%r9;"
@@ -593,7 +593,7 @@ static inline void fsqr2 (uint64_t *out, uint64_t *f, uint64_t *tmp)
   asm volatile(
     // Step 1: Compute all partial products
     "  movq 0(%1), %%rdx;"                                       // f[0]
-    "  mulxq 8(%1), %%r8, %%r14;"      "  xor %%r15, %%r15;"     // f[1]*f[0]
+    "  mulxq 8(%1), %%r8, %%r14;"      "  xor %%r15d, %%r15d;"     // f[1]*f[0]
     "  mulxq 16(%1), %%r9, %%r10;"     "  adcx %%r14, %%r9;"     // f[2]*f[0]
     "  mulxq 24(%1), %%rax, %%rcx;"    "  adcx %%rax, %%r10;"    // f[3]*f[0]
     "  movq 24(%1), %%rdx;"                                      // f[3]
@@ -603,7 +603,7 @@ static inline void fsqr2 (uint64_t *out, uint64_t *f, uint64_t *tmp)
     "  mulxq 16(%1), %%rax, %%rcx;"    "  mov $0, %%r14;"        // f[2]*f[1]
 
     // Step 2: Compute two parallel carry chains
-    "  xor %%r15, %%r15;"
+    "  xor %%r15d, %%r15d;"
     "  adox %%rax, %%r10;"
     "  adcx %%r8, %%r8;"
     "  adox %%rcx, %%r11;"
@@ -633,7 +633,7 @@ static inline void fsqr2 (uint64_t *out, uint64_t *f, uint64_t *tmp)
 
     // Step 1: Compute all partial products
     "  movq 32(%1), %%rdx;"                                       // f[0]
-    "  mulxq 40(%1), %%r8, %%r14;"      "  xor %%r15, %%r15;"     // f[1]*f[0]
+    "  mulxq 40(%1), %%r8, %%r14;"      "  xor %%r15d, %%r15d;"     // f[1]*f[0]
     "  mulxq 48(%1), %%r9, %%r10;"     "  adcx %%r14, %%r9;"     // f[2]*f[0]
     "  mulxq 56(%1), %%rax, %%rcx;"    "  adcx %%rax, %%r10;"    // f[3]*f[0]
     "  movq 56(%1), %%rdx;"                                      // f[3]
@@ -643,7 +643,7 @@ static inline void fsqr2 (uint64_t *out, uint64_t *f, uint64_t *tmp)
     "  mulxq 48(%1), %%rax, %%rcx;"    "  mov $0, %%r14;"        // f[2]*f[1]
 
     // Step 2: Compute two parallel carry chains
-    "  xor %%r15, %%r15;"
+    "  xor %%r15d, %%r15d;"
     "  adox %%rax, %%r10;"
     "  adcx %%r8, %%r8;"
     "  adox %%rcx, %%r11;"
@@ -678,7 +678,7 @@ static inline void fsqr2 (uint64_t *out, uint64_t *f, uint64_t *tmp)
     // Step 1: Compute dst + carry == tmp_hi * 38 + tmp_lo
     "  mov $38, %%rdx;"
     "  mulxq 32(%1), %%r8, %%r13;"
-    "  xor %%rcx, %%rcx;"
+    "  xor %%ecx, %%ecx;"
     "  adoxq 0(%1), %%r8;"
     "  mulxq 40(%1), %%r9, %%rbx;"
     "  adcx %%r13, %%r9;"
@@ -711,7 +711,7 @@ static inline void fsqr2 (uint64_t *out, uint64_t *f, uint64_t *tmp)
     // Step 1: Compute dst + carry == tmp_hi * 38 + tmp_lo
     "  mov $38, %%rdx;"
     "  mulxq 96(%1), %%r8, %%r13;"
-    "  xor %%rcx, %%rcx;"
+    "  xor %%ecx, %%ecx;"
     "  adoxq 64(%1), %%r8;"
     "  mulxq 104(%1), %%r9, %%rbx;"
     "  adcx %%r13, %%r9;"

--- a/dist/mitls/curve25519-x86_64-darwin.S
+++ b/dist/mitls/curve25519-x86_64-darwin.S
@@ -4,11 +4,11 @@ _add_scalar_e:
   push %rdi
   push %rsi
   ;# Clear registers to propagate the carry bit
-  xor %r8, %r8
-  xor %r9, %r9
-  xor %r10, %r10
-  xor %r11, %r11
-  xor %rax, %rax
+  xor %r8d, %r8d
+  xor %r9d, %r9d
+  xor %r10d, %r10d
+  xor %r11d, %r11d
+  xor %eax, %eax
   
   ;# Begin addition chain
   addq 0(%rsi), %rdx
@@ -44,7 +44,7 @@ _fadd_e:
   cmovc %rdx, %rax
   
   ;# Step 2: Add carry*38 to the original sum
-  xor %rcx, %rcx
+  xor %ecx, %ecx
   add %rax, %r8
   adcx %rcx, %r9
   movq %r9, 8(%rdi)
@@ -149,7 +149,7 @@ _fmul_e:
   ;# Compute src1[0] * src2
   movq 0(%rsi), %rdx
   mulxq 0(%rcx), %r8, %r9
-  xor %r10, %r10
+  xor %r10d, %r10d
   movq %r8, 0(%rdi)
   
   mulxq 8(%rcx), %r10, %r11
@@ -167,7 +167,7 @@ _fmul_e:
   ;# Compute src1[1] * src2
   movq 8(%rsi), %rdx
   mulxq 0(%rcx), %r8, %r9
-  xor %r10, %r10
+  xor %r10d, %r10d
   adcxq 8(%rdi), %r8
   movq %r8, 8(%rdi)
   mulxq 8(%rcx), %r10, %r11
@@ -189,7 +189,7 @@ _fmul_e:
   ;# Compute src1[2] * src2
   movq 16(%rsi), %rdx
   mulxq 0(%rcx), %r8, %r9
-  xor %r10, %r10
+  xor %r10d, %r10d
   adcxq 16(%rdi), %r8
   movq %r8, 16(%rdi)
   mulxq 8(%rcx), %r10, %r11
@@ -211,7 +211,7 @@ _fmul_e:
   ;# Compute src1[3] * src2
   movq 24(%rsi), %rdx
   mulxq 0(%rcx), %r8, %r9
-  xor %r10, %r10
+  xor %r10d, %r10d
   adcxq 24(%rdi), %r8
   movq %r8, 24(%rdi)
   mulxq 8(%rcx), %r10, %r11
@@ -240,7 +240,7 @@ _fmul_e:
   ;# Step 1: Compute dst + carry == tmp_hi * 38 + tmp_lo
   mov $38, %rdx
   mulxq 32(%rsi), %r8, %r13
-  xor %rcx, %rcx
+  xor %ecx, %ecx
   adoxq 0(%rsi), %r8
   mulxq 40(%rsi), %r9, %rbx
   adcx %r13, %r9
@@ -286,7 +286,7 @@ _fmul2_e:
   ;# Compute src1[0] * src2
   movq 0(%rsi), %rdx
   mulxq 0(%rcx), %r8, %r9
-  xor %r10, %r10
+  xor %r10d, %r10d
   movq %r8, 0(%rdi)
   
   mulxq 8(%rcx), %r10, %r11
@@ -304,7 +304,7 @@ _fmul2_e:
   ;# Compute src1[1] * src2
   movq 8(%rsi), %rdx
   mulxq 0(%rcx), %r8, %r9
-  xor %r10, %r10
+  xor %r10d, %r10d
   adcxq 8(%rdi), %r8
   movq %r8, 8(%rdi)
   mulxq 8(%rcx), %r10, %r11
@@ -326,7 +326,7 @@ _fmul2_e:
   ;# Compute src1[2] * src2
   movq 16(%rsi), %rdx
   mulxq 0(%rcx), %r8, %r9
-  xor %r10, %r10
+  xor %r10d, %r10d
   adcxq 16(%rdi), %r8
   movq %r8, 16(%rdi)
   mulxq 8(%rcx), %r10, %r11
@@ -348,7 +348,7 @@ _fmul2_e:
   ;# Compute src1[3] * src2
   movq 24(%rsi), %rdx
   mulxq 0(%rcx), %r8, %r9
-  xor %r10, %r10
+  xor %r10d, %r10d
   adcxq 24(%rdi), %r8
   movq %r8, 24(%rdi)
   mulxq 8(%rcx), %r10, %r11
@@ -373,7 +373,7 @@ _fmul2_e:
   ;# Compute src1[0] * src2
   movq 32(%rsi), %rdx
   mulxq 32(%rcx), %r8, %r9
-  xor %r10, %r10
+  xor %r10d, %r10d
   movq %r8, 64(%rdi)
   
   mulxq 40(%rcx), %r10, %r11
@@ -391,7 +391,7 @@ _fmul2_e:
   ;# Compute src1[1] * src2
   movq 40(%rsi), %rdx
   mulxq 32(%rcx), %r8, %r9
-  xor %r10, %r10
+  xor %r10d, %r10d
   adcxq 72(%rdi), %r8
   movq %r8, 72(%rdi)
   mulxq 40(%rcx), %r10, %r11
@@ -413,7 +413,7 @@ _fmul2_e:
   ;# Compute src1[2] * src2
   movq 48(%rsi), %rdx
   mulxq 32(%rcx), %r8, %r9
-  xor %r10, %r10
+  xor %r10d, %r10d
   adcxq 80(%rdi), %r8
   movq %r8, 80(%rdi)
   mulxq 40(%rcx), %r10, %r11
@@ -435,7 +435,7 @@ _fmul2_e:
   ;# Compute src1[3] * src2
   movq 56(%rsi), %rdx
   mulxq 32(%rcx), %r8, %r9
-  xor %r10, %r10
+  xor %r10d, %r10d
   adcxq 88(%rdi), %r8
   movq %r8, 88(%rdi)
   mulxq 40(%rcx), %r10, %r11
@@ -464,7 +464,7 @@ _fmul2_e:
   ;# Step 1: Compute dst + carry == tmp_hi * 38 + tmp_lo
   mov $38, %rdx
   mulxq 32(%rsi), %r8, %r13
-  xor %rcx, %rcx
+  xor %ecx, %ecx
   adoxq 0(%rsi), %r8
   mulxq 40(%rsi), %r9, %rbx
   adcx %r13, %r9
@@ -497,7 +497,7 @@ _fmul2_e:
   ;# Step 1: Compute dst + carry == tmp_hi * 38 + tmp_lo
   mov $38, %rdx
   mulxq 96(%rsi), %r8, %r13
-  xor %rcx, %rcx
+  xor %ecx, %ecx
   adoxq 64(%rsi), %r8
   mulxq 104(%rsi), %r9, %rbx
   adcx %r13, %r9
@@ -545,7 +545,7 @@ _fsqr_e:
   movq 0(%rsi), %rdx
   ;# f[0]
   mulxq 8(%rsi), %r8, %r14
-  xor %r15, %r15
+  xor %r15d, %r15d
   ;# f[1]*f[0]
   mulxq 16(%rsi), %r9, %r10
   adcx %r14, %r9
@@ -569,7 +569,7 @@ _fsqr_e:
   ;# f[2]*f[1]
   
   ;# Step 2: Compute two parallel carry chains
-  xor %r15, %r15
+  xor %r15d, %r15d
   adox %rax, %r10
   adcx %r8, %r8
   adox %rcx, %r11
@@ -627,7 +627,7 @@ _fsqr_e:
   ;# Step 1: Compute dst + carry == tmp_hi * 38 + tmp_lo
   mov $38, %rdx
   mulxq 32(%rsi), %r8, %r13
-  xor %rcx, %rcx
+  xor %ecx, %ecx
   adoxq 0(%rsi), %r8
   mulxq 40(%rsi), %r9, %rbx
   adcx %r13, %r9
@@ -675,7 +675,7 @@ _fsqr2_e:
   movq 0(%rsi), %rdx
   ;# f[0]
   mulxq 8(%rsi), %r8, %r14
-  xor %r15, %r15
+  xor %r15d, %r15d
   ;# f[1]*f[0]
   mulxq 16(%rsi), %r9, %r10
   adcx %r14, %r9
@@ -699,7 +699,7 @@ _fsqr2_e:
   ;# f[2]*f[1]
   
   ;# Step 2: Compute two parallel carry chains
-  xor %r15, %r15
+  xor %r15d, %r15d
   adox %rax, %r10
   adcx %r8, %r8
   adox %rcx, %r11
@@ -754,7 +754,7 @@ _fsqr2_e:
   movq 32(%rsi), %rdx
   ;# f[0]
   mulxq 40(%rsi), %r8, %r14
-  xor %r15, %r15
+  xor %r15d, %r15d
   ;# f[1]*f[0]
   mulxq 48(%rsi), %r9, %r10
   adcx %r14, %r9
@@ -778,7 +778,7 @@ _fsqr2_e:
   ;# f[2]*f[1]
   
   ;# Step 2: Compute two parallel carry chains
-  xor %r15, %r15
+  xor %r15d, %r15d
   adox %rax, %r10
   adcx %r8, %r8
   adox %rcx, %r11
@@ -836,7 +836,7 @@ _fsqr2_e:
   ;# Step 1: Compute dst + carry == tmp_hi * 38 + tmp_lo
   mov $38, %rdx
   mulxq 32(%rsi), %r8, %r13
-  xor %rcx, %rcx
+  xor %ecx, %ecx
   adoxq 0(%rsi), %r8
   mulxq 40(%rsi), %r9, %rbx
   adcx %r13, %r9
@@ -869,7 +869,7 @@ _fsqr2_e:
   ;# Step 1: Compute dst + carry == tmp_hi * 38 + tmp_lo
   mov $38, %rdx
   mulxq 96(%rsi), %r8, %r13
-  xor %rcx, %rcx
+  xor %ecx, %ecx
   adoxq 64(%rsi), %r8
   mulxq 104(%rsi), %r9, %rbx
   adcx %r13, %r9

--- a/dist/mitls/curve25519-x86_64-linux.S
+++ b/dist/mitls/curve25519-x86_64-linux.S
@@ -4,11 +4,11 @@ add_scalar_e:
   push %rdi
   push %rsi
   ;# Clear registers to propagate the carry bit
-  xor %r8, %r8
-  xor %r9, %r9
-  xor %r10, %r10
-  xor %r11, %r11
-  xor %rax, %rax
+  xor %r8d, %r8d
+  xor %r9d, %r9d
+  xor %r10d, %r10d
+  xor %r11d, %r11d
+  xor %eax, %eax
   
   ;# Begin addition chain
   addq 0(%rsi), %rdx
@@ -44,7 +44,7 @@ fadd_e:
   cmovc %rdx, %rax
   
   ;# Step 2: Add carry*38 to the original sum
-  xor %rcx, %rcx
+  xor %ecx, %ecx
   add %rax, %r8
   adcx %rcx, %r9
   movq %r9, 8(%rdi)
@@ -149,7 +149,7 @@ fmul_e:
   ;# Compute src1[0] * src2
   movq 0(%rsi), %rdx
   mulxq 0(%rcx), %r8, %r9
-  xor %r10, %r10
+  xor %r10d, %r10d
   movq %r8, 0(%rdi)
   
   mulxq 8(%rcx), %r10, %r11
@@ -167,7 +167,7 @@ fmul_e:
   ;# Compute src1[1] * src2
   movq 8(%rsi), %rdx
   mulxq 0(%rcx), %r8, %r9
-  xor %r10, %r10
+  xor %r10d, %r10d
   adcxq 8(%rdi), %r8
   movq %r8, 8(%rdi)
   mulxq 8(%rcx), %r10, %r11
@@ -189,7 +189,7 @@ fmul_e:
   ;# Compute src1[2] * src2
   movq 16(%rsi), %rdx
   mulxq 0(%rcx), %r8, %r9
-  xor %r10, %r10
+  xor %r10d, %r10d
   adcxq 16(%rdi), %r8
   movq %r8, 16(%rdi)
   mulxq 8(%rcx), %r10, %r11
@@ -211,7 +211,7 @@ fmul_e:
   ;# Compute src1[3] * src2
   movq 24(%rsi), %rdx
   mulxq 0(%rcx), %r8, %r9
-  xor %r10, %r10
+  xor %r10d, %r10d
   adcxq 24(%rdi), %r8
   movq %r8, 24(%rdi)
   mulxq 8(%rcx), %r10, %r11
@@ -240,7 +240,7 @@ fmul_e:
   ;# Step 1: Compute dst + carry == tmp_hi * 38 + tmp_lo
   mov $38, %rdx
   mulxq 32(%rsi), %r8, %r13
-  xor %rcx, %rcx
+  xor %ecx, %ecx
   adoxq 0(%rsi), %r8
   mulxq 40(%rsi), %r9, %rbx
   adcx %r13, %r9
@@ -286,7 +286,7 @@ fmul2_e:
   ;# Compute src1[0] * src2
   movq 0(%rsi), %rdx
   mulxq 0(%rcx), %r8, %r9
-  xor %r10, %r10
+  xor %r10d, %r10d
   movq %r8, 0(%rdi)
   
   mulxq 8(%rcx), %r10, %r11
@@ -304,7 +304,7 @@ fmul2_e:
   ;# Compute src1[1] * src2
   movq 8(%rsi), %rdx
   mulxq 0(%rcx), %r8, %r9
-  xor %r10, %r10
+  xor %r10d, %r10d
   adcxq 8(%rdi), %r8
   movq %r8, 8(%rdi)
   mulxq 8(%rcx), %r10, %r11
@@ -326,7 +326,7 @@ fmul2_e:
   ;# Compute src1[2] * src2
   movq 16(%rsi), %rdx
   mulxq 0(%rcx), %r8, %r9
-  xor %r10, %r10
+  xor %r10d, %r10d
   adcxq 16(%rdi), %r8
   movq %r8, 16(%rdi)
   mulxq 8(%rcx), %r10, %r11
@@ -348,7 +348,7 @@ fmul2_e:
   ;# Compute src1[3] * src2
   movq 24(%rsi), %rdx
   mulxq 0(%rcx), %r8, %r9
-  xor %r10, %r10
+  xor %r10d, %r10d
   adcxq 24(%rdi), %r8
   movq %r8, 24(%rdi)
   mulxq 8(%rcx), %r10, %r11
@@ -373,7 +373,7 @@ fmul2_e:
   ;# Compute src1[0] * src2
   movq 32(%rsi), %rdx
   mulxq 32(%rcx), %r8, %r9
-  xor %r10, %r10
+  xor %r10d, %r10d
   movq %r8, 64(%rdi)
   
   mulxq 40(%rcx), %r10, %r11
@@ -391,7 +391,7 @@ fmul2_e:
   ;# Compute src1[1] * src2
   movq 40(%rsi), %rdx
   mulxq 32(%rcx), %r8, %r9
-  xor %r10, %r10
+  xor %r10d, %r10d
   adcxq 72(%rdi), %r8
   movq %r8, 72(%rdi)
   mulxq 40(%rcx), %r10, %r11
@@ -413,7 +413,7 @@ fmul2_e:
   ;# Compute src1[2] * src2
   movq 48(%rsi), %rdx
   mulxq 32(%rcx), %r8, %r9
-  xor %r10, %r10
+  xor %r10d, %r10d
   adcxq 80(%rdi), %r8
   movq %r8, 80(%rdi)
   mulxq 40(%rcx), %r10, %r11
@@ -435,7 +435,7 @@ fmul2_e:
   ;# Compute src1[3] * src2
   movq 56(%rsi), %rdx
   mulxq 32(%rcx), %r8, %r9
-  xor %r10, %r10
+  xor %r10d, %r10d
   adcxq 88(%rdi), %r8
   movq %r8, 88(%rdi)
   mulxq 40(%rcx), %r10, %r11
@@ -464,7 +464,7 @@ fmul2_e:
   ;# Step 1: Compute dst + carry == tmp_hi * 38 + tmp_lo
   mov $38, %rdx
   mulxq 32(%rsi), %r8, %r13
-  xor %rcx, %rcx
+  xor %ecx, %ecx
   adoxq 0(%rsi), %r8
   mulxq 40(%rsi), %r9, %rbx
   adcx %r13, %r9
@@ -497,7 +497,7 @@ fmul2_e:
   ;# Step 1: Compute dst + carry == tmp_hi * 38 + tmp_lo
   mov $38, %rdx
   mulxq 96(%rsi), %r8, %r13
-  xor %rcx, %rcx
+  xor %ecx, %ecx
   adoxq 64(%rsi), %r8
   mulxq 104(%rsi), %r9, %rbx
   adcx %r13, %r9
@@ -545,7 +545,7 @@ fsqr_e:
   movq 0(%rsi), %rdx
   ;# f[0]
   mulxq 8(%rsi), %r8, %r14
-  xor %r15, %r15
+  xor %r15d, %r15d
   ;# f[1]*f[0]
   mulxq 16(%rsi), %r9, %r10
   adcx %r14, %r9
@@ -569,7 +569,7 @@ fsqr_e:
   ;# f[2]*f[1]
   
   ;# Step 2: Compute two parallel carry chains
-  xor %r15, %r15
+  xor %r15d, %r15d
   adox %rax, %r10
   adcx %r8, %r8
   adox %rcx, %r11
@@ -627,7 +627,7 @@ fsqr_e:
   ;# Step 1: Compute dst + carry == tmp_hi * 38 + tmp_lo
   mov $38, %rdx
   mulxq 32(%rsi), %r8, %r13
-  xor %rcx, %rcx
+  xor %ecx, %ecx
   adoxq 0(%rsi), %r8
   mulxq 40(%rsi), %r9, %rbx
   adcx %r13, %r9
@@ -675,7 +675,7 @@ fsqr2_e:
   movq 0(%rsi), %rdx
   ;# f[0]
   mulxq 8(%rsi), %r8, %r14
-  xor %r15, %r15
+  xor %r15d, %r15d
   ;# f[1]*f[0]
   mulxq 16(%rsi), %r9, %r10
   adcx %r14, %r9
@@ -699,7 +699,7 @@ fsqr2_e:
   ;# f[2]*f[1]
   
   ;# Step 2: Compute two parallel carry chains
-  xor %r15, %r15
+  xor %r15d, %r15d
   adox %rax, %r10
   adcx %r8, %r8
   adox %rcx, %r11
@@ -754,7 +754,7 @@ fsqr2_e:
   movq 32(%rsi), %rdx
   ;# f[0]
   mulxq 40(%rsi), %r8, %r14
-  xor %r15, %r15
+  xor %r15d, %r15d
   ;# f[1]*f[0]
   mulxq 48(%rsi), %r9, %r10
   adcx %r14, %r9
@@ -778,7 +778,7 @@ fsqr2_e:
   ;# f[2]*f[1]
   
   ;# Step 2: Compute two parallel carry chains
-  xor %r15, %r15
+  xor %r15d, %r15d
   adox %rax, %r10
   adcx %r8, %r8
   adox %rcx, %r11
@@ -836,7 +836,7 @@ fsqr2_e:
   ;# Step 1: Compute dst + carry == tmp_hi * 38 + tmp_lo
   mov $38, %rdx
   mulxq 32(%rsi), %r8, %r13
-  xor %rcx, %rcx
+  xor %ecx, %ecx
   adoxq 0(%rsi), %r8
   mulxq 40(%rsi), %r9, %rbx
   adcx %r13, %r9
@@ -869,7 +869,7 @@ fsqr2_e:
   ;# Step 1: Compute dst + carry == tmp_hi * 38 + tmp_lo
   mov $38, %rdx
   mulxq 96(%rsi), %r8, %r13
-  xor %rcx, %rcx
+  xor %ecx, %ecx
   adoxq 64(%rsi), %r8
   mulxq 104(%rsi), %r9, %rbx
   adcx %r13, %r9

--- a/dist/mitls/curve25519-x86_64-mingw.S
+++ b/dist/mitls/curve25519-x86_64-mingw.S
@@ -7,11 +7,11 @@ add_scalar_e:
   mov %rdx, %rsi
   mov %r8, %rdx
   ;# Clear registers to propagate the carry bit
-  xor %r8, %r8
-  xor %r9, %r9
-  xor %r10, %r10
-  xor %r11, %r11
-  xor %rax, %rax
+  xor %r8d, %r8d
+  xor %r9d, %r9d
+  xor %r10d, %r10d
+  xor %r11d, %r11d
+  xor %eax, %eax
   
   ;# Begin addition chain
   addq 0(%rsi), %rdx
@@ -52,7 +52,7 @@ fadd_e:
   cmovc %rdx, %rax
   
   ;# Step 2: Add carry*38 to the original sum
-  xor %rcx, %rcx
+  xor %ecx, %ecx
   add %rax, %r8
   adcx %rcx, %r9
   movq %r9, 8(%rdi)
@@ -176,7 +176,7 @@ fmul_e:
   ;# Compute src1[0] * src2
   movq 0(%rsi), %rdx
   mulxq 0(%rcx), %r8, %r9
-  xor %r10, %r10
+  xor %r10d, %r10d
   movq %r8, 0(%rdi)
   
   mulxq 8(%rcx), %r10, %r11
@@ -194,7 +194,7 @@ fmul_e:
   ;# Compute src1[1] * src2
   movq 8(%rsi), %rdx
   mulxq 0(%rcx), %r8, %r9
-  xor %r10, %r10
+  xor %r10d, %r10d
   adcxq 8(%rdi), %r8
   movq %r8, 8(%rdi)
   mulxq 8(%rcx), %r10, %r11
@@ -216,7 +216,7 @@ fmul_e:
   ;# Compute src1[2] * src2
   movq 16(%rsi), %rdx
   mulxq 0(%rcx), %r8, %r9
-  xor %r10, %r10
+  xor %r10d, %r10d
   adcxq 16(%rdi), %r8
   movq %r8, 16(%rdi)
   mulxq 8(%rcx), %r10, %r11
@@ -238,7 +238,7 @@ fmul_e:
   ;# Compute src1[3] * src2
   movq 24(%rsi), %rdx
   mulxq 0(%rcx), %r8, %r9
-  xor %r10, %r10
+  xor %r10d, %r10d
   adcxq 24(%rdi), %r8
   movq %r8, 24(%rdi)
   mulxq 8(%rcx), %r10, %r11
@@ -267,7 +267,7 @@ fmul_e:
   ;# Step 1: Compute dst + carry == tmp_hi * 38 + tmp_lo
   mov $38, %rdx
   mulxq 32(%rsi), %r8, %r13
-  xor %rcx, %rcx
+  xor %ecx, %ecx
   adoxq 0(%rsi), %r8
   mulxq 40(%rsi), %r9, %rbx
   adcx %r13, %r9
@@ -320,7 +320,7 @@ fmul2_e:
   ;# Compute src1[0] * src2
   movq 0(%rsi), %rdx
   mulxq 0(%rcx), %r8, %r9
-  xor %r10, %r10
+  xor %r10d, %r10d
   movq %r8, 0(%rdi)
   
   mulxq 8(%rcx), %r10, %r11
@@ -338,7 +338,7 @@ fmul2_e:
   ;# Compute src1[1] * src2
   movq 8(%rsi), %rdx
   mulxq 0(%rcx), %r8, %r9
-  xor %r10, %r10
+  xor %r10d, %r10d
   adcxq 8(%rdi), %r8
   movq %r8, 8(%rdi)
   mulxq 8(%rcx), %r10, %r11
@@ -360,7 +360,7 @@ fmul2_e:
   ;# Compute src1[2] * src2
   movq 16(%rsi), %rdx
   mulxq 0(%rcx), %r8, %r9
-  xor %r10, %r10
+  xor %r10d, %r10d
   adcxq 16(%rdi), %r8
   movq %r8, 16(%rdi)
   mulxq 8(%rcx), %r10, %r11
@@ -382,7 +382,7 @@ fmul2_e:
   ;# Compute src1[3] * src2
   movq 24(%rsi), %rdx
   mulxq 0(%rcx), %r8, %r9
-  xor %r10, %r10
+  xor %r10d, %r10d
   adcxq 24(%rdi), %r8
   movq %r8, 24(%rdi)
   mulxq 8(%rcx), %r10, %r11
@@ -407,7 +407,7 @@ fmul2_e:
   ;# Compute src1[0] * src2
   movq 32(%rsi), %rdx
   mulxq 32(%rcx), %r8, %r9
-  xor %r10, %r10
+  xor %r10d, %r10d
   movq %r8, 64(%rdi)
   
   mulxq 40(%rcx), %r10, %r11
@@ -425,7 +425,7 @@ fmul2_e:
   ;# Compute src1[1] * src2
   movq 40(%rsi), %rdx
   mulxq 32(%rcx), %r8, %r9
-  xor %r10, %r10
+  xor %r10d, %r10d
   adcxq 72(%rdi), %r8
   movq %r8, 72(%rdi)
   mulxq 40(%rcx), %r10, %r11
@@ -447,7 +447,7 @@ fmul2_e:
   ;# Compute src1[2] * src2
   movq 48(%rsi), %rdx
   mulxq 32(%rcx), %r8, %r9
-  xor %r10, %r10
+  xor %r10d, %r10d
   adcxq 80(%rdi), %r8
   movq %r8, 80(%rdi)
   mulxq 40(%rcx), %r10, %r11
@@ -469,7 +469,7 @@ fmul2_e:
   ;# Compute src1[3] * src2
   movq 56(%rsi), %rdx
   mulxq 32(%rcx), %r8, %r9
-  xor %r10, %r10
+  xor %r10d, %r10d
   adcxq 88(%rdi), %r8
   movq %r8, 88(%rdi)
   mulxq 40(%rcx), %r10, %r11
@@ -498,7 +498,7 @@ fmul2_e:
   ;# Step 1: Compute dst + carry == tmp_hi * 38 + tmp_lo
   mov $38, %rdx
   mulxq 32(%rsi), %r8, %r13
-  xor %rcx, %rcx
+  xor %ecx, %ecx
   adoxq 0(%rsi), %r8
   mulxq 40(%rsi), %r9, %rbx
   adcx %r13, %r9
@@ -531,7 +531,7 @@ fmul2_e:
   ;# Step 1: Compute dst + carry == tmp_hi * 38 + tmp_lo
   mov $38, %rdx
   mulxq 96(%rsi), %r8, %r13
-  xor %rcx, %rcx
+  xor %ecx, %ecx
   adoxq 64(%rsi), %r8
   mulxq 104(%rsi), %r9, %rbx
   adcx %r13, %r9
@@ -585,7 +585,7 @@ fsqr_e:
   movq 0(%rsi), %rdx
   ;# f[0]
   mulxq 8(%rsi), %r8, %r14
-  xor %r15, %r15
+  xor %r15d, %r15d
   ;# f[1]*f[0]
   mulxq 16(%rsi), %r9, %r10
   adcx %r14, %r9
@@ -609,7 +609,7 @@ fsqr_e:
   ;# f[2]*f[1]
   
   ;# Step 2: Compute two parallel carry chains
-  xor %r15, %r15
+  xor %r15d, %r15d
   adox %rax, %r10
   adcx %r8, %r8
   adox %rcx, %r11
@@ -667,7 +667,7 @@ fsqr_e:
   ;# Step 1: Compute dst + carry == tmp_hi * 38 + tmp_lo
   mov $38, %rdx
   mulxq 32(%rsi), %r8, %r13
-  xor %rcx, %rcx
+  xor %ecx, %ecx
   adoxq 0(%rsi), %r8
   mulxq 40(%rsi), %r9, %rbx
   adcx %r13, %r9
@@ -721,7 +721,7 @@ fsqr2_e:
   movq 0(%rsi), %rdx
   ;# f[0]
   mulxq 8(%rsi), %r8, %r14
-  xor %r15, %r15
+  xor %r15d, %r15d
   ;# f[1]*f[0]
   mulxq 16(%rsi), %r9, %r10
   adcx %r14, %r9
@@ -745,7 +745,7 @@ fsqr2_e:
   ;# f[2]*f[1]
   
   ;# Step 2: Compute two parallel carry chains
-  xor %r15, %r15
+  xor %r15d, %r15d
   adox %rax, %r10
   adcx %r8, %r8
   adox %rcx, %r11
@@ -800,7 +800,7 @@ fsqr2_e:
   movq 32(%rsi), %rdx
   ;# f[0]
   mulxq 40(%rsi), %r8, %r14
-  xor %r15, %r15
+  xor %r15d, %r15d
   ;# f[1]*f[0]
   mulxq 48(%rsi), %r9, %r10
   adcx %r14, %r9
@@ -824,7 +824,7 @@ fsqr2_e:
   ;# f[2]*f[1]
   
   ;# Step 2: Compute two parallel carry chains
-  xor %r15, %r15
+  xor %r15d, %r15d
   adox %rax, %r10
   adcx %r8, %r8
   adox %rcx, %r11
@@ -882,7 +882,7 @@ fsqr2_e:
   ;# Step 1: Compute dst + carry == tmp_hi * 38 + tmp_lo
   mov $38, %rdx
   mulxq 32(%rsi), %r8, %r13
-  xor %rcx, %rcx
+  xor %ecx, %ecx
   adoxq 0(%rsi), %r8
   mulxq 40(%rsi), %r9, %rbx
   adcx %r13, %r9
@@ -915,7 +915,7 @@ fsqr2_e:
   ;# Step 1: Compute dst + carry == tmp_hi * 38 + tmp_lo
   mov $38, %rdx
   mulxq 96(%rsi), %r8, %r13
-  xor %rcx, %rcx
+  xor %ecx, %ecx
   adoxq 64(%rsi), %r8
   mulxq 104(%rsi), %r9, %rbx
   adcx %r13, %r9

--- a/dist/mitls/curve25519-x86_64-msvc.asm
+++ b/dist/mitls/curve25519-x86_64-msvc.asm
@@ -7,11 +7,11 @@ add_scalar_e proc
   mov rsi, rdx
   mov rdx, r8
   ;# Clear registers to propagate the carry bit
-  xor r8, r8
-  xor r9, r9
-  xor r10, r10
-  xor r11, r11
-  xor rax, rax
+  xor r8d, r8d
+  xor r9d, r9d
+  xor r10d, r10d
+  xor r11d, r11d
+  xor eax, eax
   
   ;# Begin addition chain
   add rdx, qword ptr [rsi + 0]
@@ -52,7 +52,7 @@ fadd_e proc
   cmovc rax, rdx
   
   ;# Step 2: Add carry*38 to the original sum
-  xor rcx, rcx
+  xor ecx, ecx
   add r8, rax
   adcx r9, rcx
   mov qword ptr [rdi + 8], r9
@@ -176,7 +176,7 @@ fmul_e proc
   ;# Compute src1[0] * src2
   mov rdx, qword ptr [rsi + 0]
   mulx r9, r8, qword ptr [rcx + 0]
-  xor r10, r10
+  xor r10d, r10d
   mov qword ptr [rdi + 0], r8
   
   mulx r11, r10, qword ptr [rcx + 8]
@@ -194,7 +194,7 @@ fmul_e proc
   ;# Compute src1[1] * src2
   mov rdx, qword ptr [rsi + 8]
   mulx r9, r8, qword ptr [rcx + 0]
-  xor r10, r10
+  xor r10d, r10d
   adcx r8, qword ptr [rdi + 8]
   mov qword ptr [rdi + 8], r8
   mulx r11, r10, qword ptr [rcx + 8]
@@ -216,7 +216,7 @@ fmul_e proc
   ;# Compute src1[2] * src2
   mov rdx, qword ptr [rsi + 16]
   mulx r9, r8, qword ptr [rcx + 0]
-  xor r10, r10
+  xor r10d, r10d
   adcx r8, qword ptr [rdi + 16]
   mov qword ptr [rdi + 16], r8
   mulx r11, r10, qword ptr [rcx + 8]
@@ -238,7 +238,7 @@ fmul_e proc
   ;# Compute src1[3] * src2
   mov rdx, qword ptr [rsi + 24]
   mulx r9, r8, qword ptr [rcx + 0]
-  xor r10, r10
+  xor r10d, r10d
   adcx r8, qword ptr [rdi + 24]
   mov qword ptr [rdi + 24], r8
   mulx r11, r10, qword ptr [rcx + 8]
@@ -267,7 +267,7 @@ fmul_e proc
   ;# Step 1: Compute dst + carry == tmp_hi * 38 + tmp_lo
   mov rdx, 38
   mulx r13, r8, qword ptr [rsi + 32]
-  xor rcx, rcx
+  xor ecx, ecx
   adox r8, qword ptr [rsi + 0]
   mulx rbx, r9, qword ptr [rsi + 40]
   adcx r9, r13
@@ -320,7 +320,7 @@ fmul2_e proc
   ;# Compute src1[0] * src2
   mov rdx, qword ptr [rsi + 0]
   mulx r9, r8, qword ptr [rcx + 0]
-  xor r10, r10
+  xor r10d, r10d
   mov qword ptr [rdi + 0], r8
   
   mulx r11, r10, qword ptr [rcx + 8]
@@ -338,7 +338,7 @@ fmul2_e proc
   ;# Compute src1[1] * src2
   mov rdx, qword ptr [rsi + 8]
   mulx r9, r8, qword ptr [rcx + 0]
-  xor r10, r10
+  xor r10d, r10d
   adcx r8, qword ptr [rdi + 8]
   mov qword ptr [rdi + 8], r8
   mulx r11, r10, qword ptr [rcx + 8]
@@ -360,7 +360,7 @@ fmul2_e proc
   ;# Compute src1[2] * src2
   mov rdx, qword ptr [rsi + 16]
   mulx r9, r8, qword ptr [rcx + 0]
-  xor r10, r10
+  xor r10d, r10d
   adcx r8, qword ptr [rdi + 16]
   mov qword ptr [rdi + 16], r8
   mulx r11, r10, qword ptr [rcx + 8]
@@ -382,7 +382,7 @@ fmul2_e proc
   ;# Compute src1[3] * src2
   mov rdx, qword ptr [rsi + 24]
   mulx r9, r8, qword ptr [rcx + 0]
-  xor r10, r10
+  xor r10d, r10d
   adcx r8, qword ptr [rdi + 24]
   mov qword ptr [rdi + 24], r8
   mulx r11, r10, qword ptr [rcx + 8]
@@ -407,7 +407,7 @@ fmul2_e proc
   ;# Compute src1[0] * src2
   mov rdx, qword ptr [rsi + 32]
   mulx r9, r8, qword ptr [rcx + 32]
-  xor r10, r10
+  xor r10d, r10d
   mov qword ptr [rdi + 64], r8
   
   mulx r11, r10, qword ptr [rcx + 40]
@@ -425,7 +425,7 @@ fmul2_e proc
   ;# Compute src1[1] * src2
   mov rdx, qword ptr [rsi + 40]
   mulx r9, r8, qword ptr [rcx + 32]
-  xor r10, r10
+  xor r10d, r10d
   adcx r8, qword ptr [rdi + 72]
   mov qword ptr [rdi + 72], r8
   mulx r11, r10, qword ptr [rcx + 40]
@@ -447,7 +447,7 @@ fmul2_e proc
   ;# Compute src1[2] * src2
   mov rdx, qword ptr [rsi + 48]
   mulx r9, r8, qword ptr [rcx + 32]
-  xor r10, r10
+  xor r10d, r10d
   adcx r8, qword ptr [rdi + 80]
   mov qword ptr [rdi + 80], r8
   mulx r11, r10, qword ptr [rcx + 40]
@@ -469,7 +469,7 @@ fmul2_e proc
   ;# Compute src1[3] * src2
   mov rdx, qword ptr [rsi + 56]
   mulx r9, r8, qword ptr [rcx + 32]
-  xor r10, r10
+  xor r10d, r10d
   adcx r8, qword ptr [rdi + 88]
   mov qword ptr [rdi + 88], r8
   mulx r11, r10, qword ptr [rcx + 40]
@@ -498,7 +498,7 @@ fmul2_e proc
   ;# Step 1: Compute dst + carry == tmp_hi * 38 + tmp_lo
   mov rdx, 38
   mulx r13, r8, qword ptr [rsi + 32]
-  xor rcx, rcx
+  xor ecx, ecx
   adox r8, qword ptr [rsi + 0]
   mulx rbx, r9, qword ptr [rsi + 40]
   adcx r9, r13
@@ -531,7 +531,7 @@ fmul2_e proc
   ;# Step 1: Compute dst + carry == tmp_hi * 38 + tmp_lo
   mov rdx, 38
   mulx r13, r8, qword ptr [rsi + 96]
-  xor rcx, rcx
+  xor ecx, ecx
   adox r8, qword ptr [rsi + 64]
   mulx rbx, r9, qword ptr [rsi + 104]
   adcx r9, r13
@@ -585,7 +585,7 @@ fsqr_e proc
   mov rdx, qword ptr [rsi + 0]
   ;# f[0]
   mulx r14, r8, qword ptr [rsi + 8]
-  xor r15, r15
+  xor r15d, r15d
   ;# f[1]*f[0]
   mulx r10, r9, qword ptr [rsi + 16]
   adcx r9, r14
@@ -609,7 +609,7 @@ fsqr_e proc
   ;# f[2]*f[1]
   
   ;# Step 2: Compute two parallel carry chains
-  xor r15, r15
+  xor r15d, r15d
   adox r10, rax
   adcx r8, r8
   adox r11, rcx
@@ -667,7 +667,7 @@ fsqr_e proc
   ;# Step 1: Compute dst + carry == tmp_hi * 38 + tmp_lo
   mov rdx, 38
   mulx r13, r8, qword ptr [rsi + 32]
-  xor rcx, rcx
+  xor ecx, ecx
   adox r8, qword ptr [rsi + 0]
   mulx rbx, r9, qword ptr [rsi + 40]
   adcx r9, r13
@@ -721,7 +721,7 @@ fsqr2_e proc
   mov rdx, qword ptr [rsi + 0]
   ;# f[0]
   mulx r14, r8, qword ptr [rsi + 8]
-  xor r15, r15
+  xor r15d, r15d
   ;# f[1]*f[0]
   mulx r10, r9, qword ptr [rsi + 16]
   adcx r9, r14
@@ -745,7 +745,7 @@ fsqr2_e proc
   ;# f[2]*f[1]
   
   ;# Step 2: Compute two parallel carry chains
-  xor r15, r15
+  xor r15d, r15d
   adox r10, rax
   adcx r8, r8
   adox r11, rcx
@@ -800,7 +800,7 @@ fsqr2_e proc
   mov rdx, qword ptr [rsi + 32]
   ;# f[0]
   mulx r14, r8, qword ptr [rsi + 40]
-  xor r15, r15
+  xor r15d, r15d
   ;# f[1]*f[0]
   mulx r10, r9, qword ptr [rsi + 48]
   adcx r9, r14
@@ -824,7 +824,7 @@ fsqr2_e proc
   ;# f[2]*f[1]
   
   ;# Step 2: Compute two parallel carry chains
-  xor r15, r15
+  xor r15d, r15d
   adox r10, rax
   adcx r8, r8
   adox r11, rcx
@@ -882,7 +882,7 @@ fsqr2_e proc
   ;# Step 1: Compute dst + carry == tmp_hi * 38 + tmp_lo
   mov rdx, 38
   mulx r13, r8, qword ptr [rsi + 32]
-  xor rcx, rcx
+  xor ecx, ecx
   adox r8, qword ptr [rsi + 0]
   mulx rbx, r9, qword ptr [rsi + 40]
   adcx r9, r13
@@ -915,7 +915,7 @@ fsqr2_e proc
   ;# Step 1: Compute dst + carry == tmp_hi * 38 + tmp_lo
   mov rdx, 38
   mulx r13, r8, qword ptr [rsi + 96]
-  xor rcx, rcx
+  xor ecx, ecx
   adox r8, qword ptr [rsi + 64]
   mulx rbx, r9, qword ptr [rsi + 104]
   adcx r9, r13

--- a/dist/mozilla/curve25519-inline.h
+++ b/dist/mozilla/curve25519-inline.h
@@ -10,11 +10,11 @@ static inline uint64_t add_scalar (uint64_t *out, uint64_t *f1, uint64_t f2)
 
   asm volatile(
     // Clear registers to propagate the carry bit
-    "  xor %%r8, %%r8;"
-    "  xor %%r9, %%r9;"
-    "  xor %%r10, %%r10;"
-    "  xor %%r11, %%r11;"
-    "  xor %1, %1;"
+    "  xor %%r8d, %%r8d;"
+    "  xor %%r9d, %%r9d;"
+    "  xor %%r10d, %%r10d;"
+    "  xor %%r11d, %%r11d;"
+    "  xor %k1, %k1;"
 
     // Begin addition chain
     "  addq 0(%3), %0;"
@@ -58,7 +58,7 @@ static inline void fadd (uint64_t *out, uint64_t *f1, uint64_t *f2)
     "  cmovc %0, %%rax;"
 
     // Step 2: Add carry*38 to the original sum
-    "  xor %%rcx, %%rcx;"
+    "  xor %%ecx, %%ecx;"
     "  add %%rax, %%r8;"
     "  adcx %%rcx, %%r9;"
     "  movq %%r9, 8(%1);"
@@ -131,7 +131,7 @@ static inline void fmul (uint64_t *out, uint64_t *f1, uint64_t *f2, uint64_t *tm
 
     // Compute src1[0] * src2
     "  movq 0(%1), %%rdx;"
-    "  mulxq 0(%2), %%r8, %%r9;"       "  xor %%r10, %%r10;"     "  movq %%r8, 0(%3);"
+    "  mulxq 0(%2), %%r8, %%r9;"       "  xor %%r10d, %%r10d;"     "  movq %%r8, 0(%3);"
     "  mulxq 8(%2), %%r10, %%r11;"     "  adox %%r9, %%r10;"     "  movq %%r10, 8(%3);"
     "  mulxq 16(%2), %%rbx, %%r13;"    "  adox %%r11, %%rbx;"
     "  mulxq 24(%2), %%r14, %%rdx;"    "  adox %%r13, %%r14;"    "  mov $0, %%rax;"
@@ -139,7 +139,7 @@ static inline void fmul (uint64_t *out, uint64_t *f1, uint64_t *f2, uint64_t *tm
 
     // Compute src1[1] * src2
     "  movq 8(%1), %%rdx;"
-    "  mulxq 0(%2), %%r8, %%r9;"       "  xor %%r10, %%r10;"     "  adcxq 8(%3), %%r8;"    "  movq %%r8, 8(%3);"
+    "  mulxq 0(%2), %%r8, %%r9;"       "  xor %%r10d, %%r10d;"     "  adcxq 8(%3), %%r8;"    "  movq %%r8, 8(%3);"
     "  mulxq 8(%2), %%r10, %%r11;"     "  adox %%r9, %%r10;"     "  adcx %%rbx, %%r10;"    "  movq %%r10, 16(%3);"
     "  mulxq 16(%2), %%rbx, %%r13;"    "  adox %%r11, %%rbx;"    "  adcx %%r14, %%rbx;"    "  mov $0, %%r8;"
     "  mulxq 24(%2), %%r14, %%rdx;"    "  adox %%r13, %%r14;"    "  adcx %%rax, %%r14;"    "  mov $0, %%rax;"
@@ -148,7 +148,7 @@ static inline void fmul (uint64_t *out, uint64_t *f1, uint64_t *f2, uint64_t *tm
 
     // Compute src1[2] * src2
     "  movq 16(%1), %%rdx;"
-    "  mulxq 0(%2), %%r8, %%r9;"       "  xor %%r10, %%r10;"    "  adcxq 16(%3), %%r8;"    "  movq %%r8, 16(%3);"
+    "  mulxq 0(%2), %%r8, %%r9;"       "  xor %%r10d, %%r10d;"    "  adcxq 16(%3), %%r8;"    "  movq %%r8, 16(%3);"
     "  mulxq 8(%2), %%r10, %%r11;"     "  adox %%r9, %%r10;"     "  adcx %%rbx, %%r10;"    "  movq %%r10, 24(%3);"
     "  mulxq 16(%2), %%rbx, %%r13;"    "  adox %%r11, %%rbx;"    "  adcx %%r14, %%rbx;"    "  mov $0, %%r8;"
     "  mulxq 24(%2), %%r14, %%rdx;"    "  adox %%r13, %%r14;"    "  adcx %%rax, %%r14;"    "  mov $0, %%rax;"
@@ -157,7 +157,7 @@ static inline void fmul (uint64_t *out, uint64_t *f1, uint64_t *f2, uint64_t *tm
 
     // Compute src1[3] * src2
     "  movq 24(%1), %%rdx;"
-    "  mulxq 0(%2), %%r8, %%r9;"       "  xor %%r10, %%r10;"    "  adcxq 24(%3), %%r8;"    "  movq %%r8, 24(%3);"
+    "  mulxq 0(%2), %%r8, %%r9;"       "  xor %%r10d, %%r10d;"    "  adcxq 24(%3), %%r8;"    "  movq %%r8, 24(%3);"
     "  mulxq 8(%2), %%r10, %%r11;"     "  adox %%r9, %%r10;"     "  adcx %%rbx, %%r10;"    "  movq %%r10, 32(%3);"
     "  mulxq 16(%2), %%rbx, %%r13;"    "  adox %%r11, %%rbx;"    "  adcx %%r14, %%rbx;"    "  movq %%rbx, 40(%3);"    "  mov $0, %%r8;"
     "  mulxq 24(%2), %%r14, %%rdx;"    "  adox %%r13, %%r14;"    "  adcx %%rax, %%r14;"    "  movq %%r14, 48(%3);"    "  mov $0, %%rax;"
@@ -172,7 +172,7 @@ static inline void fmul (uint64_t *out, uint64_t *f1, uint64_t *f2, uint64_t *tm
     // Step 1: Compute dst + carry == tmp_hi * 38 + tmp_lo
     "  mov $38, %%rdx;"
     "  mulxq 32(%1), %%r8, %%r13;"
-    "  xor %2, %2;"
+    "  xor %k2, %k2;"
     "  adoxq 0(%1), %%r8;"
     "  mulxq 40(%1), %%r9, %%rbx;"
     "  adcx %%r13, %%r9;"
@@ -219,7 +219,7 @@ static inline void fmul2 (uint64_t *out, uint64_t *f1, uint64_t *f2, uint64_t *t
 
     // Compute src1[0] * src2
     "  movq 0(%1), %%rdx;"
-    "  mulxq 0(%2), %%r8, %%r9;"       "  xor %%r10, %%r10;"     "  movq %%r8, 0(%3);"
+    "  mulxq 0(%2), %%r8, %%r9;"       "  xor %%r10d, %%r10d;"     "  movq %%r8, 0(%3);"
     "  mulxq 8(%2), %%r10, %%r11;"     "  adox %%r9, %%r10;"     "  movq %%r10, 8(%3);"
     "  mulxq 16(%2), %%rbx, %%r13;"    "  adox %%r11, %%rbx;"
     "  mulxq 24(%2), %%r14, %%rdx;"    "  adox %%r13, %%r14;"    "  mov $0, %%rax;"
@@ -227,7 +227,7 @@ static inline void fmul2 (uint64_t *out, uint64_t *f1, uint64_t *f2, uint64_t *t
 
     // Compute src1[1] * src2
     "  movq 8(%1), %%rdx;"
-    "  mulxq 0(%2), %%r8, %%r9;"       "  xor %%r10, %%r10;"     "  adcxq 8(%3), %%r8;"    "  movq %%r8, 8(%3);"
+    "  mulxq 0(%2), %%r8, %%r9;"       "  xor %%r10d, %%r10d;"     "  adcxq 8(%3), %%r8;"    "  movq %%r8, 8(%3);"
     "  mulxq 8(%2), %%r10, %%r11;"     "  adox %%r9, %%r10;"     "  adcx %%rbx, %%r10;"    "  movq %%r10, 16(%3);"
     "  mulxq 16(%2), %%rbx, %%r13;"    "  adox %%r11, %%rbx;"    "  adcx %%r14, %%rbx;"    "  mov $0, %%r8;"
     "  mulxq 24(%2), %%r14, %%rdx;"    "  adox %%r13, %%r14;"    "  adcx %%rax, %%r14;"    "  mov $0, %%rax;"
@@ -236,7 +236,7 @@ static inline void fmul2 (uint64_t *out, uint64_t *f1, uint64_t *f2, uint64_t *t
 
     // Compute src1[2] * src2
     "  movq 16(%1), %%rdx;"
-    "  mulxq 0(%2), %%r8, %%r9;"       "  xor %%r10, %%r10;"    "  adcxq 16(%3), %%r8;"    "  movq %%r8, 16(%3);"
+    "  mulxq 0(%2), %%r8, %%r9;"       "  xor %%r10d, %%r10d;"    "  adcxq 16(%3), %%r8;"    "  movq %%r8, 16(%3);"
     "  mulxq 8(%2), %%r10, %%r11;"     "  adox %%r9, %%r10;"     "  adcx %%rbx, %%r10;"    "  movq %%r10, 24(%3);"
     "  mulxq 16(%2), %%rbx, %%r13;"    "  adox %%r11, %%rbx;"    "  adcx %%r14, %%rbx;"    "  mov $0, %%r8;"
     "  mulxq 24(%2), %%r14, %%rdx;"    "  adox %%r13, %%r14;"    "  adcx %%rax, %%r14;"    "  mov $0, %%rax;"
@@ -245,7 +245,7 @@ static inline void fmul2 (uint64_t *out, uint64_t *f1, uint64_t *f2, uint64_t *t
 
     // Compute src1[3] * src2
     "  movq 24(%1), %%rdx;"
-    "  mulxq 0(%2), %%r8, %%r9;"       "  xor %%r10, %%r10;"    "  adcxq 24(%3), %%r8;"    "  movq %%r8, 24(%3);"
+    "  mulxq 0(%2), %%r8, %%r9;"       "  xor %%r10d, %%r10d;"    "  adcxq 24(%3), %%r8;"    "  movq %%r8, 24(%3);"
     "  mulxq 8(%2), %%r10, %%r11;"     "  adox %%r9, %%r10;"     "  adcx %%rbx, %%r10;"    "  movq %%r10, 32(%3);"
     "  mulxq 16(%2), %%rbx, %%r13;"    "  adox %%r11, %%rbx;"    "  adcx %%r14, %%rbx;"    "  movq %%rbx, 40(%3);"    "  mov $0, %%r8;"
     "  mulxq 24(%2), %%r14, %%rdx;"    "  adox %%r13, %%r14;"    "  adcx %%rax, %%r14;"    "  movq %%r14, 48(%3);"    "  mov $0, %%rax;"
@@ -255,7 +255,7 @@ static inline void fmul2 (uint64_t *out, uint64_t *f1, uint64_t *f2, uint64_t *t
 
     // Compute src1[0] * src2
     "  movq 32(%1), %%rdx;"
-    "  mulxq 32(%2), %%r8, %%r9;"       "  xor %%r10, %%r10;"     "  movq %%r8, 64(%3);"
+    "  mulxq 32(%2), %%r8, %%r9;"       "  xor %%r10d, %%r10d;"     "  movq %%r8, 64(%3);"
     "  mulxq 40(%2), %%r10, %%r11;"     "  adox %%r9, %%r10;"     "  movq %%r10, 72(%3);"
     "  mulxq 48(%2), %%rbx, %%r13;"    "  adox %%r11, %%rbx;"
     "  mulxq 56(%2), %%r14, %%rdx;"    "  adox %%r13, %%r14;"    "  mov $0, %%rax;"
@@ -263,7 +263,7 @@ static inline void fmul2 (uint64_t *out, uint64_t *f1, uint64_t *f2, uint64_t *t
 
     // Compute src1[1] * src2
     "  movq 40(%1), %%rdx;"
-    "  mulxq 32(%2), %%r8, %%r9;"       "  xor %%r10, %%r10;"     "  adcxq 72(%3), %%r8;"    "  movq %%r8, 72(%3);"
+    "  mulxq 32(%2), %%r8, %%r9;"       "  xor %%r10d, %%r10d;"     "  adcxq 72(%3), %%r8;"    "  movq %%r8, 72(%3);"
     "  mulxq 40(%2), %%r10, %%r11;"     "  adox %%r9, %%r10;"     "  adcx %%rbx, %%r10;"    "  movq %%r10, 80(%3);"
     "  mulxq 48(%2), %%rbx, %%r13;"    "  adox %%r11, %%rbx;"    "  adcx %%r14, %%rbx;"    "  mov $0, %%r8;"
     "  mulxq 56(%2), %%r14, %%rdx;"    "  adox %%r13, %%r14;"    "  adcx %%rax, %%r14;"    "  mov $0, %%rax;"
@@ -272,7 +272,7 @@ static inline void fmul2 (uint64_t *out, uint64_t *f1, uint64_t *f2, uint64_t *t
 
     // Compute src1[2] * src2
     "  movq 48(%1), %%rdx;"
-    "  mulxq 32(%2), %%r8, %%r9;"       "  xor %%r10, %%r10;"    "  adcxq 80(%3), %%r8;"    "  movq %%r8, 80(%3);"
+    "  mulxq 32(%2), %%r8, %%r9;"       "  xor %%r10d, %%r10d;"    "  adcxq 80(%3), %%r8;"    "  movq %%r8, 80(%3);"
     "  mulxq 40(%2), %%r10, %%r11;"     "  adox %%r9, %%r10;"     "  adcx %%rbx, %%r10;"    "  movq %%r10, 88(%3);"
     "  mulxq 48(%2), %%rbx, %%r13;"    "  adox %%r11, %%rbx;"    "  adcx %%r14, %%rbx;"    "  mov $0, %%r8;"
     "  mulxq 56(%2), %%r14, %%rdx;"    "  adox %%r13, %%r14;"    "  adcx %%rax, %%r14;"    "  mov $0, %%rax;"
@@ -281,7 +281,7 @@ static inline void fmul2 (uint64_t *out, uint64_t *f1, uint64_t *f2, uint64_t *t
 
     // Compute src1[3] * src2
     "  movq 56(%1), %%rdx;"
-    "  mulxq 32(%2), %%r8, %%r9;"       "  xor %%r10, %%r10;"    "  adcxq 88(%3), %%r8;"    "  movq %%r8, 88(%3);"
+    "  mulxq 32(%2), %%r8, %%r9;"       "  xor %%r10d, %%r10d;"    "  adcxq 88(%3), %%r8;"    "  movq %%r8, 88(%3);"
     "  mulxq 40(%2), %%r10, %%r11;"     "  adox %%r9, %%r10;"     "  adcx %%rbx, %%r10;"    "  movq %%r10, 96(%3);"
     "  mulxq 48(%2), %%rbx, %%r13;"    "  adox %%r11, %%rbx;"    "  adcx %%r14, %%rbx;"    "  movq %%rbx, 104(%3);"    "  mov $0, %%r8;"
     "  mulxq 56(%2), %%r14, %%rdx;"    "  adox %%r13, %%r14;"    "  adcx %%rax, %%r14;"    "  movq %%r14, 112(%3);"    "  mov $0, %%rax;"
@@ -296,7 +296,7 @@ static inline void fmul2 (uint64_t *out, uint64_t *f1, uint64_t *f2, uint64_t *t
     // Step 1: Compute dst + carry == tmp_hi * 38 + tmp_lo
     "  mov $38, %%rdx;"
     "  mulxq 32(%1), %%r8, %%r13;"
-    "  xor %2, %2;"
+    "  xor %k2, %k2;"
     "  adoxq 0(%1), %%r8;"
     "  mulxq 40(%1), %%r9, %%rbx;"
     "  adcx %%r13, %%r9;"
@@ -329,7 +329,7 @@ static inline void fmul2 (uint64_t *out, uint64_t *f1, uint64_t *f2, uint64_t *t
     // Step 1: Compute dst + carry == tmp_hi * 38 + tmp_lo
     "  mov $38, %%rdx;"
     "  mulxq 96(%1), %%r8, %%r13;"
-    "  xor %2, %2;"
+    "  xor %k2, %k2;"
     "  adoxq 64(%1), %%r8;"
     "  mulxq 104(%1), %%r9, %%rbx;"
     "  adcx %%r13, %%r9;"
@@ -502,7 +502,7 @@ static inline void fsqr (uint64_t *out, uint64_t *f, uint64_t *tmp)
 
     // Step 1: Compute all partial products
     "  movq 0(%1), %%rdx;"                                       // f[0]
-    "  mulxq 8(%1), %%r8, %%r14;"      "  xor %%r15, %%r15;"     // f[1]*f[0]
+    "  mulxq 8(%1), %%r8, %%r14;"      "  xor %%r15d, %%r15d;"     // f[1]*f[0]
     "  mulxq 16(%1), %%r9, %%r10;"     "  adcx %%r14, %%r9;"     // f[2]*f[0]
     "  mulxq 24(%1), %%rax, %%rcx;"    "  adcx %%rax, %%r10;"    // f[3]*f[0]
     "  movq 24(%1), %%rdx;"                                      // f[3]
@@ -512,7 +512,7 @@ static inline void fsqr (uint64_t *out, uint64_t *f, uint64_t *tmp)
     "  mulxq 16(%1), %%rax, %%rcx;"    "  mov $0, %%r14;"        // f[2]*f[1]
 
     // Step 2: Compute two parallel carry chains
-    "  xor %%r15, %%r15;"
+    "  xor %%r15d, %%r15d;"
     "  adox %%rax, %%r10;"
     "  adcx %%r8, %%r8;"
     "  adox %%rcx, %%r11;"
@@ -549,7 +549,7 @@ static inline void fsqr (uint64_t *out, uint64_t *f, uint64_t *tmp)
     // Step 1: Compute dst + carry == tmp_hi * 38 + tmp_lo
     "  mov $38, %%rdx;"
     "  mulxq 32(%1), %%r8, %%r13;"
-    "  xor %%rcx, %%rcx;"
+    "  xor %%ecx, %%ecx;"
     "  adoxq 0(%1), %%r8;"
     "  mulxq 40(%1), %%r9, %%rbx;"
     "  adcx %%r13, %%r9;"
@@ -593,7 +593,7 @@ static inline void fsqr2 (uint64_t *out, uint64_t *f, uint64_t *tmp)
   asm volatile(
     // Step 1: Compute all partial products
     "  movq 0(%1), %%rdx;"                                       // f[0]
-    "  mulxq 8(%1), %%r8, %%r14;"      "  xor %%r15, %%r15;"     // f[1]*f[0]
+    "  mulxq 8(%1), %%r8, %%r14;"      "  xor %%r15d, %%r15d;"     // f[1]*f[0]
     "  mulxq 16(%1), %%r9, %%r10;"     "  adcx %%r14, %%r9;"     // f[2]*f[0]
     "  mulxq 24(%1), %%rax, %%rcx;"    "  adcx %%rax, %%r10;"    // f[3]*f[0]
     "  movq 24(%1), %%rdx;"                                      // f[3]
@@ -603,7 +603,7 @@ static inline void fsqr2 (uint64_t *out, uint64_t *f, uint64_t *tmp)
     "  mulxq 16(%1), %%rax, %%rcx;"    "  mov $0, %%r14;"        // f[2]*f[1]
 
     // Step 2: Compute two parallel carry chains
-    "  xor %%r15, %%r15;"
+    "  xor %%r15d, %%r15d;"
     "  adox %%rax, %%r10;"
     "  adcx %%r8, %%r8;"
     "  adox %%rcx, %%r11;"
@@ -633,7 +633,7 @@ static inline void fsqr2 (uint64_t *out, uint64_t *f, uint64_t *tmp)
 
     // Step 1: Compute all partial products
     "  movq 32(%1), %%rdx;"                                       // f[0]
-    "  mulxq 40(%1), %%r8, %%r14;"      "  xor %%r15, %%r15;"     // f[1]*f[0]
+    "  mulxq 40(%1), %%r8, %%r14;"      "  xor %%r15d, %%r15d;"     // f[1]*f[0]
     "  mulxq 48(%1), %%r9, %%r10;"     "  adcx %%r14, %%r9;"     // f[2]*f[0]
     "  mulxq 56(%1), %%rax, %%rcx;"    "  adcx %%rax, %%r10;"    // f[3]*f[0]
     "  movq 56(%1), %%rdx;"                                      // f[3]
@@ -643,7 +643,7 @@ static inline void fsqr2 (uint64_t *out, uint64_t *f, uint64_t *tmp)
     "  mulxq 48(%1), %%rax, %%rcx;"    "  mov $0, %%r14;"        // f[2]*f[1]
 
     // Step 2: Compute two parallel carry chains
-    "  xor %%r15, %%r15;"
+    "  xor %%r15d, %%r15d;"
     "  adox %%rax, %%r10;"
     "  adcx %%r8, %%r8;"
     "  adox %%rcx, %%r11;"
@@ -678,7 +678,7 @@ static inline void fsqr2 (uint64_t *out, uint64_t *f, uint64_t *tmp)
     // Step 1: Compute dst + carry == tmp_hi * 38 + tmp_lo
     "  mov $38, %%rdx;"
     "  mulxq 32(%1), %%r8, %%r13;"
-    "  xor %%rcx, %%rcx;"
+    "  xor %%ecx, %%ecx;"
     "  adoxq 0(%1), %%r8;"
     "  mulxq 40(%1), %%r9, %%rbx;"
     "  adcx %%r13, %%r9;"
@@ -711,7 +711,7 @@ static inline void fsqr2 (uint64_t *out, uint64_t *f, uint64_t *tmp)
     // Step 1: Compute dst + carry == tmp_hi * 38 + tmp_lo
     "  mov $38, %%rdx;"
     "  mulxq 96(%1), %%r8, %%r13;"
-    "  xor %%rcx, %%rcx;"
+    "  xor %%ecx, %%ecx;"
     "  adoxq 64(%1), %%r8;"
     "  mulxq 104(%1), %%r9, %%rbx;"
     "  adcx %%r13, %%r9;"

--- a/dist/mozilla/curve25519-x86_64-darwin.S
+++ b/dist/mozilla/curve25519-x86_64-darwin.S
@@ -4,11 +4,11 @@ _add_scalar_e:
   push %rdi
   push %rsi
   ;# Clear registers to propagate the carry bit
-  xor %r8, %r8
-  xor %r9, %r9
-  xor %r10, %r10
-  xor %r11, %r11
-  xor %rax, %rax
+  xor %r8d, %r8d
+  xor %r9d, %r9d
+  xor %r10d, %r10d
+  xor %r11d, %r11d
+  xor %eax, %eax
   
   ;# Begin addition chain
   addq 0(%rsi), %rdx
@@ -44,7 +44,7 @@ _fadd_e:
   cmovc %rdx, %rax
   
   ;# Step 2: Add carry*38 to the original sum
-  xor %rcx, %rcx
+  xor %ecx, %ecx
   add %rax, %r8
   adcx %rcx, %r9
   movq %r9, 8(%rdi)
@@ -149,7 +149,7 @@ _fmul_e:
   ;# Compute src1[0] * src2
   movq 0(%rsi), %rdx
   mulxq 0(%rcx), %r8, %r9
-  xor %r10, %r10
+  xor %r10d, %r10d
   movq %r8, 0(%rdi)
   
   mulxq 8(%rcx), %r10, %r11
@@ -167,7 +167,7 @@ _fmul_e:
   ;# Compute src1[1] * src2
   movq 8(%rsi), %rdx
   mulxq 0(%rcx), %r8, %r9
-  xor %r10, %r10
+  xor %r10d, %r10d
   adcxq 8(%rdi), %r8
   movq %r8, 8(%rdi)
   mulxq 8(%rcx), %r10, %r11
@@ -189,7 +189,7 @@ _fmul_e:
   ;# Compute src1[2] * src2
   movq 16(%rsi), %rdx
   mulxq 0(%rcx), %r8, %r9
-  xor %r10, %r10
+  xor %r10d, %r10d
   adcxq 16(%rdi), %r8
   movq %r8, 16(%rdi)
   mulxq 8(%rcx), %r10, %r11
@@ -211,7 +211,7 @@ _fmul_e:
   ;# Compute src1[3] * src2
   movq 24(%rsi), %rdx
   mulxq 0(%rcx), %r8, %r9
-  xor %r10, %r10
+  xor %r10d, %r10d
   adcxq 24(%rdi), %r8
   movq %r8, 24(%rdi)
   mulxq 8(%rcx), %r10, %r11
@@ -240,7 +240,7 @@ _fmul_e:
   ;# Step 1: Compute dst + carry == tmp_hi * 38 + tmp_lo
   mov $38, %rdx
   mulxq 32(%rsi), %r8, %r13
-  xor %rcx, %rcx
+  xor %ecx, %ecx
   adoxq 0(%rsi), %r8
   mulxq 40(%rsi), %r9, %rbx
   adcx %r13, %r9
@@ -286,7 +286,7 @@ _fmul2_e:
   ;# Compute src1[0] * src2
   movq 0(%rsi), %rdx
   mulxq 0(%rcx), %r8, %r9
-  xor %r10, %r10
+  xor %r10d, %r10d
   movq %r8, 0(%rdi)
   
   mulxq 8(%rcx), %r10, %r11
@@ -304,7 +304,7 @@ _fmul2_e:
   ;# Compute src1[1] * src2
   movq 8(%rsi), %rdx
   mulxq 0(%rcx), %r8, %r9
-  xor %r10, %r10
+  xor %r10d, %r10d
   adcxq 8(%rdi), %r8
   movq %r8, 8(%rdi)
   mulxq 8(%rcx), %r10, %r11
@@ -326,7 +326,7 @@ _fmul2_e:
   ;# Compute src1[2] * src2
   movq 16(%rsi), %rdx
   mulxq 0(%rcx), %r8, %r9
-  xor %r10, %r10
+  xor %r10d, %r10d
   adcxq 16(%rdi), %r8
   movq %r8, 16(%rdi)
   mulxq 8(%rcx), %r10, %r11
@@ -348,7 +348,7 @@ _fmul2_e:
   ;# Compute src1[3] * src2
   movq 24(%rsi), %rdx
   mulxq 0(%rcx), %r8, %r9
-  xor %r10, %r10
+  xor %r10d, %r10d
   adcxq 24(%rdi), %r8
   movq %r8, 24(%rdi)
   mulxq 8(%rcx), %r10, %r11
@@ -373,7 +373,7 @@ _fmul2_e:
   ;# Compute src1[0] * src2
   movq 32(%rsi), %rdx
   mulxq 32(%rcx), %r8, %r9
-  xor %r10, %r10
+  xor %r10d, %r10d
   movq %r8, 64(%rdi)
   
   mulxq 40(%rcx), %r10, %r11
@@ -391,7 +391,7 @@ _fmul2_e:
   ;# Compute src1[1] * src2
   movq 40(%rsi), %rdx
   mulxq 32(%rcx), %r8, %r9
-  xor %r10, %r10
+  xor %r10d, %r10d
   adcxq 72(%rdi), %r8
   movq %r8, 72(%rdi)
   mulxq 40(%rcx), %r10, %r11
@@ -413,7 +413,7 @@ _fmul2_e:
   ;# Compute src1[2] * src2
   movq 48(%rsi), %rdx
   mulxq 32(%rcx), %r8, %r9
-  xor %r10, %r10
+  xor %r10d, %r10d
   adcxq 80(%rdi), %r8
   movq %r8, 80(%rdi)
   mulxq 40(%rcx), %r10, %r11
@@ -435,7 +435,7 @@ _fmul2_e:
   ;# Compute src1[3] * src2
   movq 56(%rsi), %rdx
   mulxq 32(%rcx), %r8, %r9
-  xor %r10, %r10
+  xor %r10d, %r10d
   adcxq 88(%rdi), %r8
   movq %r8, 88(%rdi)
   mulxq 40(%rcx), %r10, %r11
@@ -464,7 +464,7 @@ _fmul2_e:
   ;# Step 1: Compute dst + carry == tmp_hi * 38 + tmp_lo
   mov $38, %rdx
   mulxq 32(%rsi), %r8, %r13
-  xor %rcx, %rcx
+  xor %ecx, %ecx
   adoxq 0(%rsi), %r8
   mulxq 40(%rsi), %r9, %rbx
   adcx %r13, %r9
@@ -497,7 +497,7 @@ _fmul2_e:
   ;# Step 1: Compute dst + carry == tmp_hi * 38 + tmp_lo
   mov $38, %rdx
   mulxq 96(%rsi), %r8, %r13
-  xor %rcx, %rcx
+  xor %ecx, %ecx
   adoxq 64(%rsi), %r8
   mulxq 104(%rsi), %r9, %rbx
   adcx %r13, %r9
@@ -545,7 +545,7 @@ _fsqr_e:
   movq 0(%rsi), %rdx
   ;# f[0]
   mulxq 8(%rsi), %r8, %r14
-  xor %r15, %r15
+  xor %r15d, %r15d
   ;# f[1]*f[0]
   mulxq 16(%rsi), %r9, %r10
   adcx %r14, %r9
@@ -569,7 +569,7 @@ _fsqr_e:
   ;# f[2]*f[1]
   
   ;# Step 2: Compute two parallel carry chains
-  xor %r15, %r15
+  xor %r15d, %r15d
   adox %rax, %r10
   adcx %r8, %r8
   adox %rcx, %r11
@@ -627,7 +627,7 @@ _fsqr_e:
   ;# Step 1: Compute dst + carry == tmp_hi * 38 + tmp_lo
   mov $38, %rdx
   mulxq 32(%rsi), %r8, %r13
-  xor %rcx, %rcx
+  xor %ecx, %ecx
   adoxq 0(%rsi), %r8
   mulxq 40(%rsi), %r9, %rbx
   adcx %r13, %r9
@@ -675,7 +675,7 @@ _fsqr2_e:
   movq 0(%rsi), %rdx
   ;# f[0]
   mulxq 8(%rsi), %r8, %r14
-  xor %r15, %r15
+  xor %r15d, %r15d
   ;# f[1]*f[0]
   mulxq 16(%rsi), %r9, %r10
   adcx %r14, %r9
@@ -699,7 +699,7 @@ _fsqr2_e:
   ;# f[2]*f[1]
   
   ;# Step 2: Compute two parallel carry chains
-  xor %r15, %r15
+  xor %r15d, %r15d
   adox %rax, %r10
   adcx %r8, %r8
   adox %rcx, %r11
@@ -754,7 +754,7 @@ _fsqr2_e:
   movq 32(%rsi), %rdx
   ;# f[0]
   mulxq 40(%rsi), %r8, %r14
-  xor %r15, %r15
+  xor %r15d, %r15d
   ;# f[1]*f[0]
   mulxq 48(%rsi), %r9, %r10
   adcx %r14, %r9
@@ -778,7 +778,7 @@ _fsqr2_e:
   ;# f[2]*f[1]
   
   ;# Step 2: Compute two parallel carry chains
-  xor %r15, %r15
+  xor %r15d, %r15d
   adox %rax, %r10
   adcx %r8, %r8
   adox %rcx, %r11
@@ -836,7 +836,7 @@ _fsqr2_e:
   ;# Step 1: Compute dst + carry == tmp_hi * 38 + tmp_lo
   mov $38, %rdx
   mulxq 32(%rsi), %r8, %r13
-  xor %rcx, %rcx
+  xor %ecx, %ecx
   adoxq 0(%rsi), %r8
   mulxq 40(%rsi), %r9, %rbx
   adcx %r13, %r9
@@ -869,7 +869,7 @@ _fsqr2_e:
   ;# Step 1: Compute dst + carry == tmp_hi * 38 + tmp_lo
   mov $38, %rdx
   mulxq 96(%rsi), %r8, %r13
-  xor %rcx, %rcx
+  xor %ecx, %ecx
   adoxq 64(%rsi), %r8
   mulxq 104(%rsi), %r9, %rbx
   adcx %r13, %r9

--- a/dist/mozilla/curve25519-x86_64-linux.S
+++ b/dist/mozilla/curve25519-x86_64-linux.S
@@ -4,11 +4,11 @@ add_scalar_e:
   push %rdi
   push %rsi
   ;# Clear registers to propagate the carry bit
-  xor %r8, %r8
-  xor %r9, %r9
-  xor %r10, %r10
-  xor %r11, %r11
-  xor %rax, %rax
+  xor %r8d, %r8d
+  xor %r9d, %r9d
+  xor %r10d, %r10d
+  xor %r11d, %r11d
+  xor %eax, %eax
   
   ;# Begin addition chain
   addq 0(%rsi), %rdx
@@ -44,7 +44,7 @@ fadd_e:
   cmovc %rdx, %rax
   
   ;# Step 2: Add carry*38 to the original sum
-  xor %rcx, %rcx
+  xor %ecx, %ecx
   add %rax, %r8
   adcx %rcx, %r9
   movq %r9, 8(%rdi)
@@ -149,7 +149,7 @@ fmul_e:
   ;# Compute src1[0] * src2
   movq 0(%rsi), %rdx
   mulxq 0(%rcx), %r8, %r9
-  xor %r10, %r10
+  xor %r10d, %r10d
   movq %r8, 0(%rdi)
   
   mulxq 8(%rcx), %r10, %r11
@@ -167,7 +167,7 @@ fmul_e:
   ;# Compute src1[1] * src2
   movq 8(%rsi), %rdx
   mulxq 0(%rcx), %r8, %r9
-  xor %r10, %r10
+  xor %r10d, %r10d
   adcxq 8(%rdi), %r8
   movq %r8, 8(%rdi)
   mulxq 8(%rcx), %r10, %r11
@@ -189,7 +189,7 @@ fmul_e:
   ;# Compute src1[2] * src2
   movq 16(%rsi), %rdx
   mulxq 0(%rcx), %r8, %r9
-  xor %r10, %r10
+  xor %r10d, %r10d
   adcxq 16(%rdi), %r8
   movq %r8, 16(%rdi)
   mulxq 8(%rcx), %r10, %r11
@@ -211,7 +211,7 @@ fmul_e:
   ;# Compute src1[3] * src2
   movq 24(%rsi), %rdx
   mulxq 0(%rcx), %r8, %r9
-  xor %r10, %r10
+  xor %r10d, %r10d
   adcxq 24(%rdi), %r8
   movq %r8, 24(%rdi)
   mulxq 8(%rcx), %r10, %r11
@@ -240,7 +240,7 @@ fmul_e:
   ;# Step 1: Compute dst + carry == tmp_hi * 38 + tmp_lo
   mov $38, %rdx
   mulxq 32(%rsi), %r8, %r13
-  xor %rcx, %rcx
+  xor %ecx, %ecx
   adoxq 0(%rsi), %r8
   mulxq 40(%rsi), %r9, %rbx
   adcx %r13, %r9
@@ -286,7 +286,7 @@ fmul2_e:
   ;# Compute src1[0] * src2
   movq 0(%rsi), %rdx
   mulxq 0(%rcx), %r8, %r9
-  xor %r10, %r10
+  xor %r10d, %r10d
   movq %r8, 0(%rdi)
   
   mulxq 8(%rcx), %r10, %r11
@@ -304,7 +304,7 @@ fmul2_e:
   ;# Compute src1[1] * src2
   movq 8(%rsi), %rdx
   mulxq 0(%rcx), %r8, %r9
-  xor %r10, %r10
+  xor %r10d, %r10d
   adcxq 8(%rdi), %r8
   movq %r8, 8(%rdi)
   mulxq 8(%rcx), %r10, %r11
@@ -326,7 +326,7 @@ fmul2_e:
   ;# Compute src1[2] * src2
   movq 16(%rsi), %rdx
   mulxq 0(%rcx), %r8, %r9
-  xor %r10, %r10
+  xor %r10d, %r10d
   adcxq 16(%rdi), %r8
   movq %r8, 16(%rdi)
   mulxq 8(%rcx), %r10, %r11
@@ -348,7 +348,7 @@ fmul2_e:
   ;# Compute src1[3] * src2
   movq 24(%rsi), %rdx
   mulxq 0(%rcx), %r8, %r9
-  xor %r10, %r10
+  xor %r10d, %r10d
   adcxq 24(%rdi), %r8
   movq %r8, 24(%rdi)
   mulxq 8(%rcx), %r10, %r11
@@ -373,7 +373,7 @@ fmul2_e:
   ;# Compute src1[0] * src2
   movq 32(%rsi), %rdx
   mulxq 32(%rcx), %r8, %r9
-  xor %r10, %r10
+  xor %r10d, %r10d
   movq %r8, 64(%rdi)
   
   mulxq 40(%rcx), %r10, %r11
@@ -391,7 +391,7 @@ fmul2_e:
   ;# Compute src1[1] * src2
   movq 40(%rsi), %rdx
   mulxq 32(%rcx), %r8, %r9
-  xor %r10, %r10
+  xor %r10d, %r10d
   adcxq 72(%rdi), %r8
   movq %r8, 72(%rdi)
   mulxq 40(%rcx), %r10, %r11
@@ -413,7 +413,7 @@ fmul2_e:
   ;# Compute src1[2] * src2
   movq 48(%rsi), %rdx
   mulxq 32(%rcx), %r8, %r9
-  xor %r10, %r10
+  xor %r10d, %r10d
   adcxq 80(%rdi), %r8
   movq %r8, 80(%rdi)
   mulxq 40(%rcx), %r10, %r11
@@ -435,7 +435,7 @@ fmul2_e:
   ;# Compute src1[3] * src2
   movq 56(%rsi), %rdx
   mulxq 32(%rcx), %r8, %r9
-  xor %r10, %r10
+  xor %r10d, %r10d
   adcxq 88(%rdi), %r8
   movq %r8, 88(%rdi)
   mulxq 40(%rcx), %r10, %r11
@@ -464,7 +464,7 @@ fmul2_e:
   ;# Step 1: Compute dst + carry == tmp_hi * 38 + tmp_lo
   mov $38, %rdx
   mulxq 32(%rsi), %r8, %r13
-  xor %rcx, %rcx
+  xor %ecx, %ecx
   adoxq 0(%rsi), %r8
   mulxq 40(%rsi), %r9, %rbx
   adcx %r13, %r9
@@ -497,7 +497,7 @@ fmul2_e:
   ;# Step 1: Compute dst + carry == tmp_hi * 38 + tmp_lo
   mov $38, %rdx
   mulxq 96(%rsi), %r8, %r13
-  xor %rcx, %rcx
+  xor %ecx, %ecx
   adoxq 64(%rsi), %r8
   mulxq 104(%rsi), %r9, %rbx
   adcx %r13, %r9
@@ -545,7 +545,7 @@ fsqr_e:
   movq 0(%rsi), %rdx
   ;# f[0]
   mulxq 8(%rsi), %r8, %r14
-  xor %r15, %r15
+  xor %r15d, %r15d
   ;# f[1]*f[0]
   mulxq 16(%rsi), %r9, %r10
   adcx %r14, %r9
@@ -569,7 +569,7 @@ fsqr_e:
   ;# f[2]*f[1]
   
   ;# Step 2: Compute two parallel carry chains
-  xor %r15, %r15
+  xor %r15d, %r15d
   adox %rax, %r10
   adcx %r8, %r8
   adox %rcx, %r11
@@ -627,7 +627,7 @@ fsqr_e:
   ;# Step 1: Compute dst + carry == tmp_hi * 38 + tmp_lo
   mov $38, %rdx
   mulxq 32(%rsi), %r8, %r13
-  xor %rcx, %rcx
+  xor %ecx, %ecx
   adoxq 0(%rsi), %r8
   mulxq 40(%rsi), %r9, %rbx
   adcx %r13, %r9
@@ -675,7 +675,7 @@ fsqr2_e:
   movq 0(%rsi), %rdx
   ;# f[0]
   mulxq 8(%rsi), %r8, %r14
-  xor %r15, %r15
+  xor %r15d, %r15d
   ;# f[1]*f[0]
   mulxq 16(%rsi), %r9, %r10
   adcx %r14, %r9
@@ -699,7 +699,7 @@ fsqr2_e:
   ;# f[2]*f[1]
   
   ;# Step 2: Compute two parallel carry chains
-  xor %r15, %r15
+  xor %r15d, %r15d
   adox %rax, %r10
   adcx %r8, %r8
   adox %rcx, %r11
@@ -754,7 +754,7 @@ fsqr2_e:
   movq 32(%rsi), %rdx
   ;# f[0]
   mulxq 40(%rsi), %r8, %r14
-  xor %r15, %r15
+  xor %r15d, %r15d
   ;# f[1]*f[0]
   mulxq 48(%rsi), %r9, %r10
   adcx %r14, %r9
@@ -778,7 +778,7 @@ fsqr2_e:
   ;# f[2]*f[1]
   
   ;# Step 2: Compute two parallel carry chains
-  xor %r15, %r15
+  xor %r15d, %r15d
   adox %rax, %r10
   adcx %r8, %r8
   adox %rcx, %r11
@@ -836,7 +836,7 @@ fsqr2_e:
   ;# Step 1: Compute dst + carry == tmp_hi * 38 + tmp_lo
   mov $38, %rdx
   mulxq 32(%rsi), %r8, %r13
-  xor %rcx, %rcx
+  xor %ecx, %ecx
   adoxq 0(%rsi), %r8
   mulxq 40(%rsi), %r9, %rbx
   adcx %r13, %r9
@@ -869,7 +869,7 @@ fsqr2_e:
   ;# Step 1: Compute dst + carry == tmp_hi * 38 + tmp_lo
   mov $38, %rdx
   mulxq 96(%rsi), %r8, %r13
-  xor %rcx, %rcx
+  xor %ecx, %ecx
   adoxq 64(%rsi), %r8
   mulxq 104(%rsi), %r9, %rbx
   adcx %r13, %r9

--- a/dist/mozilla/curve25519-x86_64-mingw.S
+++ b/dist/mozilla/curve25519-x86_64-mingw.S
@@ -7,11 +7,11 @@ add_scalar_e:
   mov %rdx, %rsi
   mov %r8, %rdx
   ;# Clear registers to propagate the carry bit
-  xor %r8, %r8
-  xor %r9, %r9
-  xor %r10, %r10
-  xor %r11, %r11
-  xor %rax, %rax
+  xor %r8d, %r8d
+  xor %r9d, %r9d
+  xor %r10d, %r10d
+  xor %r11d, %r11d
+  xor %eax, %eax
   
   ;# Begin addition chain
   addq 0(%rsi), %rdx
@@ -52,7 +52,7 @@ fadd_e:
   cmovc %rdx, %rax
   
   ;# Step 2: Add carry*38 to the original sum
-  xor %rcx, %rcx
+  xor %ecx, %ecx
   add %rax, %r8
   adcx %rcx, %r9
   movq %r9, 8(%rdi)
@@ -176,7 +176,7 @@ fmul_e:
   ;# Compute src1[0] * src2
   movq 0(%rsi), %rdx
   mulxq 0(%rcx), %r8, %r9
-  xor %r10, %r10
+  xor %r10d, %r10d
   movq %r8, 0(%rdi)
   
   mulxq 8(%rcx), %r10, %r11
@@ -194,7 +194,7 @@ fmul_e:
   ;# Compute src1[1] * src2
   movq 8(%rsi), %rdx
   mulxq 0(%rcx), %r8, %r9
-  xor %r10, %r10
+  xor %r10d, %r10d
   adcxq 8(%rdi), %r8
   movq %r8, 8(%rdi)
   mulxq 8(%rcx), %r10, %r11
@@ -216,7 +216,7 @@ fmul_e:
   ;# Compute src1[2] * src2
   movq 16(%rsi), %rdx
   mulxq 0(%rcx), %r8, %r9
-  xor %r10, %r10
+  xor %r10d, %r10d
   adcxq 16(%rdi), %r8
   movq %r8, 16(%rdi)
   mulxq 8(%rcx), %r10, %r11
@@ -238,7 +238,7 @@ fmul_e:
   ;# Compute src1[3] * src2
   movq 24(%rsi), %rdx
   mulxq 0(%rcx), %r8, %r9
-  xor %r10, %r10
+  xor %r10d, %r10d
   adcxq 24(%rdi), %r8
   movq %r8, 24(%rdi)
   mulxq 8(%rcx), %r10, %r11
@@ -267,7 +267,7 @@ fmul_e:
   ;# Step 1: Compute dst + carry == tmp_hi * 38 + tmp_lo
   mov $38, %rdx
   mulxq 32(%rsi), %r8, %r13
-  xor %rcx, %rcx
+  xor %ecx, %ecx
   adoxq 0(%rsi), %r8
   mulxq 40(%rsi), %r9, %rbx
   adcx %r13, %r9
@@ -320,7 +320,7 @@ fmul2_e:
   ;# Compute src1[0] * src2
   movq 0(%rsi), %rdx
   mulxq 0(%rcx), %r8, %r9
-  xor %r10, %r10
+  xor %r10d, %r10d
   movq %r8, 0(%rdi)
   
   mulxq 8(%rcx), %r10, %r11
@@ -338,7 +338,7 @@ fmul2_e:
   ;# Compute src1[1] * src2
   movq 8(%rsi), %rdx
   mulxq 0(%rcx), %r8, %r9
-  xor %r10, %r10
+  xor %r10d, %r10d
   adcxq 8(%rdi), %r8
   movq %r8, 8(%rdi)
   mulxq 8(%rcx), %r10, %r11
@@ -360,7 +360,7 @@ fmul2_e:
   ;# Compute src1[2] * src2
   movq 16(%rsi), %rdx
   mulxq 0(%rcx), %r8, %r9
-  xor %r10, %r10
+  xor %r10d, %r10d
   adcxq 16(%rdi), %r8
   movq %r8, 16(%rdi)
   mulxq 8(%rcx), %r10, %r11
@@ -382,7 +382,7 @@ fmul2_e:
   ;# Compute src1[3] * src2
   movq 24(%rsi), %rdx
   mulxq 0(%rcx), %r8, %r9
-  xor %r10, %r10
+  xor %r10d, %r10d
   adcxq 24(%rdi), %r8
   movq %r8, 24(%rdi)
   mulxq 8(%rcx), %r10, %r11
@@ -407,7 +407,7 @@ fmul2_e:
   ;# Compute src1[0] * src2
   movq 32(%rsi), %rdx
   mulxq 32(%rcx), %r8, %r9
-  xor %r10, %r10
+  xor %r10d, %r10d
   movq %r8, 64(%rdi)
   
   mulxq 40(%rcx), %r10, %r11
@@ -425,7 +425,7 @@ fmul2_e:
   ;# Compute src1[1] * src2
   movq 40(%rsi), %rdx
   mulxq 32(%rcx), %r8, %r9
-  xor %r10, %r10
+  xor %r10d, %r10d
   adcxq 72(%rdi), %r8
   movq %r8, 72(%rdi)
   mulxq 40(%rcx), %r10, %r11
@@ -447,7 +447,7 @@ fmul2_e:
   ;# Compute src1[2] * src2
   movq 48(%rsi), %rdx
   mulxq 32(%rcx), %r8, %r9
-  xor %r10, %r10
+  xor %r10d, %r10d
   adcxq 80(%rdi), %r8
   movq %r8, 80(%rdi)
   mulxq 40(%rcx), %r10, %r11
@@ -469,7 +469,7 @@ fmul2_e:
   ;# Compute src1[3] * src2
   movq 56(%rsi), %rdx
   mulxq 32(%rcx), %r8, %r9
-  xor %r10, %r10
+  xor %r10d, %r10d
   adcxq 88(%rdi), %r8
   movq %r8, 88(%rdi)
   mulxq 40(%rcx), %r10, %r11
@@ -498,7 +498,7 @@ fmul2_e:
   ;# Step 1: Compute dst + carry == tmp_hi * 38 + tmp_lo
   mov $38, %rdx
   mulxq 32(%rsi), %r8, %r13
-  xor %rcx, %rcx
+  xor %ecx, %ecx
   adoxq 0(%rsi), %r8
   mulxq 40(%rsi), %r9, %rbx
   adcx %r13, %r9
@@ -531,7 +531,7 @@ fmul2_e:
   ;# Step 1: Compute dst + carry == tmp_hi * 38 + tmp_lo
   mov $38, %rdx
   mulxq 96(%rsi), %r8, %r13
-  xor %rcx, %rcx
+  xor %ecx, %ecx
   adoxq 64(%rsi), %r8
   mulxq 104(%rsi), %r9, %rbx
   adcx %r13, %r9
@@ -585,7 +585,7 @@ fsqr_e:
   movq 0(%rsi), %rdx
   ;# f[0]
   mulxq 8(%rsi), %r8, %r14
-  xor %r15, %r15
+  xor %r15d, %r15d
   ;# f[1]*f[0]
   mulxq 16(%rsi), %r9, %r10
   adcx %r14, %r9
@@ -609,7 +609,7 @@ fsqr_e:
   ;# f[2]*f[1]
   
   ;# Step 2: Compute two parallel carry chains
-  xor %r15, %r15
+  xor %r15d, %r15d
   adox %rax, %r10
   adcx %r8, %r8
   adox %rcx, %r11
@@ -667,7 +667,7 @@ fsqr_e:
   ;# Step 1: Compute dst + carry == tmp_hi * 38 + tmp_lo
   mov $38, %rdx
   mulxq 32(%rsi), %r8, %r13
-  xor %rcx, %rcx
+  xor %ecx, %ecx
   adoxq 0(%rsi), %r8
   mulxq 40(%rsi), %r9, %rbx
   adcx %r13, %r9
@@ -721,7 +721,7 @@ fsqr2_e:
   movq 0(%rsi), %rdx
   ;# f[0]
   mulxq 8(%rsi), %r8, %r14
-  xor %r15, %r15
+  xor %r15d, %r15d
   ;# f[1]*f[0]
   mulxq 16(%rsi), %r9, %r10
   adcx %r14, %r9
@@ -745,7 +745,7 @@ fsqr2_e:
   ;# f[2]*f[1]
   
   ;# Step 2: Compute two parallel carry chains
-  xor %r15, %r15
+  xor %r15d, %r15d
   adox %rax, %r10
   adcx %r8, %r8
   adox %rcx, %r11
@@ -800,7 +800,7 @@ fsqr2_e:
   movq 32(%rsi), %rdx
   ;# f[0]
   mulxq 40(%rsi), %r8, %r14
-  xor %r15, %r15
+  xor %r15d, %r15d
   ;# f[1]*f[0]
   mulxq 48(%rsi), %r9, %r10
   adcx %r14, %r9
@@ -824,7 +824,7 @@ fsqr2_e:
   ;# f[2]*f[1]
   
   ;# Step 2: Compute two parallel carry chains
-  xor %r15, %r15
+  xor %r15d, %r15d
   adox %rax, %r10
   adcx %r8, %r8
   adox %rcx, %r11
@@ -882,7 +882,7 @@ fsqr2_e:
   ;# Step 1: Compute dst + carry == tmp_hi * 38 + tmp_lo
   mov $38, %rdx
   mulxq 32(%rsi), %r8, %r13
-  xor %rcx, %rcx
+  xor %ecx, %ecx
   adoxq 0(%rsi), %r8
   mulxq 40(%rsi), %r9, %rbx
   adcx %r13, %r9
@@ -915,7 +915,7 @@ fsqr2_e:
   ;# Step 1: Compute dst + carry == tmp_hi * 38 + tmp_lo
   mov $38, %rdx
   mulxq 96(%rsi), %r8, %r13
-  xor %rcx, %rcx
+  xor %ecx, %ecx
   adoxq 64(%rsi), %r8
   mulxq 104(%rsi), %r9, %rbx
   adcx %r13, %r9

--- a/dist/mozilla/curve25519-x86_64-msvc.asm
+++ b/dist/mozilla/curve25519-x86_64-msvc.asm
@@ -7,11 +7,11 @@ add_scalar_e proc
   mov rsi, rdx
   mov rdx, r8
   ;# Clear registers to propagate the carry bit
-  xor r8, r8
-  xor r9, r9
-  xor r10, r10
-  xor r11, r11
-  xor rax, rax
+  xor r8d, r8d
+  xor r9d, r9d
+  xor r10d, r10d
+  xor r11d, r11d
+  xor eax, eax
   
   ;# Begin addition chain
   add rdx, qword ptr [rsi + 0]
@@ -52,7 +52,7 @@ fadd_e proc
   cmovc rax, rdx
   
   ;# Step 2: Add carry*38 to the original sum
-  xor rcx, rcx
+  xor ecx, ecx
   add r8, rax
   adcx r9, rcx
   mov qword ptr [rdi + 8], r9
@@ -176,7 +176,7 @@ fmul_e proc
   ;# Compute src1[0] * src2
   mov rdx, qword ptr [rsi + 0]
   mulx r9, r8, qword ptr [rcx + 0]
-  xor r10, r10
+  xor r10d, r10d
   mov qword ptr [rdi + 0], r8
   
   mulx r11, r10, qword ptr [rcx + 8]
@@ -194,7 +194,7 @@ fmul_e proc
   ;# Compute src1[1] * src2
   mov rdx, qword ptr [rsi + 8]
   mulx r9, r8, qword ptr [rcx + 0]
-  xor r10, r10
+  xor r10d, r10d
   adcx r8, qword ptr [rdi + 8]
   mov qword ptr [rdi + 8], r8
   mulx r11, r10, qword ptr [rcx + 8]
@@ -216,7 +216,7 @@ fmul_e proc
   ;# Compute src1[2] * src2
   mov rdx, qword ptr [rsi + 16]
   mulx r9, r8, qword ptr [rcx + 0]
-  xor r10, r10
+  xor r10d, r10d
   adcx r8, qword ptr [rdi + 16]
   mov qword ptr [rdi + 16], r8
   mulx r11, r10, qword ptr [rcx + 8]
@@ -238,7 +238,7 @@ fmul_e proc
   ;# Compute src1[3] * src2
   mov rdx, qword ptr [rsi + 24]
   mulx r9, r8, qword ptr [rcx + 0]
-  xor r10, r10
+  xor r10d, r10d
   adcx r8, qword ptr [rdi + 24]
   mov qword ptr [rdi + 24], r8
   mulx r11, r10, qword ptr [rcx + 8]
@@ -267,7 +267,7 @@ fmul_e proc
   ;# Step 1: Compute dst + carry == tmp_hi * 38 + tmp_lo
   mov rdx, 38
   mulx r13, r8, qword ptr [rsi + 32]
-  xor rcx, rcx
+  xor ecx, ecx
   adox r8, qword ptr [rsi + 0]
   mulx rbx, r9, qword ptr [rsi + 40]
   adcx r9, r13
@@ -320,7 +320,7 @@ fmul2_e proc
   ;# Compute src1[0] * src2
   mov rdx, qword ptr [rsi + 0]
   mulx r9, r8, qword ptr [rcx + 0]
-  xor r10, r10
+  xor r10d, r10d
   mov qword ptr [rdi + 0], r8
   
   mulx r11, r10, qword ptr [rcx + 8]
@@ -338,7 +338,7 @@ fmul2_e proc
   ;# Compute src1[1] * src2
   mov rdx, qword ptr [rsi + 8]
   mulx r9, r8, qword ptr [rcx + 0]
-  xor r10, r10
+  xor r10d, r10d
   adcx r8, qword ptr [rdi + 8]
   mov qword ptr [rdi + 8], r8
   mulx r11, r10, qword ptr [rcx + 8]
@@ -360,7 +360,7 @@ fmul2_e proc
   ;# Compute src1[2] * src2
   mov rdx, qword ptr [rsi + 16]
   mulx r9, r8, qword ptr [rcx + 0]
-  xor r10, r10
+  xor r10d, r10d
   adcx r8, qword ptr [rdi + 16]
   mov qword ptr [rdi + 16], r8
   mulx r11, r10, qword ptr [rcx + 8]
@@ -382,7 +382,7 @@ fmul2_e proc
   ;# Compute src1[3] * src2
   mov rdx, qword ptr [rsi + 24]
   mulx r9, r8, qword ptr [rcx + 0]
-  xor r10, r10
+  xor r10d, r10d
   adcx r8, qword ptr [rdi + 24]
   mov qword ptr [rdi + 24], r8
   mulx r11, r10, qword ptr [rcx + 8]
@@ -407,7 +407,7 @@ fmul2_e proc
   ;# Compute src1[0] * src2
   mov rdx, qword ptr [rsi + 32]
   mulx r9, r8, qword ptr [rcx + 32]
-  xor r10, r10
+  xor r10d, r10d
   mov qword ptr [rdi + 64], r8
   
   mulx r11, r10, qword ptr [rcx + 40]
@@ -425,7 +425,7 @@ fmul2_e proc
   ;# Compute src1[1] * src2
   mov rdx, qword ptr [rsi + 40]
   mulx r9, r8, qword ptr [rcx + 32]
-  xor r10, r10
+  xor r10d, r10d
   adcx r8, qword ptr [rdi + 72]
   mov qword ptr [rdi + 72], r8
   mulx r11, r10, qword ptr [rcx + 40]
@@ -447,7 +447,7 @@ fmul2_e proc
   ;# Compute src1[2] * src2
   mov rdx, qword ptr [rsi + 48]
   mulx r9, r8, qword ptr [rcx + 32]
-  xor r10, r10
+  xor r10d, r10d
   adcx r8, qword ptr [rdi + 80]
   mov qword ptr [rdi + 80], r8
   mulx r11, r10, qword ptr [rcx + 40]
@@ -469,7 +469,7 @@ fmul2_e proc
   ;# Compute src1[3] * src2
   mov rdx, qword ptr [rsi + 56]
   mulx r9, r8, qword ptr [rcx + 32]
-  xor r10, r10
+  xor r10d, r10d
   adcx r8, qword ptr [rdi + 88]
   mov qword ptr [rdi + 88], r8
   mulx r11, r10, qword ptr [rcx + 40]
@@ -498,7 +498,7 @@ fmul2_e proc
   ;# Step 1: Compute dst + carry == tmp_hi * 38 + tmp_lo
   mov rdx, 38
   mulx r13, r8, qword ptr [rsi + 32]
-  xor rcx, rcx
+  xor ecx, ecx
   adox r8, qword ptr [rsi + 0]
   mulx rbx, r9, qword ptr [rsi + 40]
   adcx r9, r13
@@ -531,7 +531,7 @@ fmul2_e proc
   ;# Step 1: Compute dst + carry == tmp_hi * 38 + tmp_lo
   mov rdx, 38
   mulx r13, r8, qword ptr [rsi + 96]
-  xor rcx, rcx
+  xor ecx, ecx
   adox r8, qword ptr [rsi + 64]
   mulx rbx, r9, qword ptr [rsi + 104]
   adcx r9, r13
@@ -585,7 +585,7 @@ fsqr_e proc
   mov rdx, qword ptr [rsi + 0]
   ;# f[0]
   mulx r14, r8, qword ptr [rsi + 8]
-  xor r15, r15
+  xor r15d, r15d
   ;# f[1]*f[0]
   mulx r10, r9, qword ptr [rsi + 16]
   adcx r9, r14
@@ -609,7 +609,7 @@ fsqr_e proc
   ;# f[2]*f[1]
   
   ;# Step 2: Compute two parallel carry chains
-  xor r15, r15
+  xor r15d, r15d
   adox r10, rax
   adcx r8, r8
   adox r11, rcx
@@ -667,7 +667,7 @@ fsqr_e proc
   ;# Step 1: Compute dst + carry == tmp_hi * 38 + tmp_lo
   mov rdx, 38
   mulx r13, r8, qword ptr [rsi + 32]
-  xor rcx, rcx
+  xor ecx, ecx
   adox r8, qword ptr [rsi + 0]
   mulx rbx, r9, qword ptr [rsi + 40]
   adcx r9, r13
@@ -721,7 +721,7 @@ fsqr2_e proc
   mov rdx, qword ptr [rsi + 0]
   ;# f[0]
   mulx r14, r8, qword ptr [rsi + 8]
-  xor r15, r15
+  xor r15d, r15d
   ;# f[1]*f[0]
   mulx r10, r9, qword ptr [rsi + 16]
   adcx r9, r14
@@ -745,7 +745,7 @@ fsqr2_e proc
   ;# f[2]*f[1]
   
   ;# Step 2: Compute two parallel carry chains
-  xor r15, r15
+  xor r15d, r15d
   adox r10, rax
   adcx r8, r8
   adox r11, rcx
@@ -800,7 +800,7 @@ fsqr2_e proc
   mov rdx, qword ptr [rsi + 32]
   ;# f[0]
   mulx r14, r8, qword ptr [rsi + 40]
-  xor r15, r15
+  xor r15d, r15d
   ;# f[1]*f[0]
   mulx r10, r9, qword ptr [rsi + 48]
   adcx r9, r14
@@ -824,7 +824,7 @@ fsqr2_e proc
   ;# f[2]*f[1]
   
   ;# Step 2: Compute two parallel carry chains
-  xor r15, r15
+  xor r15d, r15d
   adox r10, rax
   adcx r8, r8
   adox r11, rcx
@@ -882,7 +882,7 @@ fsqr2_e proc
   ;# Step 1: Compute dst + carry == tmp_hi * 38 + tmp_lo
   mov rdx, 38
   mulx r13, r8, qword ptr [rsi + 32]
-  xor rcx, rcx
+  xor ecx, ecx
   adox r8, qword ptr [rsi + 0]
   mulx rbx, r9, qword ptr [rsi + 40]
   adcx r9, r13
@@ -915,7 +915,7 @@ fsqr2_e proc
   ;# Step 1: Compute dst + carry == tmp_hi * 38 + tmp_lo
   mov rdx, 38
   mulx r13, r8, qword ptr [rsi + 96]
-  xor rcx, rcx
+  xor ecx, ecx
   adox r8, qword ptr [rsi + 64]
   mulx rbx, r9, qword ptr [rsi + 104]
   adcx r9, r13

--- a/dist/msvc-compatible/curve25519-inline.h
+++ b/dist/msvc-compatible/curve25519-inline.h
@@ -10,11 +10,11 @@ static inline uint64_t add_scalar (uint64_t *out, uint64_t *f1, uint64_t f2)
 
   asm volatile(
     // Clear registers to propagate the carry bit
-    "  xor %%r8, %%r8;"
-    "  xor %%r9, %%r9;"
-    "  xor %%r10, %%r10;"
-    "  xor %%r11, %%r11;"
-    "  xor %1, %1;"
+    "  xor %%r8d, %%r8d;"
+    "  xor %%r9d, %%r9d;"
+    "  xor %%r10d, %%r10d;"
+    "  xor %%r11d, %%r11d;"
+    "  xor %k1, %k1;"
 
     // Begin addition chain
     "  addq 0(%3), %0;"
@@ -58,7 +58,7 @@ static inline void fadd (uint64_t *out, uint64_t *f1, uint64_t *f2)
     "  cmovc %0, %%rax;"
 
     // Step 2: Add carry*38 to the original sum
-    "  xor %%rcx, %%rcx;"
+    "  xor %%ecx, %%ecx;"
     "  add %%rax, %%r8;"
     "  adcx %%rcx, %%r9;"
     "  movq %%r9, 8(%1);"
@@ -131,7 +131,7 @@ static inline void fmul (uint64_t *out, uint64_t *f1, uint64_t *f2, uint64_t *tm
 
     // Compute src1[0] * src2
     "  movq 0(%1), %%rdx;"
-    "  mulxq 0(%2), %%r8, %%r9;"       "  xor %%r10, %%r10;"     "  movq %%r8, 0(%3);"
+    "  mulxq 0(%2), %%r8, %%r9;"       "  xor %%r10d, %%r10d;"     "  movq %%r8, 0(%3);"
     "  mulxq 8(%2), %%r10, %%r11;"     "  adox %%r9, %%r10;"     "  movq %%r10, 8(%3);"
     "  mulxq 16(%2), %%rbx, %%r13;"    "  adox %%r11, %%rbx;"
     "  mulxq 24(%2), %%r14, %%rdx;"    "  adox %%r13, %%r14;"    "  mov $0, %%rax;"
@@ -139,7 +139,7 @@ static inline void fmul (uint64_t *out, uint64_t *f1, uint64_t *f2, uint64_t *tm
 
     // Compute src1[1] * src2
     "  movq 8(%1), %%rdx;"
-    "  mulxq 0(%2), %%r8, %%r9;"       "  xor %%r10, %%r10;"     "  adcxq 8(%3), %%r8;"    "  movq %%r8, 8(%3);"
+    "  mulxq 0(%2), %%r8, %%r9;"       "  xor %%r10d, %%r10d;"     "  adcxq 8(%3), %%r8;"    "  movq %%r8, 8(%3);"
     "  mulxq 8(%2), %%r10, %%r11;"     "  adox %%r9, %%r10;"     "  adcx %%rbx, %%r10;"    "  movq %%r10, 16(%3);"
     "  mulxq 16(%2), %%rbx, %%r13;"    "  adox %%r11, %%rbx;"    "  adcx %%r14, %%rbx;"    "  mov $0, %%r8;"
     "  mulxq 24(%2), %%r14, %%rdx;"    "  adox %%r13, %%r14;"    "  adcx %%rax, %%r14;"    "  mov $0, %%rax;"
@@ -148,7 +148,7 @@ static inline void fmul (uint64_t *out, uint64_t *f1, uint64_t *f2, uint64_t *tm
 
     // Compute src1[2] * src2
     "  movq 16(%1), %%rdx;"
-    "  mulxq 0(%2), %%r8, %%r9;"       "  xor %%r10, %%r10;"    "  adcxq 16(%3), %%r8;"    "  movq %%r8, 16(%3);"
+    "  mulxq 0(%2), %%r8, %%r9;"       "  xor %%r10d, %%r10d;"    "  adcxq 16(%3), %%r8;"    "  movq %%r8, 16(%3);"
     "  mulxq 8(%2), %%r10, %%r11;"     "  adox %%r9, %%r10;"     "  adcx %%rbx, %%r10;"    "  movq %%r10, 24(%3);"
     "  mulxq 16(%2), %%rbx, %%r13;"    "  adox %%r11, %%rbx;"    "  adcx %%r14, %%rbx;"    "  mov $0, %%r8;"
     "  mulxq 24(%2), %%r14, %%rdx;"    "  adox %%r13, %%r14;"    "  adcx %%rax, %%r14;"    "  mov $0, %%rax;"
@@ -157,7 +157,7 @@ static inline void fmul (uint64_t *out, uint64_t *f1, uint64_t *f2, uint64_t *tm
 
     // Compute src1[3] * src2
     "  movq 24(%1), %%rdx;"
-    "  mulxq 0(%2), %%r8, %%r9;"       "  xor %%r10, %%r10;"    "  adcxq 24(%3), %%r8;"    "  movq %%r8, 24(%3);"
+    "  mulxq 0(%2), %%r8, %%r9;"       "  xor %%r10d, %%r10d;"    "  adcxq 24(%3), %%r8;"    "  movq %%r8, 24(%3);"
     "  mulxq 8(%2), %%r10, %%r11;"     "  adox %%r9, %%r10;"     "  adcx %%rbx, %%r10;"    "  movq %%r10, 32(%3);"
     "  mulxq 16(%2), %%rbx, %%r13;"    "  adox %%r11, %%rbx;"    "  adcx %%r14, %%rbx;"    "  movq %%rbx, 40(%3);"    "  mov $0, %%r8;"
     "  mulxq 24(%2), %%r14, %%rdx;"    "  adox %%r13, %%r14;"    "  adcx %%rax, %%r14;"    "  movq %%r14, 48(%3);"    "  mov $0, %%rax;"
@@ -172,7 +172,7 @@ static inline void fmul (uint64_t *out, uint64_t *f1, uint64_t *f2, uint64_t *tm
     // Step 1: Compute dst + carry == tmp_hi * 38 + tmp_lo
     "  mov $38, %%rdx;"
     "  mulxq 32(%1), %%r8, %%r13;"
-    "  xor %2, %2;"
+    "  xor %k2, %k2;"
     "  adoxq 0(%1), %%r8;"
     "  mulxq 40(%1), %%r9, %%rbx;"
     "  adcx %%r13, %%r9;"
@@ -219,7 +219,7 @@ static inline void fmul2 (uint64_t *out, uint64_t *f1, uint64_t *f2, uint64_t *t
 
     // Compute src1[0] * src2
     "  movq 0(%1), %%rdx;"
-    "  mulxq 0(%2), %%r8, %%r9;"       "  xor %%r10, %%r10;"     "  movq %%r8, 0(%3);"
+    "  mulxq 0(%2), %%r8, %%r9;"       "  xor %%r10d, %%r10d;"     "  movq %%r8, 0(%3);"
     "  mulxq 8(%2), %%r10, %%r11;"     "  adox %%r9, %%r10;"     "  movq %%r10, 8(%3);"
     "  mulxq 16(%2), %%rbx, %%r13;"    "  adox %%r11, %%rbx;"
     "  mulxq 24(%2), %%r14, %%rdx;"    "  adox %%r13, %%r14;"    "  mov $0, %%rax;"
@@ -227,7 +227,7 @@ static inline void fmul2 (uint64_t *out, uint64_t *f1, uint64_t *f2, uint64_t *t
 
     // Compute src1[1] * src2
     "  movq 8(%1), %%rdx;"
-    "  mulxq 0(%2), %%r8, %%r9;"       "  xor %%r10, %%r10;"     "  adcxq 8(%3), %%r8;"    "  movq %%r8, 8(%3);"
+    "  mulxq 0(%2), %%r8, %%r9;"       "  xor %%r10d, %%r10d;"     "  adcxq 8(%3), %%r8;"    "  movq %%r8, 8(%3);"
     "  mulxq 8(%2), %%r10, %%r11;"     "  adox %%r9, %%r10;"     "  adcx %%rbx, %%r10;"    "  movq %%r10, 16(%3);"
     "  mulxq 16(%2), %%rbx, %%r13;"    "  adox %%r11, %%rbx;"    "  adcx %%r14, %%rbx;"    "  mov $0, %%r8;"
     "  mulxq 24(%2), %%r14, %%rdx;"    "  adox %%r13, %%r14;"    "  adcx %%rax, %%r14;"    "  mov $0, %%rax;"
@@ -236,7 +236,7 @@ static inline void fmul2 (uint64_t *out, uint64_t *f1, uint64_t *f2, uint64_t *t
 
     // Compute src1[2] * src2
     "  movq 16(%1), %%rdx;"
-    "  mulxq 0(%2), %%r8, %%r9;"       "  xor %%r10, %%r10;"    "  adcxq 16(%3), %%r8;"    "  movq %%r8, 16(%3);"
+    "  mulxq 0(%2), %%r8, %%r9;"       "  xor %%r10d, %%r10d;"    "  adcxq 16(%3), %%r8;"    "  movq %%r8, 16(%3);"
     "  mulxq 8(%2), %%r10, %%r11;"     "  adox %%r9, %%r10;"     "  adcx %%rbx, %%r10;"    "  movq %%r10, 24(%3);"
     "  mulxq 16(%2), %%rbx, %%r13;"    "  adox %%r11, %%rbx;"    "  adcx %%r14, %%rbx;"    "  mov $0, %%r8;"
     "  mulxq 24(%2), %%r14, %%rdx;"    "  adox %%r13, %%r14;"    "  adcx %%rax, %%r14;"    "  mov $0, %%rax;"
@@ -245,7 +245,7 @@ static inline void fmul2 (uint64_t *out, uint64_t *f1, uint64_t *f2, uint64_t *t
 
     // Compute src1[3] * src2
     "  movq 24(%1), %%rdx;"
-    "  mulxq 0(%2), %%r8, %%r9;"       "  xor %%r10, %%r10;"    "  adcxq 24(%3), %%r8;"    "  movq %%r8, 24(%3);"
+    "  mulxq 0(%2), %%r8, %%r9;"       "  xor %%r10d, %%r10d;"    "  adcxq 24(%3), %%r8;"    "  movq %%r8, 24(%3);"
     "  mulxq 8(%2), %%r10, %%r11;"     "  adox %%r9, %%r10;"     "  adcx %%rbx, %%r10;"    "  movq %%r10, 32(%3);"
     "  mulxq 16(%2), %%rbx, %%r13;"    "  adox %%r11, %%rbx;"    "  adcx %%r14, %%rbx;"    "  movq %%rbx, 40(%3);"    "  mov $0, %%r8;"
     "  mulxq 24(%2), %%r14, %%rdx;"    "  adox %%r13, %%r14;"    "  adcx %%rax, %%r14;"    "  movq %%r14, 48(%3);"    "  mov $0, %%rax;"
@@ -255,7 +255,7 @@ static inline void fmul2 (uint64_t *out, uint64_t *f1, uint64_t *f2, uint64_t *t
 
     // Compute src1[0] * src2
     "  movq 32(%1), %%rdx;"
-    "  mulxq 32(%2), %%r8, %%r9;"       "  xor %%r10, %%r10;"     "  movq %%r8, 64(%3);"
+    "  mulxq 32(%2), %%r8, %%r9;"       "  xor %%r10d, %%r10d;"     "  movq %%r8, 64(%3);"
     "  mulxq 40(%2), %%r10, %%r11;"     "  adox %%r9, %%r10;"     "  movq %%r10, 72(%3);"
     "  mulxq 48(%2), %%rbx, %%r13;"    "  adox %%r11, %%rbx;"
     "  mulxq 56(%2), %%r14, %%rdx;"    "  adox %%r13, %%r14;"    "  mov $0, %%rax;"
@@ -263,7 +263,7 @@ static inline void fmul2 (uint64_t *out, uint64_t *f1, uint64_t *f2, uint64_t *t
 
     // Compute src1[1] * src2
     "  movq 40(%1), %%rdx;"
-    "  mulxq 32(%2), %%r8, %%r9;"       "  xor %%r10, %%r10;"     "  adcxq 72(%3), %%r8;"    "  movq %%r8, 72(%3);"
+    "  mulxq 32(%2), %%r8, %%r9;"       "  xor %%r10d, %%r10d;"     "  adcxq 72(%3), %%r8;"    "  movq %%r8, 72(%3);"
     "  mulxq 40(%2), %%r10, %%r11;"     "  adox %%r9, %%r10;"     "  adcx %%rbx, %%r10;"    "  movq %%r10, 80(%3);"
     "  mulxq 48(%2), %%rbx, %%r13;"    "  adox %%r11, %%rbx;"    "  adcx %%r14, %%rbx;"    "  mov $0, %%r8;"
     "  mulxq 56(%2), %%r14, %%rdx;"    "  adox %%r13, %%r14;"    "  adcx %%rax, %%r14;"    "  mov $0, %%rax;"
@@ -272,7 +272,7 @@ static inline void fmul2 (uint64_t *out, uint64_t *f1, uint64_t *f2, uint64_t *t
 
     // Compute src1[2] * src2
     "  movq 48(%1), %%rdx;"
-    "  mulxq 32(%2), %%r8, %%r9;"       "  xor %%r10, %%r10;"    "  adcxq 80(%3), %%r8;"    "  movq %%r8, 80(%3);"
+    "  mulxq 32(%2), %%r8, %%r9;"       "  xor %%r10d, %%r10d;"    "  adcxq 80(%3), %%r8;"    "  movq %%r8, 80(%3);"
     "  mulxq 40(%2), %%r10, %%r11;"     "  adox %%r9, %%r10;"     "  adcx %%rbx, %%r10;"    "  movq %%r10, 88(%3);"
     "  mulxq 48(%2), %%rbx, %%r13;"    "  adox %%r11, %%rbx;"    "  adcx %%r14, %%rbx;"    "  mov $0, %%r8;"
     "  mulxq 56(%2), %%r14, %%rdx;"    "  adox %%r13, %%r14;"    "  adcx %%rax, %%r14;"    "  mov $0, %%rax;"
@@ -281,7 +281,7 @@ static inline void fmul2 (uint64_t *out, uint64_t *f1, uint64_t *f2, uint64_t *t
 
     // Compute src1[3] * src2
     "  movq 56(%1), %%rdx;"
-    "  mulxq 32(%2), %%r8, %%r9;"       "  xor %%r10, %%r10;"    "  adcxq 88(%3), %%r8;"    "  movq %%r8, 88(%3);"
+    "  mulxq 32(%2), %%r8, %%r9;"       "  xor %%r10d, %%r10d;"    "  adcxq 88(%3), %%r8;"    "  movq %%r8, 88(%3);"
     "  mulxq 40(%2), %%r10, %%r11;"     "  adox %%r9, %%r10;"     "  adcx %%rbx, %%r10;"    "  movq %%r10, 96(%3);"
     "  mulxq 48(%2), %%rbx, %%r13;"    "  adox %%r11, %%rbx;"    "  adcx %%r14, %%rbx;"    "  movq %%rbx, 104(%3);"    "  mov $0, %%r8;"
     "  mulxq 56(%2), %%r14, %%rdx;"    "  adox %%r13, %%r14;"    "  adcx %%rax, %%r14;"    "  movq %%r14, 112(%3);"    "  mov $0, %%rax;"
@@ -296,7 +296,7 @@ static inline void fmul2 (uint64_t *out, uint64_t *f1, uint64_t *f2, uint64_t *t
     // Step 1: Compute dst + carry == tmp_hi * 38 + tmp_lo
     "  mov $38, %%rdx;"
     "  mulxq 32(%1), %%r8, %%r13;"
-    "  xor %2, %2;"
+    "  xor %k2, %k2;"
     "  adoxq 0(%1), %%r8;"
     "  mulxq 40(%1), %%r9, %%rbx;"
     "  adcx %%r13, %%r9;"
@@ -329,7 +329,7 @@ static inline void fmul2 (uint64_t *out, uint64_t *f1, uint64_t *f2, uint64_t *t
     // Step 1: Compute dst + carry == tmp_hi * 38 + tmp_lo
     "  mov $38, %%rdx;"
     "  mulxq 96(%1), %%r8, %%r13;"
-    "  xor %2, %2;"
+    "  xor %k2, %k2;"
     "  adoxq 64(%1), %%r8;"
     "  mulxq 104(%1), %%r9, %%rbx;"
     "  adcx %%r13, %%r9;"
@@ -502,7 +502,7 @@ static inline void fsqr (uint64_t *out, uint64_t *f, uint64_t *tmp)
 
     // Step 1: Compute all partial products
     "  movq 0(%1), %%rdx;"                                       // f[0]
-    "  mulxq 8(%1), %%r8, %%r14;"      "  xor %%r15, %%r15;"     // f[1]*f[0]
+    "  mulxq 8(%1), %%r8, %%r14;"      "  xor %%r15d, %%r15d;"     // f[1]*f[0]
     "  mulxq 16(%1), %%r9, %%r10;"     "  adcx %%r14, %%r9;"     // f[2]*f[0]
     "  mulxq 24(%1), %%rax, %%rcx;"    "  adcx %%rax, %%r10;"    // f[3]*f[0]
     "  movq 24(%1), %%rdx;"                                      // f[3]
@@ -512,7 +512,7 @@ static inline void fsqr (uint64_t *out, uint64_t *f, uint64_t *tmp)
     "  mulxq 16(%1), %%rax, %%rcx;"    "  mov $0, %%r14;"        // f[2]*f[1]
 
     // Step 2: Compute two parallel carry chains
-    "  xor %%r15, %%r15;"
+    "  xor %%r15d, %%r15d;"
     "  adox %%rax, %%r10;"
     "  adcx %%r8, %%r8;"
     "  adox %%rcx, %%r11;"
@@ -549,7 +549,7 @@ static inline void fsqr (uint64_t *out, uint64_t *f, uint64_t *tmp)
     // Step 1: Compute dst + carry == tmp_hi * 38 + tmp_lo
     "  mov $38, %%rdx;"
     "  mulxq 32(%1), %%r8, %%r13;"
-    "  xor %%rcx, %%rcx;"
+    "  xor %%ecx, %%ecx;"
     "  adoxq 0(%1), %%r8;"
     "  mulxq 40(%1), %%r9, %%rbx;"
     "  adcx %%r13, %%r9;"
@@ -593,7 +593,7 @@ static inline void fsqr2 (uint64_t *out, uint64_t *f, uint64_t *tmp)
   asm volatile(
     // Step 1: Compute all partial products
     "  movq 0(%1), %%rdx;"                                       // f[0]
-    "  mulxq 8(%1), %%r8, %%r14;"      "  xor %%r15, %%r15;"     // f[1]*f[0]
+    "  mulxq 8(%1), %%r8, %%r14;"      "  xor %%r15d, %%r15d;"     // f[1]*f[0]
     "  mulxq 16(%1), %%r9, %%r10;"     "  adcx %%r14, %%r9;"     // f[2]*f[0]
     "  mulxq 24(%1), %%rax, %%rcx;"    "  adcx %%rax, %%r10;"    // f[3]*f[0]
     "  movq 24(%1), %%rdx;"                                      // f[3]
@@ -603,7 +603,7 @@ static inline void fsqr2 (uint64_t *out, uint64_t *f, uint64_t *tmp)
     "  mulxq 16(%1), %%rax, %%rcx;"    "  mov $0, %%r14;"        // f[2]*f[1]
 
     // Step 2: Compute two parallel carry chains
-    "  xor %%r15, %%r15;"
+    "  xor %%r15d, %%r15d;"
     "  adox %%rax, %%r10;"
     "  adcx %%r8, %%r8;"
     "  adox %%rcx, %%r11;"
@@ -633,7 +633,7 @@ static inline void fsqr2 (uint64_t *out, uint64_t *f, uint64_t *tmp)
 
     // Step 1: Compute all partial products
     "  movq 32(%1), %%rdx;"                                       // f[0]
-    "  mulxq 40(%1), %%r8, %%r14;"      "  xor %%r15, %%r15;"     // f[1]*f[0]
+    "  mulxq 40(%1), %%r8, %%r14;"      "  xor %%r15d, %%r15d;"     // f[1]*f[0]
     "  mulxq 48(%1), %%r9, %%r10;"     "  adcx %%r14, %%r9;"     // f[2]*f[0]
     "  mulxq 56(%1), %%rax, %%rcx;"    "  adcx %%rax, %%r10;"    // f[3]*f[0]
     "  movq 56(%1), %%rdx;"                                      // f[3]
@@ -643,7 +643,7 @@ static inline void fsqr2 (uint64_t *out, uint64_t *f, uint64_t *tmp)
     "  mulxq 48(%1), %%rax, %%rcx;"    "  mov $0, %%r14;"        // f[2]*f[1]
 
     // Step 2: Compute two parallel carry chains
-    "  xor %%r15, %%r15;"
+    "  xor %%r15d, %%r15d;"
     "  adox %%rax, %%r10;"
     "  adcx %%r8, %%r8;"
     "  adox %%rcx, %%r11;"
@@ -678,7 +678,7 @@ static inline void fsqr2 (uint64_t *out, uint64_t *f, uint64_t *tmp)
     // Step 1: Compute dst + carry == tmp_hi * 38 + tmp_lo
     "  mov $38, %%rdx;"
     "  mulxq 32(%1), %%r8, %%r13;"
-    "  xor %%rcx, %%rcx;"
+    "  xor %%ecx, %%ecx;"
     "  adoxq 0(%1), %%r8;"
     "  mulxq 40(%1), %%r9, %%rbx;"
     "  adcx %%r13, %%r9;"
@@ -711,7 +711,7 @@ static inline void fsqr2 (uint64_t *out, uint64_t *f, uint64_t *tmp)
     // Step 1: Compute dst + carry == tmp_hi * 38 + tmp_lo
     "  mov $38, %%rdx;"
     "  mulxq 96(%1), %%r8, %%r13;"
-    "  xor %%rcx, %%rcx;"
+    "  xor %%ecx, %%ecx;"
     "  adoxq 64(%1), %%r8;"
     "  mulxq 104(%1), %%r9, %%rbx;"
     "  adcx %%r13, %%r9;"

--- a/dist/msvc-compatible/curve25519-x86_64-darwin.S
+++ b/dist/msvc-compatible/curve25519-x86_64-darwin.S
@@ -4,11 +4,11 @@ _add_scalar_e:
   push %rdi
   push %rsi
   ;# Clear registers to propagate the carry bit
-  xor %r8, %r8
-  xor %r9, %r9
-  xor %r10, %r10
-  xor %r11, %r11
-  xor %rax, %rax
+  xor %r8d, %r8d
+  xor %r9d, %r9d
+  xor %r10d, %r10d
+  xor %r11d, %r11d
+  xor %eax, %eax
   
   ;# Begin addition chain
   addq 0(%rsi), %rdx
@@ -44,7 +44,7 @@ _fadd_e:
   cmovc %rdx, %rax
   
   ;# Step 2: Add carry*38 to the original sum
-  xor %rcx, %rcx
+  xor %ecx, %ecx
   add %rax, %r8
   adcx %rcx, %r9
   movq %r9, 8(%rdi)
@@ -149,7 +149,7 @@ _fmul_e:
   ;# Compute src1[0] * src2
   movq 0(%rsi), %rdx
   mulxq 0(%rcx), %r8, %r9
-  xor %r10, %r10
+  xor %r10d, %r10d
   movq %r8, 0(%rdi)
   
   mulxq 8(%rcx), %r10, %r11
@@ -167,7 +167,7 @@ _fmul_e:
   ;# Compute src1[1] * src2
   movq 8(%rsi), %rdx
   mulxq 0(%rcx), %r8, %r9
-  xor %r10, %r10
+  xor %r10d, %r10d
   adcxq 8(%rdi), %r8
   movq %r8, 8(%rdi)
   mulxq 8(%rcx), %r10, %r11
@@ -189,7 +189,7 @@ _fmul_e:
   ;# Compute src1[2] * src2
   movq 16(%rsi), %rdx
   mulxq 0(%rcx), %r8, %r9
-  xor %r10, %r10
+  xor %r10d, %r10d
   adcxq 16(%rdi), %r8
   movq %r8, 16(%rdi)
   mulxq 8(%rcx), %r10, %r11
@@ -211,7 +211,7 @@ _fmul_e:
   ;# Compute src1[3] * src2
   movq 24(%rsi), %rdx
   mulxq 0(%rcx), %r8, %r9
-  xor %r10, %r10
+  xor %r10d, %r10d
   adcxq 24(%rdi), %r8
   movq %r8, 24(%rdi)
   mulxq 8(%rcx), %r10, %r11
@@ -240,7 +240,7 @@ _fmul_e:
   ;# Step 1: Compute dst + carry == tmp_hi * 38 + tmp_lo
   mov $38, %rdx
   mulxq 32(%rsi), %r8, %r13
-  xor %rcx, %rcx
+  xor %ecx, %ecx
   adoxq 0(%rsi), %r8
   mulxq 40(%rsi), %r9, %rbx
   adcx %r13, %r9
@@ -286,7 +286,7 @@ _fmul2_e:
   ;# Compute src1[0] * src2
   movq 0(%rsi), %rdx
   mulxq 0(%rcx), %r8, %r9
-  xor %r10, %r10
+  xor %r10d, %r10d
   movq %r8, 0(%rdi)
   
   mulxq 8(%rcx), %r10, %r11
@@ -304,7 +304,7 @@ _fmul2_e:
   ;# Compute src1[1] * src2
   movq 8(%rsi), %rdx
   mulxq 0(%rcx), %r8, %r9
-  xor %r10, %r10
+  xor %r10d, %r10d
   adcxq 8(%rdi), %r8
   movq %r8, 8(%rdi)
   mulxq 8(%rcx), %r10, %r11
@@ -326,7 +326,7 @@ _fmul2_e:
   ;# Compute src1[2] * src2
   movq 16(%rsi), %rdx
   mulxq 0(%rcx), %r8, %r9
-  xor %r10, %r10
+  xor %r10d, %r10d
   adcxq 16(%rdi), %r8
   movq %r8, 16(%rdi)
   mulxq 8(%rcx), %r10, %r11
@@ -348,7 +348,7 @@ _fmul2_e:
   ;# Compute src1[3] * src2
   movq 24(%rsi), %rdx
   mulxq 0(%rcx), %r8, %r9
-  xor %r10, %r10
+  xor %r10d, %r10d
   adcxq 24(%rdi), %r8
   movq %r8, 24(%rdi)
   mulxq 8(%rcx), %r10, %r11
@@ -373,7 +373,7 @@ _fmul2_e:
   ;# Compute src1[0] * src2
   movq 32(%rsi), %rdx
   mulxq 32(%rcx), %r8, %r9
-  xor %r10, %r10
+  xor %r10d, %r10d
   movq %r8, 64(%rdi)
   
   mulxq 40(%rcx), %r10, %r11
@@ -391,7 +391,7 @@ _fmul2_e:
   ;# Compute src1[1] * src2
   movq 40(%rsi), %rdx
   mulxq 32(%rcx), %r8, %r9
-  xor %r10, %r10
+  xor %r10d, %r10d
   adcxq 72(%rdi), %r8
   movq %r8, 72(%rdi)
   mulxq 40(%rcx), %r10, %r11
@@ -413,7 +413,7 @@ _fmul2_e:
   ;# Compute src1[2] * src2
   movq 48(%rsi), %rdx
   mulxq 32(%rcx), %r8, %r9
-  xor %r10, %r10
+  xor %r10d, %r10d
   adcxq 80(%rdi), %r8
   movq %r8, 80(%rdi)
   mulxq 40(%rcx), %r10, %r11
@@ -435,7 +435,7 @@ _fmul2_e:
   ;# Compute src1[3] * src2
   movq 56(%rsi), %rdx
   mulxq 32(%rcx), %r8, %r9
-  xor %r10, %r10
+  xor %r10d, %r10d
   adcxq 88(%rdi), %r8
   movq %r8, 88(%rdi)
   mulxq 40(%rcx), %r10, %r11
@@ -464,7 +464,7 @@ _fmul2_e:
   ;# Step 1: Compute dst + carry == tmp_hi * 38 + tmp_lo
   mov $38, %rdx
   mulxq 32(%rsi), %r8, %r13
-  xor %rcx, %rcx
+  xor %ecx, %ecx
   adoxq 0(%rsi), %r8
   mulxq 40(%rsi), %r9, %rbx
   adcx %r13, %r9
@@ -497,7 +497,7 @@ _fmul2_e:
   ;# Step 1: Compute dst + carry == tmp_hi * 38 + tmp_lo
   mov $38, %rdx
   mulxq 96(%rsi), %r8, %r13
-  xor %rcx, %rcx
+  xor %ecx, %ecx
   adoxq 64(%rsi), %r8
   mulxq 104(%rsi), %r9, %rbx
   adcx %r13, %r9
@@ -545,7 +545,7 @@ _fsqr_e:
   movq 0(%rsi), %rdx
   ;# f[0]
   mulxq 8(%rsi), %r8, %r14
-  xor %r15, %r15
+  xor %r15d, %r15d
   ;# f[1]*f[0]
   mulxq 16(%rsi), %r9, %r10
   adcx %r14, %r9
@@ -569,7 +569,7 @@ _fsqr_e:
   ;# f[2]*f[1]
   
   ;# Step 2: Compute two parallel carry chains
-  xor %r15, %r15
+  xor %r15d, %r15d
   adox %rax, %r10
   adcx %r8, %r8
   adox %rcx, %r11
@@ -627,7 +627,7 @@ _fsqr_e:
   ;# Step 1: Compute dst + carry == tmp_hi * 38 + tmp_lo
   mov $38, %rdx
   mulxq 32(%rsi), %r8, %r13
-  xor %rcx, %rcx
+  xor %ecx, %ecx
   adoxq 0(%rsi), %r8
   mulxq 40(%rsi), %r9, %rbx
   adcx %r13, %r9
@@ -675,7 +675,7 @@ _fsqr2_e:
   movq 0(%rsi), %rdx
   ;# f[0]
   mulxq 8(%rsi), %r8, %r14
-  xor %r15, %r15
+  xor %r15d, %r15d
   ;# f[1]*f[0]
   mulxq 16(%rsi), %r9, %r10
   adcx %r14, %r9
@@ -699,7 +699,7 @@ _fsqr2_e:
   ;# f[2]*f[1]
   
   ;# Step 2: Compute two parallel carry chains
-  xor %r15, %r15
+  xor %r15d, %r15d
   adox %rax, %r10
   adcx %r8, %r8
   adox %rcx, %r11
@@ -754,7 +754,7 @@ _fsqr2_e:
   movq 32(%rsi), %rdx
   ;# f[0]
   mulxq 40(%rsi), %r8, %r14
-  xor %r15, %r15
+  xor %r15d, %r15d
   ;# f[1]*f[0]
   mulxq 48(%rsi), %r9, %r10
   adcx %r14, %r9
@@ -778,7 +778,7 @@ _fsqr2_e:
   ;# f[2]*f[1]
   
   ;# Step 2: Compute two parallel carry chains
-  xor %r15, %r15
+  xor %r15d, %r15d
   adox %rax, %r10
   adcx %r8, %r8
   adox %rcx, %r11
@@ -836,7 +836,7 @@ _fsqr2_e:
   ;# Step 1: Compute dst + carry == tmp_hi * 38 + tmp_lo
   mov $38, %rdx
   mulxq 32(%rsi), %r8, %r13
-  xor %rcx, %rcx
+  xor %ecx, %ecx
   adoxq 0(%rsi), %r8
   mulxq 40(%rsi), %r9, %rbx
   adcx %r13, %r9
@@ -869,7 +869,7 @@ _fsqr2_e:
   ;# Step 1: Compute dst + carry == tmp_hi * 38 + tmp_lo
   mov $38, %rdx
   mulxq 96(%rsi), %r8, %r13
-  xor %rcx, %rcx
+  xor %ecx, %ecx
   adoxq 64(%rsi), %r8
   mulxq 104(%rsi), %r9, %rbx
   adcx %r13, %r9

--- a/dist/msvc-compatible/curve25519-x86_64-linux.S
+++ b/dist/msvc-compatible/curve25519-x86_64-linux.S
@@ -4,11 +4,11 @@ add_scalar_e:
   push %rdi
   push %rsi
   ;# Clear registers to propagate the carry bit
-  xor %r8, %r8
-  xor %r9, %r9
-  xor %r10, %r10
-  xor %r11, %r11
-  xor %rax, %rax
+  xor %r8d, %r8d
+  xor %r9d, %r9d
+  xor %r10d, %r10d
+  xor %r11d, %r11d
+  xor %eax, %eax
   
   ;# Begin addition chain
   addq 0(%rsi), %rdx
@@ -44,7 +44,7 @@ fadd_e:
   cmovc %rdx, %rax
   
   ;# Step 2: Add carry*38 to the original sum
-  xor %rcx, %rcx
+  xor %ecx, %ecx
   add %rax, %r8
   adcx %rcx, %r9
   movq %r9, 8(%rdi)
@@ -149,7 +149,7 @@ fmul_e:
   ;# Compute src1[0] * src2
   movq 0(%rsi), %rdx
   mulxq 0(%rcx), %r8, %r9
-  xor %r10, %r10
+  xor %r10d, %r10d
   movq %r8, 0(%rdi)
   
   mulxq 8(%rcx), %r10, %r11
@@ -167,7 +167,7 @@ fmul_e:
   ;# Compute src1[1] * src2
   movq 8(%rsi), %rdx
   mulxq 0(%rcx), %r8, %r9
-  xor %r10, %r10
+  xor %r10d, %r10d
   adcxq 8(%rdi), %r8
   movq %r8, 8(%rdi)
   mulxq 8(%rcx), %r10, %r11
@@ -189,7 +189,7 @@ fmul_e:
   ;# Compute src1[2] * src2
   movq 16(%rsi), %rdx
   mulxq 0(%rcx), %r8, %r9
-  xor %r10, %r10
+  xor %r10d, %r10d
   adcxq 16(%rdi), %r8
   movq %r8, 16(%rdi)
   mulxq 8(%rcx), %r10, %r11
@@ -211,7 +211,7 @@ fmul_e:
   ;# Compute src1[3] * src2
   movq 24(%rsi), %rdx
   mulxq 0(%rcx), %r8, %r9
-  xor %r10, %r10
+  xor %r10d, %r10d
   adcxq 24(%rdi), %r8
   movq %r8, 24(%rdi)
   mulxq 8(%rcx), %r10, %r11
@@ -240,7 +240,7 @@ fmul_e:
   ;# Step 1: Compute dst + carry == tmp_hi * 38 + tmp_lo
   mov $38, %rdx
   mulxq 32(%rsi), %r8, %r13
-  xor %rcx, %rcx
+  xor %ecx, %ecx
   adoxq 0(%rsi), %r8
   mulxq 40(%rsi), %r9, %rbx
   adcx %r13, %r9
@@ -286,7 +286,7 @@ fmul2_e:
   ;# Compute src1[0] * src2
   movq 0(%rsi), %rdx
   mulxq 0(%rcx), %r8, %r9
-  xor %r10, %r10
+  xor %r10d, %r10d
   movq %r8, 0(%rdi)
   
   mulxq 8(%rcx), %r10, %r11
@@ -304,7 +304,7 @@ fmul2_e:
   ;# Compute src1[1] * src2
   movq 8(%rsi), %rdx
   mulxq 0(%rcx), %r8, %r9
-  xor %r10, %r10
+  xor %r10d, %r10d
   adcxq 8(%rdi), %r8
   movq %r8, 8(%rdi)
   mulxq 8(%rcx), %r10, %r11
@@ -326,7 +326,7 @@ fmul2_e:
   ;# Compute src1[2] * src2
   movq 16(%rsi), %rdx
   mulxq 0(%rcx), %r8, %r9
-  xor %r10, %r10
+  xor %r10d, %r10d
   adcxq 16(%rdi), %r8
   movq %r8, 16(%rdi)
   mulxq 8(%rcx), %r10, %r11
@@ -348,7 +348,7 @@ fmul2_e:
   ;# Compute src1[3] * src2
   movq 24(%rsi), %rdx
   mulxq 0(%rcx), %r8, %r9
-  xor %r10, %r10
+  xor %r10d, %r10d
   adcxq 24(%rdi), %r8
   movq %r8, 24(%rdi)
   mulxq 8(%rcx), %r10, %r11
@@ -373,7 +373,7 @@ fmul2_e:
   ;# Compute src1[0] * src2
   movq 32(%rsi), %rdx
   mulxq 32(%rcx), %r8, %r9
-  xor %r10, %r10
+  xor %r10d, %r10d
   movq %r8, 64(%rdi)
   
   mulxq 40(%rcx), %r10, %r11
@@ -391,7 +391,7 @@ fmul2_e:
   ;# Compute src1[1] * src2
   movq 40(%rsi), %rdx
   mulxq 32(%rcx), %r8, %r9
-  xor %r10, %r10
+  xor %r10d, %r10d
   adcxq 72(%rdi), %r8
   movq %r8, 72(%rdi)
   mulxq 40(%rcx), %r10, %r11
@@ -413,7 +413,7 @@ fmul2_e:
   ;# Compute src1[2] * src2
   movq 48(%rsi), %rdx
   mulxq 32(%rcx), %r8, %r9
-  xor %r10, %r10
+  xor %r10d, %r10d
   adcxq 80(%rdi), %r8
   movq %r8, 80(%rdi)
   mulxq 40(%rcx), %r10, %r11
@@ -435,7 +435,7 @@ fmul2_e:
   ;# Compute src1[3] * src2
   movq 56(%rsi), %rdx
   mulxq 32(%rcx), %r8, %r9
-  xor %r10, %r10
+  xor %r10d, %r10d
   adcxq 88(%rdi), %r8
   movq %r8, 88(%rdi)
   mulxq 40(%rcx), %r10, %r11
@@ -464,7 +464,7 @@ fmul2_e:
   ;# Step 1: Compute dst + carry == tmp_hi * 38 + tmp_lo
   mov $38, %rdx
   mulxq 32(%rsi), %r8, %r13
-  xor %rcx, %rcx
+  xor %ecx, %ecx
   adoxq 0(%rsi), %r8
   mulxq 40(%rsi), %r9, %rbx
   adcx %r13, %r9
@@ -497,7 +497,7 @@ fmul2_e:
   ;# Step 1: Compute dst + carry == tmp_hi * 38 + tmp_lo
   mov $38, %rdx
   mulxq 96(%rsi), %r8, %r13
-  xor %rcx, %rcx
+  xor %ecx, %ecx
   adoxq 64(%rsi), %r8
   mulxq 104(%rsi), %r9, %rbx
   adcx %r13, %r9
@@ -545,7 +545,7 @@ fsqr_e:
   movq 0(%rsi), %rdx
   ;# f[0]
   mulxq 8(%rsi), %r8, %r14
-  xor %r15, %r15
+  xor %r15d, %r15d
   ;# f[1]*f[0]
   mulxq 16(%rsi), %r9, %r10
   adcx %r14, %r9
@@ -569,7 +569,7 @@ fsqr_e:
   ;# f[2]*f[1]
   
   ;# Step 2: Compute two parallel carry chains
-  xor %r15, %r15
+  xor %r15d, %r15d
   adox %rax, %r10
   adcx %r8, %r8
   adox %rcx, %r11
@@ -627,7 +627,7 @@ fsqr_e:
   ;# Step 1: Compute dst + carry == tmp_hi * 38 + tmp_lo
   mov $38, %rdx
   mulxq 32(%rsi), %r8, %r13
-  xor %rcx, %rcx
+  xor %ecx, %ecx
   adoxq 0(%rsi), %r8
   mulxq 40(%rsi), %r9, %rbx
   adcx %r13, %r9
@@ -675,7 +675,7 @@ fsqr2_e:
   movq 0(%rsi), %rdx
   ;# f[0]
   mulxq 8(%rsi), %r8, %r14
-  xor %r15, %r15
+  xor %r15d, %r15d
   ;# f[1]*f[0]
   mulxq 16(%rsi), %r9, %r10
   adcx %r14, %r9
@@ -699,7 +699,7 @@ fsqr2_e:
   ;# f[2]*f[1]
   
   ;# Step 2: Compute two parallel carry chains
-  xor %r15, %r15
+  xor %r15d, %r15d
   adox %rax, %r10
   adcx %r8, %r8
   adox %rcx, %r11
@@ -754,7 +754,7 @@ fsqr2_e:
   movq 32(%rsi), %rdx
   ;# f[0]
   mulxq 40(%rsi), %r8, %r14
-  xor %r15, %r15
+  xor %r15d, %r15d
   ;# f[1]*f[0]
   mulxq 48(%rsi), %r9, %r10
   adcx %r14, %r9
@@ -778,7 +778,7 @@ fsqr2_e:
   ;# f[2]*f[1]
   
   ;# Step 2: Compute two parallel carry chains
-  xor %r15, %r15
+  xor %r15d, %r15d
   adox %rax, %r10
   adcx %r8, %r8
   adox %rcx, %r11
@@ -836,7 +836,7 @@ fsqr2_e:
   ;# Step 1: Compute dst + carry == tmp_hi * 38 + tmp_lo
   mov $38, %rdx
   mulxq 32(%rsi), %r8, %r13
-  xor %rcx, %rcx
+  xor %ecx, %ecx
   adoxq 0(%rsi), %r8
   mulxq 40(%rsi), %r9, %rbx
   adcx %r13, %r9
@@ -869,7 +869,7 @@ fsqr2_e:
   ;# Step 1: Compute dst + carry == tmp_hi * 38 + tmp_lo
   mov $38, %rdx
   mulxq 96(%rsi), %r8, %r13
-  xor %rcx, %rcx
+  xor %ecx, %ecx
   adoxq 64(%rsi), %r8
   mulxq 104(%rsi), %r9, %rbx
   adcx %r13, %r9

--- a/dist/msvc-compatible/curve25519-x86_64-mingw.S
+++ b/dist/msvc-compatible/curve25519-x86_64-mingw.S
@@ -7,11 +7,11 @@ add_scalar_e:
   mov %rdx, %rsi
   mov %r8, %rdx
   ;# Clear registers to propagate the carry bit
-  xor %r8, %r8
-  xor %r9, %r9
-  xor %r10, %r10
-  xor %r11, %r11
-  xor %rax, %rax
+  xor %r8d, %r8d
+  xor %r9d, %r9d
+  xor %r10d, %r10d
+  xor %r11d, %r11d
+  xor %eax, %eax
   
   ;# Begin addition chain
   addq 0(%rsi), %rdx
@@ -52,7 +52,7 @@ fadd_e:
   cmovc %rdx, %rax
   
   ;# Step 2: Add carry*38 to the original sum
-  xor %rcx, %rcx
+  xor %ecx, %ecx
   add %rax, %r8
   adcx %rcx, %r9
   movq %r9, 8(%rdi)
@@ -176,7 +176,7 @@ fmul_e:
   ;# Compute src1[0] * src2
   movq 0(%rsi), %rdx
   mulxq 0(%rcx), %r8, %r9
-  xor %r10, %r10
+  xor %r10d, %r10d
   movq %r8, 0(%rdi)
   
   mulxq 8(%rcx), %r10, %r11
@@ -194,7 +194,7 @@ fmul_e:
   ;# Compute src1[1] * src2
   movq 8(%rsi), %rdx
   mulxq 0(%rcx), %r8, %r9
-  xor %r10, %r10
+  xor %r10d, %r10d
   adcxq 8(%rdi), %r8
   movq %r8, 8(%rdi)
   mulxq 8(%rcx), %r10, %r11
@@ -216,7 +216,7 @@ fmul_e:
   ;# Compute src1[2] * src2
   movq 16(%rsi), %rdx
   mulxq 0(%rcx), %r8, %r9
-  xor %r10, %r10
+  xor %r10d, %r10d
   adcxq 16(%rdi), %r8
   movq %r8, 16(%rdi)
   mulxq 8(%rcx), %r10, %r11
@@ -238,7 +238,7 @@ fmul_e:
   ;# Compute src1[3] * src2
   movq 24(%rsi), %rdx
   mulxq 0(%rcx), %r8, %r9
-  xor %r10, %r10
+  xor %r10d, %r10d
   adcxq 24(%rdi), %r8
   movq %r8, 24(%rdi)
   mulxq 8(%rcx), %r10, %r11
@@ -267,7 +267,7 @@ fmul_e:
   ;# Step 1: Compute dst + carry == tmp_hi * 38 + tmp_lo
   mov $38, %rdx
   mulxq 32(%rsi), %r8, %r13
-  xor %rcx, %rcx
+  xor %ecx, %ecx
   adoxq 0(%rsi), %r8
   mulxq 40(%rsi), %r9, %rbx
   adcx %r13, %r9
@@ -320,7 +320,7 @@ fmul2_e:
   ;# Compute src1[0] * src2
   movq 0(%rsi), %rdx
   mulxq 0(%rcx), %r8, %r9
-  xor %r10, %r10
+  xor %r10d, %r10d
   movq %r8, 0(%rdi)
   
   mulxq 8(%rcx), %r10, %r11
@@ -338,7 +338,7 @@ fmul2_e:
   ;# Compute src1[1] * src2
   movq 8(%rsi), %rdx
   mulxq 0(%rcx), %r8, %r9
-  xor %r10, %r10
+  xor %r10d, %r10d
   adcxq 8(%rdi), %r8
   movq %r8, 8(%rdi)
   mulxq 8(%rcx), %r10, %r11
@@ -360,7 +360,7 @@ fmul2_e:
   ;# Compute src1[2] * src2
   movq 16(%rsi), %rdx
   mulxq 0(%rcx), %r8, %r9
-  xor %r10, %r10
+  xor %r10d, %r10d
   adcxq 16(%rdi), %r8
   movq %r8, 16(%rdi)
   mulxq 8(%rcx), %r10, %r11
@@ -382,7 +382,7 @@ fmul2_e:
   ;# Compute src1[3] * src2
   movq 24(%rsi), %rdx
   mulxq 0(%rcx), %r8, %r9
-  xor %r10, %r10
+  xor %r10d, %r10d
   adcxq 24(%rdi), %r8
   movq %r8, 24(%rdi)
   mulxq 8(%rcx), %r10, %r11
@@ -407,7 +407,7 @@ fmul2_e:
   ;# Compute src1[0] * src2
   movq 32(%rsi), %rdx
   mulxq 32(%rcx), %r8, %r9
-  xor %r10, %r10
+  xor %r10d, %r10d
   movq %r8, 64(%rdi)
   
   mulxq 40(%rcx), %r10, %r11
@@ -425,7 +425,7 @@ fmul2_e:
   ;# Compute src1[1] * src2
   movq 40(%rsi), %rdx
   mulxq 32(%rcx), %r8, %r9
-  xor %r10, %r10
+  xor %r10d, %r10d
   adcxq 72(%rdi), %r8
   movq %r8, 72(%rdi)
   mulxq 40(%rcx), %r10, %r11
@@ -447,7 +447,7 @@ fmul2_e:
   ;# Compute src1[2] * src2
   movq 48(%rsi), %rdx
   mulxq 32(%rcx), %r8, %r9
-  xor %r10, %r10
+  xor %r10d, %r10d
   adcxq 80(%rdi), %r8
   movq %r8, 80(%rdi)
   mulxq 40(%rcx), %r10, %r11
@@ -469,7 +469,7 @@ fmul2_e:
   ;# Compute src1[3] * src2
   movq 56(%rsi), %rdx
   mulxq 32(%rcx), %r8, %r9
-  xor %r10, %r10
+  xor %r10d, %r10d
   adcxq 88(%rdi), %r8
   movq %r8, 88(%rdi)
   mulxq 40(%rcx), %r10, %r11
@@ -498,7 +498,7 @@ fmul2_e:
   ;# Step 1: Compute dst + carry == tmp_hi * 38 + tmp_lo
   mov $38, %rdx
   mulxq 32(%rsi), %r8, %r13
-  xor %rcx, %rcx
+  xor %ecx, %ecx
   adoxq 0(%rsi), %r8
   mulxq 40(%rsi), %r9, %rbx
   adcx %r13, %r9
@@ -531,7 +531,7 @@ fmul2_e:
   ;# Step 1: Compute dst + carry == tmp_hi * 38 + tmp_lo
   mov $38, %rdx
   mulxq 96(%rsi), %r8, %r13
-  xor %rcx, %rcx
+  xor %ecx, %ecx
   adoxq 64(%rsi), %r8
   mulxq 104(%rsi), %r9, %rbx
   adcx %r13, %r9
@@ -585,7 +585,7 @@ fsqr_e:
   movq 0(%rsi), %rdx
   ;# f[0]
   mulxq 8(%rsi), %r8, %r14
-  xor %r15, %r15
+  xor %r15d, %r15d
   ;# f[1]*f[0]
   mulxq 16(%rsi), %r9, %r10
   adcx %r14, %r9
@@ -609,7 +609,7 @@ fsqr_e:
   ;# f[2]*f[1]
   
   ;# Step 2: Compute two parallel carry chains
-  xor %r15, %r15
+  xor %r15d, %r15d
   adox %rax, %r10
   adcx %r8, %r8
   adox %rcx, %r11
@@ -667,7 +667,7 @@ fsqr_e:
   ;# Step 1: Compute dst + carry == tmp_hi * 38 + tmp_lo
   mov $38, %rdx
   mulxq 32(%rsi), %r8, %r13
-  xor %rcx, %rcx
+  xor %ecx, %ecx
   adoxq 0(%rsi), %r8
   mulxq 40(%rsi), %r9, %rbx
   adcx %r13, %r9
@@ -721,7 +721,7 @@ fsqr2_e:
   movq 0(%rsi), %rdx
   ;# f[0]
   mulxq 8(%rsi), %r8, %r14
-  xor %r15, %r15
+  xor %r15d, %r15d
   ;# f[1]*f[0]
   mulxq 16(%rsi), %r9, %r10
   adcx %r14, %r9
@@ -745,7 +745,7 @@ fsqr2_e:
   ;# f[2]*f[1]
   
   ;# Step 2: Compute two parallel carry chains
-  xor %r15, %r15
+  xor %r15d, %r15d
   adox %rax, %r10
   adcx %r8, %r8
   adox %rcx, %r11
@@ -800,7 +800,7 @@ fsqr2_e:
   movq 32(%rsi), %rdx
   ;# f[0]
   mulxq 40(%rsi), %r8, %r14
-  xor %r15, %r15
+  xor %r15d, %r15d
   ;# f[1]*f[0]
   mulxq 48(%rsi), %r9, %r10
   adcx %r14, %r9
@@ -824,7 +824,7 @@ fsqr2_e:
   ;# f[2]*f[1]
   
   ;# Step 2: Compute two parallel carry chains
-  xor %r15, %r15
+  xor %r15d, %r15d
   adox %rax, %r10
   adcx %r8, %r8
   adox %rcx, %r11
@@ -882,7 +882,7 @@ fsqr2_e:
   ;# Step 1: Compute dst + carry == tmp_hi * 38 + tmp_lo
   mov $38, %rdx
   mulxq 32(%rsi), %r8, %r13
-  xor %rcx, %rcx
+  xor %ecx, %ecx
   adoxq 0(%rsi), %r8
   mulxq 40(%rsi), %r9, %rbx
   adcx %r13, %r9
@@ -915,7 +915,7 @@ fsqr2_e:
   ;# Step 1: Compute dst + carry == tmp_hi * 38 + tmp_lo
   mov $38, %rdx
   mulxq 96(%rsi), %r8, %r13
-  xor %rcx, %rcx
+  xor %ecx, %ecx
   adoxq 64(%rsi), %r8
   mulxq 104(%rsi), %r9, %rbx
   adcx %r13, %r9

--- a/dist/msvc-compatible/curve25519-x86_64-msvc.asm
+++ b/dist/msvc-compatible/curve25519-x86_64-msvc.asm
@@ -7,11 +7,11 @@ add_scalar_e proc
   mov rsi, rdx
   mov rdx, r8
   ;# Clear registers to propagate the carry bit
-  xor r8, r8
-  xor r9, r9
-  xor r10, r10
-  xor r11, r11
-  xor rax, rax
+  xor r8d, r8d
+  xor r9d, r9d
+  xor r10d, r10d
+  xor r11d, r11d
+  xor eax, eax
   
   ;# Begin addition chain
   add rdx, qword ptr [rsi + 0]
@@ -52,7 +52,7 @@ fadd_e proc
   cmovc rax, rdx
   
   ;# Step 2: Add carry*38 to the original sum
-  xor rcx, rcx
+  xor ecx, ecx
   add r8, rax
   adcx r9, rcx
   mov qword ptr [rdi + 8], r9
@@ -176,7 +176,7 @@ fmul_e proc
   ;# Compute src1[0] * src2
   mov rdx, qword ptr [rsi + 0]
   mulx r9, r8, qword ptr [rcx + 0]
-  xor r10, r10
+  xor r10d, r10d
   mov qword ptr [rdi + 0], r8
   
   mulx r11, r10, qword ptr [rcx + 8]
@@ -194,7 +194,7 @@ fmul_e proc
   ;# Compute src1[1] * src2
   mov rdx, qword ptr [rsi + 8]
   mulx r9, r8, qword ptr [rcx + 0]
-  xor r10, r10
+  xor r10d, r10d
   adcx r8, qword ptr [rdi + 8]
   mov qword ptr [rdi + 8], r8
   mulx r11, r10, qword ptr [rcx + 8]
@@ -216,7 +216,7 @@ fmul_e proc
   ;# Compute src1[2] * src2
   mov rdx, qword ptr [rsi + 16]
   mulx r9, r8, qword ptr [rcx + 0]
-  xor r10, r10
+  xor r10d, r10d
   adcx r8, qword ptr [rdi + 16]
   mov qword ptr [rdi + 16], r8
   mulx r11, r10, qword ptr [rcx + 8]
@@ -238,7 +238,7 @@ fmul_e proc
   ;# Compute src1[3] * src2
   mov rdx, qword ptr [rsi + 24]
   mulx r9, r8, qword ptr [rcx + 0]
-  xor r10, r10
+  xor r10d, r10d
   adcx r8, qword ptr [rdi + 24]
   mov qword ptr [rdi + 24], r8
   mulx r11, r10, qword ptr [rcx + 8]
@@ -267,7 +267,7 @@ fmul_e proc
   ;# Step 1: Compute dst + carry == tmp_hi * 38 + tmp_lo
   mov rdx, 38
   mulx r13, r8, qword ptr [rsi + 32]
-  xor rcx, rcx
+  xor ecx, ecx
   adox r8, qword ptr [rsi + 0]
   mulx rbx, r9, qword ptr [rsi + 40]
   adcx r9, r13
@@ -320,7 +320,7 @@ fmul2_e proc
   ;# Compute src1[0] * src2
   mov rdx, qword ptr [rsi + 0]
   mulx r9, r8, qword ptr [rcx + 0]
-  xor r10, r10
+  xor r10d, r10d
   mov qword ptr [rdi + 0], r8
   
   mulx r11, r10, qword ptr [rcx + 8]
@@ -338,7 +338,7 @@ fmul2_e proc
   ;# Compute src1[1] * src2
   mov rdx, qword ptr [rsi + 8]
   mulx r9, r8, qword ptr [rcx + 0]
-  xor r10, r10
+  xor r10d, r10d
   adcx r8, qword ptr [rdi + 8]
   mov qword ptr [rdi + 8], r8
   mulx r11, r10, qword ptr [rcx + 8]
@@ -360,7 +360,7 @@ fmul2_e proc
   ;# Compute src1[2] * src2
   mov rdx, qword ptr [rsi + 16]
   mulx r9, r8, qword ptr [rcx + 0]
-  xor r10, r10
+  xor r10d, r10d
   adcx r8, qword ptr [rdi + 16]
   mov qword ptr [rdi + 16], r8
   mulx r11, r10, qword ptr [rcx + 8]
@@ -382,7 +382,7 @@ fmul2_e proc
   ;# Compute src1[3] * src2
   mov rdx, qword ptr [rsi + 24]
   mulx r9, r8, qword ptr [rcx + 0]
-  xor r10, r10
+  xor r10d, r10d
   adcx r8, qword ptr [rdi + 24]
   mov qword ptr [rdi + 24], r8
   mulx r11, r10, qword ptr [rcx + 8]
@@ -407,7 +407,7 @@ fmul2_e proc
   ;# Compute src1[0] * src2
   mov rdx, qword ptr [rsi + 32]
   mulx r9, r8, qword ptr [rcx + 32]
-  xor r10, r10
+  xor r10d, r10d
   mov qword ptr [rdi + 64], r8
   
   mulx r11, r10, qword ptr [rcx + 40]
@@ -425,7 +425,7 @@ fmul2_e proc
   ;# Compute src1[1] * src2
   mov rdx, qword ptr [rsi + 40]
   mulx r9, r8, qword ptr [rcx + 32]
-  xor r10, r10
+  xor r10d, r10d
   adcx r8, qword ptr [rdi + 72]
   mov qword ptr [rdi + 72], r8
   mulx r11, r10, qword ptr [rcx + 40]
@@ -447,7 +447,7 @@ fmul2_e proc
   ;# Compute src1[2] * src2
   mov rdx, qword ptr [rsi + 48]
   mulx r9, r8, qword ptr [rcx + 32]
-  xor r10, r10
+  xor r10d, r10d
   adcx r8, qword ptr [rdi + 80]
   mov qword ptr [rdi + 80], r8
   mulx r11, r10, qword ptr [rcx + 40]
@@ -469,7 +469,7 @@ fmul2_e proc
   ;# Compute src1[3] * src2
   mov rdx, qword ptr [rsi + 56]
   mulx r9, r8, qword ptr [rcx + 32]
-  xor r10, r10
+  xor r10d, r10d
   adcx r8, qword ptr [rdi + 88]
   mov qword ptr [rdi + 88], r8
   mulx r11, r10, qword ptr [rcx + 40]
@@ -498,7 +498,7 @@ fmul2_e proc
   ;# Step 1: Compute dst + carry == tmp_hi * 38 + tmp_lo
   mov rdx, 38
   mulx r13, r8, qword ptr [rsi + 32]
-  xor rcx, rcx
+  xor ecx, ecx
   adox r8, qword ptr [rsi + 0]
   mulx rbx, r9, qword ptr [rsi + 40]
   adcx r9, r13
@@ -531,7 +531,7 @@ fmul2_e proc
   ;# Step 1: Compute dst + carry == tmp_hi * 38 + tmp_lo
   mov rdx, 38
   mulx r13, r8, qword ptr [rsi + 96]
-  xor rcx, rcx
+  xor ecx, ecx
   adox r8, qword ptr [rsi + 64]
   mulx rbx, r9, qword ptr [rsi + 104]
   adcx r9, r13
@@ -585,7 +585,7 @@ fsqr_e proc
   mov rdx, qword ptr [rsi + 0]
   ;# f[0]
   mulx r14, r8, qword ptr [rsi + 8]
-  xor r15, r15
+  xor r15d, r15d
   ;# f[1]*f[0]
   mulx r10, r9, qword ptr [rsi + 16]
   adcx r9, r14
@@ -609,7 +609,7 @@ fsqr_e proc
   ;# f[2]*f[1]
   
   ;# Step 2: Compute two parallel carry chains
-  xor r15, r15
+  xor r15d, r15d
   adox r10, rax
   adcx r8, r8
   adox r11, rcx
@@ -667,7 +667,7 @@ fsqr_e proc
   ;# Step 1: Compute dst + carry == tmp_hi * 38 + tmp_lo
   mov rdx, 38
   mulx r13, r8, qword ptr [rsi + 32]
-  xor rcx, rcx
+  xor ecx, ecx
   adox r8, qword ptr [rsi + 0]
   mulx rbx, r9, qword ptr [rsi + 40]
   adcx r9, r13
@@ -721,7 +721,7 @@ fsqr2_e proc
   mov rdx, qword ptr [rsi + 0]
   ;# f[0]
   mulx r14, r8, qword ptr [rsi + 8]
-  xor r15, r15
+  xor r15d, r15d
   ;# f[1]*f[0]
   mulx r10, r9, qword ptr [rsi + 16]
   adcx r9, r14
@@ -745,7 +745,7 @@ fsqr2_e proc
   ;# f[2]*f[1]
   
   ;# Step 2: Compute two parallel carry chains
-  xor r15, r15
+  xor r15d, r15d
   adox r10, rax
   adcx r8, r8
   adox r11, rcx
@@ -800,7 +800,7 @@ fsqr2_e proc
   mov rdx, qword ptr [rsi + 32]
   ;# f[0]
   mulx r14, r8, qword ptr [rsi + 40]
-  xor r15, r15
+  xor r15d, r15d
   ;# f[1]*f[0]
   mulx r10, r9, qword ptr [rsi + 48]
   adcx r9, r14
@@ -824,7 +824,7 @@ fsqr2_e proc
   ;# f[2]*f[1]
   
   ;# Step 2: Compute two parallel carry chains
-  xor r15, r15
+  xor r15d, r15d
   adox r10, rax
   adcx r8, r8
   adox r11, rcx
@@ -882,7 +882,7 @@ fsqr2_e proc
   ;# Step 1: Compute dst + carry == tmp_hi * 38 + tmp_lo
   mov rdx, 38
   mulx r13, r8, qword ptr [rsi + 32]
-  xor rcx, rcx
+  xor ecx, ecx
   adox r8, qword ptr [rsi + 0]
   mulx rbx, r9, qword ptr [rsi + 40]
   adcx r9, r13
@@ -915,7 +915,7 @@ fsqr2_e proc
   ;# Step 1: Compute dst + carry == tmp_hi * 38 + tmp_lo
   mov rdx, 38
   mulx r13, r8, qword ptr [rsi + 96]
-  xor rcx, rcx
+  xor ecx, ecx
   adox r8, qword ptr [rsi + 64]
   mulx rbx, r9, qword ptr [rsi + 104]
   adcx r9, r13

--- a/dist/portable-gcc-compatible/curve25519-inline.h
+++ b/dist/portable-gcc-compatible/curve25519-inline.h
@@ -10,11 +10,11 @@ static inline uint64_t add_scalar (uint64_t *out, uint64_t *f1, uint64_t f2)
 
   asm volatile(
     // Clear registers to propagate the carry bit
-    "  xor %%r8, %%r8;"
-    "  xor %%r9, %%r9;"
-    "  xor %%r10, %%r10;"
-    "  xor %%r11, %%r11;"
-    "  xor %1, %1;"
+    "  xor %%r8d, %%r8d;"
+    "  xor %%r9d, %%r9d;"
+    "  xor %%r10d, %%r10d;"
+    "  xor %%r11d, %%r11d;"
+    "  xor %k1, %k1;"
 
     // Begin addition chain
     "  addq 0(%3), %0;"
@@ -58,7 +58,7 @@ static inline void fadd (uint64_t *out, uint64_t *f1, uint64_t *f2)
     "  cmovc %0, %%rax;"
 
     // Step 2: Add carry*38 to the original sum
-    "  xor %%rcx, %%rcx;"
+    "  xor %%ecx, %%ecx;"
     "  add %%rax, %%r8;"
     "  adcx %%rcx, %%r9;"
     "  movq %%r9, 8(%1);"
@@ -131,7 +131,7 @@ static inline void fmul (uint64_t *out, uint64_t *f1, uint64_t *f2, uint64_t *tm
 
     // Compute src1[0] * src2
     "  movq 0(%1), %%rdx;"
-    "  mulxq 0(%2), %%r8, %%r9;"       "  xor %%r10, %%r10;"     "  movq %%r8, 0(%3);"
+    "  mulxq 0(%2), %%r8, %%r9;"       "  xor %%r10d, %%r10d;"     "  movq %%r8, 0(%3);"
     "  mulxq 8(%2), %%r10, %%r11;"     "  adox %%r9, %%r10;"     "  movq %%r10, 8(%3);"
     "  mulxq 16(%2), %%rbx, %%r13;"    "  adox %%r11, %%rbx;"
     "  mulxq 24(%2), %%r14, %%rdx;"    "  adox %%r13, %%r14;"    "  mov $0, %%rax;"
@@ -139,7 +139,7 @@ static inline void fmul (uint64_t *out, uint64_t *f1, uint64_t *f2, uint64_t *tm
 
     // Compute src1[1] * src2
     "  movq 8(%1), %%rdx;"
-    "  mulxq 0(%2), %%r8, %%r9;"       "  xor %%r10, %%r10;"     "  adcxq 8(%3), %%r8;"    "  movq %%r8, 8(%3);"
+    "  mulxq 0(%2), %%r8, %%r9;"       "  xor %%r10d, %%r10d;"     "  adcxq 8(%3), %%r8;"    "  movq %%r8, 8(%3);"
     "  mulxq 8(%2), %%r10, %%r11;"     "  adox %%r9, %%r10;"     "  adcx %%rbx, %%r10;"    "  movq %%r10, 16(%3);"
     "  mulxq 16(%2), %%rbx, %%r13;"    "  adox %%r11, %%rbx;"    "  adcx %%r14, %%rbx;"    "  mov $0, %%r8;"
     "  mulxq 24(%2), %%r14, %%rdx;"    "  adox %%r13, %%r14;"    "  adcx %%rax, %%r14;"    "  mov $0, %%rax;"
@@ -148,7 +148,7 @@ static inline void fmul (uint64_t *out, uint64_t *f1, uint64_t *f2, uint64_t *tm
 
     // Compute src1[2] * src2
     "  movq 16(%1), %%rdx;"
-    "  mulxq 0(%2), %%r8, %%r9;"       "  xor %%r10, %%r10;"    "  adcxq 16(%3), %%r8;"    "  movq %%r8, 16(%3);"
+    "  mulxq 0(%2), %%r8, %%r9;"       "  xor %%r10d, %%r10d;"    "  adcxq 16(%3), %%r8;"    "  movq %%r8, 16(%3);"
     "  mulxq 8(%2), %%r10, %%r11;"     "  adox %%r9, %%r10;"     "  adcx %%rbx, %%r10;"    "  movq %%r10, 24(%3);"
     "  mulxq 16(%2), %%rbx, %%r13;"    "  adox %%r11, %%rbx;"    "  adcx %%r14, %%rbx;"    "  mov $0, %%r8;"
     "  mulxq 24(%2), %%r14, %%rdx;"    "  adox %%r13, %%r14;"    "  adcx %%rax, %%r14;"    "  mov $0, %%rax;"
@@ -157,7 +157,7 @@ static inline void fmul (uint64_t *out, uint64_t *f1, uint64_t *f2, uint64_t *tm
 
     // Compute src1[3] * src2
     "  movq 24(%1), %%rdx;"
-    "  mulxq 0(%2), %%r8, %%r9;"       "  xor %%r10, %%r10;"    "  adcxq 24(%3), %%r8;"    "  movq %%r8, 24(%3);"
+    "  mulxq 0(%2), %%r8, %%r9;"       "  xor %%r10d, %%r10d;"    "  adcxq 24(%3), %%r8;"    "  movq %%r8, 24(%3);"
     "  mulxq 8(%2), %%r10, %%r11;"     "  adox %%r9, %%r10;"     "  adcx %%rbx, %%r10;"    "  movq %%r10, 32(%3);"
     "  mulxq 16(%2), %%rbx, %%r13;"    "  adox %%r11, %%rbx;"    "  adcx %%r14, %%rbx;"    "  movq %%rbx, 40(%3);"    "  mov $0, %%r8;"
     "  mulxq 24(%2), %%r14, %%rdx;"    "  adox %%r13, %%r14;"    "  adcx %%rax, %%r14;"    "  movq %%r14, 48(%3);"    "  mov $0, %%rax;"
@@ -172,7 +172,7 @@ static inline void fmul (uint64_t *out, uint64_t *f1, uint64_t *f2, uint64_t *tm
     // Step 1: Compute dst + carry == tmp_hi * 38 + tmp_lo
     "  mov $38, %%rdx;"
     "  mulxq 32(%1), %%r8, %%r13;"
-    "  xor %2, %2;"
+    "  xor %k2, %k2;"
     "  adoxq 0(%1), %%r8;"
     "  mulxq 40(%1), %%r9, %%rbx;"
     "  adcx %%r13, %%r9;"
@@ -219,7 +219,7 @@ static inline void fmul2 (uint64_t *out, uint64_t *f1, uint64_t *f2, uint64_t *t
 
     // Compute src1[0] * src2
     "  movq 0(%1), %%rdx;"
-    "  mulxq 0(%2), %%r8, %%r9;"       "  xor %%r10, %%r10;"     "  movq %%r8, 0(%3);"
+    "  mulxq 0(%2), %%r8, %%r9;"       "  xor %%r10d, %%r10d;"     "  movq %%r8, 0(%3);"
     "  mulxq 8(%2), %%r10, %%r11;"     "  adox %%r9, %%r10;"     "  movq %%r10, 8(%3);"
     "  mulxq 16(%2), %%rbx, %%r13;"    "  adox %%r11, %%rbx;"
     "  mulxq 24(%2), %%r14, %%rdx;"    "  adox %%r13, %%r14;"    "  mov $0, %%rax;"
@@ -227,7 +227,7 @@ static inline void fmul2 (uint64_t *out, uint64_t *f1, uint64_t *f2, uint64_t *t
 
     // Compute src1[1] * src2
     "  movq 8(%1), %%rdx;"
-    "  mulxq 0(%2), %%r8, %%r9;"       "  xor %%r10, %%r10;"     "  adcxq 8(%3), %%r8;"    "  movq %%r8, 8(%3);"
+    "  mulxq 0(%2), %%r8, %%r9;"       "  xor %%r10d, %%r10d;"     "  adcxq 8(%3), %%r8;"    "  movq %%r8, 8(%3);"
     "  mulxq 8(%2), %%r10, %%r11;"     "  adox %%r9, %%r10;"     "  adcx %%rbx, %%r10;"    "  movq %%r10, 16(%3);"
     "  mulxq 16(%2), %%rbx, %%r13;"    "  adox %%r11, %%rbx;"    "  adcx %%r14, %%rbx;"    "  mov $0, %%r8;"
     "  mulxq 24(%2), %%r14, %%rdx;"    "  adox %%r13, %%r14;"    "  adcx %%rax, %%r14;"    "  mov $0, %%rax;"
@@ -236,7 +236,7 @@ static inline void fmul2 (uint64_t *out, uint64_t *f1, uint64_t *f2, uint64_t *t
 
     // Compute src1[2] * src2
     "  movq 16(%1), %%rdx;"
-    "  mulxq 0(%2), %%r8, %%r9;"       "  xor %%r10, %%r10;"    "  adcxq 16(%3), %%r8;"    "  movq %%r8, 16(%3);"
+    "  mulxq 0(%2), %%r8, %%r9;"       "  xor %%r10d, %%r10d;"    "  adcxq 16(%3), %%r8;"    "  movq %%r8, 16(%3);"
     "  mulxq 8(%2), %%r10, %%r11;"     "  adox %%r9, %%r10;"     "  adcx %%rbx, %%r10;"    "  movq %%r10, 24(%3);"
     "  mulxq 16(%2), %%rbx, %%r13;"    "  adox %%r11, %%rbx;"    "  adcx %%r14, %%rbx;"    "  mov $0, %%r8;"
     "  mulxq 24(%2), %%r14, %%rdx;"    "  adox %%r13, %%r14;"    "  adcx %%rax, %%r14;"    "  mov $0, %%rax;"
@@ -245,7 +245,7 @@ static inline void fmul2 (uint64_t *out, uint64_t *f1, uint64_t *f2, uint64_t *t
 
     // Compute src1[3] * src2
     "  movq 24(%1), %%rdx;"
-    "  mulxq 0(%2), %%r8, %%r9;"       "  xor %%r10, %%r10;"    "  adcxq 24(%3), %%r8;"    "  movq %%r8, 24(%3);"
+    "  mulxq 0(%2), %%r8, %%r9;"       "  xor %%r10d, %%r10d;"    "  adcxq 24(%3), %%r8;"    "  movq %%r8, 24(%3);"
     "  mulxq 8(%2), %%r10, %%r11;"     "  adox %%r9, %%r10;"     "  adcx %%rbx, %%r10;"    "  movq %%r10, 32(%3);"
     "  mulxq 16(%2), %%rbx, %%r13;"    "  adox %%r11, %%rbx;"    "  adcx %%r14, %%rbx;"    "  movq %%rbx, 40(%3);"    "  mov $0, %%r8;"
     "  mulxq 24(%2), %%r14, %%rdx;"    "  adox %%r13, %%r14;"    "  adcx %%rax, %%r14;"    "  movq %%r14, 48(%3);"    "  mov $0, %%rax;"
@@ -255,7 +255,7 @@ static inline void fmul2 (uint64_t *out, uint64_t *f1, uint64_t *f2, uint64_t *t
 
     // Compute src1[0] * src2
     "  movq 32(%1), %%rdx;"
-    "  mulxq 32(%2), %%r8, %%r9;"       "  xor %%r10, %%r10;"     "  movq %%r8, 64(%3);"
+    "  mulxq 32(%2), %%r8, %%r9;"       "  xor %%r10d, %%r10d;"     "  movq %%r8, 64(%3);"
     "  mulxq 40(%2), %%r10, %%r11;"     "  adox %%r9, %%r10;"     "  movq %%r10, 72(%3);"
     "  mulxq 48(%2), %%rbx, %%r13;"    "  adox %%r11, %%rbx;"
     "  mulxq 56(%2), %%r14, %%rdx;"    "  adox %%r13, %%r14;"    "  mov $0, %%rax;"
@@ -263,7 +263,7 @@ static inline void fmul2 (uint64_t *out, uint64_t *f1, uint64_t *f2, uint64_t *t
 
     // Compute src1[1] * src2
     "  movq 40(%1), %%rdx;"
-    "  mulxq 32(%2), %%r8, %%r9;"       "  xor %%r10, %%r10;"     "  adcxq 72(%3), %%r8;"    "  movq %%r8, 72(%3);"
+    "  mulxq 32(%2), %%r8, %%r9;"       "  xor %%r10d, %%r10d;"     "  adcxq 72(%3), %%r8;"    "  movq %%r8, 72(%3);"
     "  mulxq 40(%2), %%r10, %%r11;"     "  adox %%r9, %%r10;"     "  adcx %%rbx, %%r10;"    "  movq %%r10, 80(%3);"
     "  mulxq 48(%2), %%rbx, %%r13;"    "  adox %%r11, %%rbx;"    "  adcx %%r14, %%rbx;"    "  mov $0, %%r8;"
     "  mulxq 56(%2), %%r14, %%rdx;"    "  adox %%r13, %%r14;"    "  adcx %%rax, %%r14;"    "  mov $0, %%rax;"
@@ -272,7 +272,7 @@ static inline void fmul2 (uint64_t *out, uint64_t *f1, uint64_t *f2, uint64_t *t
 
     // Compute src1[2] * src2
     "  movq 48(%1), %%rdx;"
-    "  mulxq 32(%2), %%r8, %%r9;"       "  xor %%r10, %%r10;"    "  adcxq 80(%3), %%r8;"    "  movq %%r8, 80(%3);"
+    "  mulxq 32(%2), %%r8, %%r9;"       "  xor %%r10d, %%r10d;"    "  adcxq 80(%3), %%r8;"    "  movq %%r8, 80(%3);"
     "  mulxq 40(%2), %%r10, %%r11;"     "  adox %%r9, %%r10;"     "  adcx %%rbx, %%r10;"    "  movq %%r10, 88(%3);"
     "  mulxq 48(%2), %%rbx, %%r13;"    "  adox %%r11, %%rbx;"    "  adcx %%r14, %%rbx;"    "  mov $0, %%r8;"
     "  mulxq 56(%2), %%r14, %%rdx;"    "  adox %%r13, %%r14;"    "  adcx %%rax, %%r14;"    "  mov $0, %%rax;"
@@ -281,7 +281,7 @@ static inline void fmul2 (uint64_t *out, uint64_t *f1, uint64_t *f2, uint64_t *t
 
     // Compute src1[3] * src2
     "  movq 56(%1), %%rdx;"
-    "  mulxq 32(%2), %%r8, %%r9;"       "  xor %%r10, %%r10;"    "  adcxq 88(%3), %%r8;"    "  movq %%r8, 88(%3);"
+    "  mulxq 32(%2), %%r8, %%r9;"       "  xor %%r10d, %%r10d;"    "  adcxq 88(%3), %%r8;"    "  movq %%r8, 88(%3);"
     "  mulxq 40(%2), %%r10, %%r11;"     "  adox %%r9, %%r10;"     "  adcx %%rbx, %%r10;"    "  movq %%r10, 96(%3);"
     "  mulxq 48(%2), %%rbx, %%r13;"    "  adox %%r11, %%rbx;"    "  adcx %%r14, %%rbx;"    "  movq %%rbx, 104(%3);"    "  mov $0, %%r8;"
     "  mulxq 56(%2), %%r14, %%rdx;"    "  adox %%r13, %%r14;"    "  adcx %%rax, %%r14;"    "  movq %%r14, 112(%3);"    "  mov $0, %%rax;"
@@ -296,7 +296,7 @@ static inline void fmul2 (uint64_t *out, uint64_t *f1, uint64_t *f2, uint64_t *t
     // Step 1: Compute dst + carry == tmp_hi * 38 + tmp_lo
     "  mov $38, %%rdx;"
     "  mulxq 32(%1), %%r8, %%r13;"
-    "  xor %2, %2;"
+    "  xor %k2, %k2;"
     "  adoxq 0(%1), %%r8;"
     "  mulxq 40(%1), %%r9, %%rbx;"
     "  adcx %%r13, %%r9;"
@@ -329,7 +329,7 @@ static inline void fmul2 (uint64_t *out, uint64_t *f1, uint64_t *f2, uint64_t *t
     // Step 1: Compute dst + carry == tmp_hi * 38 + tmp_lo
     "  mov $38, %%rdx;"
     "  mulxq 96(%1), %%r8, %%r13;"
-    "  xor %2, %2;"
+    "  xor %k2, %k2;"
     "  adoxq 64(%1), %%r8;"
     "  mulxq 104(%1), %%r9, %%rbx;"
     "  adcx %%r13, %%r9;"
@@ -502,7 +502,7 @@ static inline void fsqr (uint64_t *out, uint64_t *f, uint64_t *tmp)
 
     // Step 1: Compute all partial products
     "  movq 0(%1), %%rdx;"                                       // f[0]
-    "  mulxq 8(%1), %%r8, %%r14;"      "  xor %%r15, %%r15;"     // f[1]*f[0]
+    "  mulxq 8(%1), %%r8, %%r14;"      "  xor %%r15d, %%r15d;"     // f[1]*f[0]
     "  mulxq 16(%1), %%r9, %%r10;"     "  adcx %%r14, %%r9;"     // f[2]*f[0]
     "  mulxq 24(%1), %%rax, %%rcx;"    "  adcx %%rax, %%r10;"    // f[3]*f[0]
     "  movq 24(%1), %%rdx;"                                      // f[3]
@@ -512,7 +512,7 @@ static inline void fsqr (uint64_t *out, uint64_t *f, uint64_t *tmp)
     "  mulxq 16(%1), %%rax, %%rcx;"    "  mov $0, %%r14;"        // f[2]*f[1]
 
     // Step 2: Compute two parallel carry chains
-    "  xor %%r15, %%r15;"
+    "  xor %%r15d, %%r15d;"
     "  adox %%rax, %%r10;"
     "  adcx %%r8, %%r8;"
     "  adox %%rcx, %%r11;"
@@ -549,7 +549,7 @@ static inline void fsqr (uint64_t *out, uint64_t *f, uint64_t *tmp)
     // Step 1: Compute dst + carry == tmp_hi * 38 + tmp_lo
     "  mov $38, %%rdx;"
     "  mulxq 32(%1), %%r8, %%r13;"
-    "  xor %%rcx, %%rcx;"
+    "  xor %%ecx, %%ecx;"
     "  adoxq 0(%1), %%r8;"
     "  mulxq 40(%1), %%r9, %%rbx;"
     "  adcx %%r13, %%r9;"
@@ -593,7 +593,7 @@ static inline void fsqr2 (uint64_t *out, uint64_t *f, uint64_t *tmp)
   asm volatile(
     // Step 1: Compute all partial products
     "  movq 0(%1), %%rdx;"                                       // f[0]
-    "  mulxq 8(%1), %%r8, %%r14;"      "  xor %%r15, %%r15;"     // f[1]*f[0]
+    "  mulxq 8(%1), %%r8, %%r14;"      "  xor %%r15d, %%r15d;"     // f[1]*f[0]
     "  mulxq 16(%1), %%r9, %%r10;"     "  adcx %%r14, %%r9;"     // f[2]*f[0]
     "  mulxq 24(%1), %%rax, %%rcx;"    "  adcx %%rax, %%r10;"    // f[3]*f[0]
     "  movq 24(%1), %%rdx;"                                      // f[3]
@@ -603,7 +603,7 @@ static inline void fsqr2 (uint64_t *out, uint64_t *f, uint64_t *tmp)
     "  mulxq 16(%1), %%rax, %%rcx;"    "  mov $0, %%r14;"        // f[2]*f[1]
 
     // Step 2: Compute two parallel carry chains
-    "  xor %%r15, %%r15;"
+    "  xor %%r15d, %%r15d;"
     "  adox %%rax, %%r10;"
     "  adcx %%r8, %%r8;"
     "  adox %%rcx, %%r11;"
@@ -633,7 +633,7 @@ static inline void fsqr2 (uint64_t *out, uint64_t *f, uint64_t *tmp)
 
     // Step 1: Compute all partial products
     "  movq 32(%1), %%rdx;"                                       // f[0]
-    "  mulxq 40(%1), %%r8, %%r14;"      "  xor %%r15, %%r15;"     // f[1]*f[0]
+    "  mulxq 40(%1), %%r8, %%r14;"      "  xor %%r15d, %%r15d;"     // f[1]*f[0]
     "  mulxq 48(%1), %%r9, %%r10;"     "  adcx %%r14, %%r9;"     // f[2]*f[0]
     "  mulxq 56(%1), %%rax, %%rcx;"    "  adcx %%rax, %%r10;"    // f[3]*f[0]
     "  movq 56(%1), %%rdx;"                                      // f[3]
@@ -643,7 +643,7 @@ static inline void fsqr2 (uint64_t *out, uint64_t *f, uint64_t *tmp)
     "  mulxq 48(%1), %%rax, %%rcx;"    "  mov $0, %%r14;"        // f[2]*f[1]
 
     // Step 2: Compute two parallel carry chains
-    "  xor %%r15, %%r15;"
+    "  xor %%r15d, %%r15d;"
     "  adox %%rax, %%r10;"
     "  adcx %%r8, %%r8;"
     "  adox %%rcx, %%r11;"
@@ -678,7 +678,7 @@ static inline void fsqr2 (uint64_t *out, uint64_t *f, uint64_t *tmp)
     // Step 1: Compute dst + carry == tmp_hi * 38 + tmp_lo
     "  mov $38, %%rdx;"
     "  mulxq 32(%1), %%r8, %%r13;"
-    "  xor %%rcx, %%rcx;"
+    "  xor %%ecx, %%ecx;"
     "  adoxq 0(%1), %%r8;"
     "  mulxq 40(%1), %%r9, %%rbx;"
     "  adcx %%r13, %%r9;"
@@ -711,7 +711,7 @@ static inline void fsqr2 (uint64_t *out, uint64_t *f, uint64_t *tmp)
     // Step 1: Compute dst + carry == tmp_hi * 38 + tmp_lo
     "  mov $38, %%rdx;"
     "  mulxq 96(%1), %%r8, %%r13;"
-    "  xor %%rcx, %%rcx;"
+    "  xor %%ecx, %%ecx;"
     "  adoxq 64(%1), %%r8;"
     "  mulxq 104(%1), %%r9, %%rbx;"
     "  adcx %%r13, %%r9;"

--- a/dist/portable-gcc-compatible/curve25519-x86_64-darwin.S
+++ b/dist/portable-gcc-compatible/curve25519-x86_64-darwin.S
@@ -4,11 +4,11 @@ _add_scalar_e:
   push %rdi
   push %rsi
   ;# Clear registers to propagate the carry bit
-  xor %r8, %r8
-  xor %r9, %r9
-  xor %r10, %r10
-  xor %r11, %r11
-  xor %rax, %rax
+  xor %r8d, %r8d
+  xor %r9d, %r9d
+  xor %r10d, %r10d
+  xor %r11d, %r11d
+  xor %eax, %eax
   
   ;# Begin addition chain
   addq 0(%rsi), %rdx
@@ -44,7 +44,7 @@ _fadd_e:
   cmovc %rdx, %rax
   
   ;# Step 2: Add carry*38 to the original sum
-  xor %rcx, %rcx
+  xor %ecx, %ecx
   add %rax, %r8
   adcx %rcx, %r9
   movq %r9, 8(%rdi)
@@ -149,7 +149,7 @@ _fmul_e:
   ;# Compute src1[0] * src2
   movq 0(%rsi), %rdx
   mulxq 0(%rcx), %r8, %r9
-  xor %r10, %r10
+  xor %r10d, %r10d
   movq %r8, 0(%rdi)
   
   mulxq 8(%rcx), %r10, %r11
@@ -167,7 +167,7 @@ _fmul_e:
   ;# Compute src1[1] * src2
   movq 8(%rsi), %rdx
   mulxq 0(%rcx), %r8, %r9
-  xor %r10, %r10
+  xor %r10d, %r10d
   adcxq 8(%rdi), %r8
   movq %r8, 8(%rdi)
   mulxq 8(%rcx), %r10, %r11
@@ -189,7 +189,7 @@ _fmul_e:
   ;# Compute src1[2] * src2
   movq 16(%rsi), %rdx
   mulxq 0(%rcx), %r8, %r9
-  xor %r10, %r10
+  xor %r10d, %r10d
   adcxq 16(%rdi), %r8
   movq %r8, 16(%rdi)
   mulxq 8(%rcx), %r10, %r11
@@ -211,7 +211,7 @@ _fmul_e:
   ;# Compute src1[3] * src2
   movq 24(%rsi), %rdx
   mulxq 0(%rcx), %r8, %r9
-  xor %r10, %r10
+  xor %r10d, %r10d
   adcxq 24(%rdi), %r8
   movq %r8, 24(%rdi)
   mulxq 8(%rcx), %r10, %r11
@@ -240,7 +240,7 @@ _fmul_e:
   ;# Step 1: Compute dst + carry == tmp_hi * 38 + tmp_lo
   mov $38, %rdx
   mulxq 32(%rsi), %r8, %r13
-  xor %rcx, %rcx
+  xor %ecx, %ecx
   adoxq 0(%rsi), %r8
   mulxq 40(%rsi), %r9, %rbx
   adcx %r13, %r9
@@ -286,7 +286,7 @@ _fmul2_e:
   ;# Compute src1[0] * src2
   movq 0(%rsi), %rdx
   mulxq 0(%rcx), %r8, %r9
-  xor %r10, %r10
+  xor %r10d, %r10d
   movq %r8, 0(%rdi)
   
   mulxq 8(%rcx), %r10, %r11
@@ -304,7 +304,7 @@ _fmul2_e:
   ;# Compute src1[1] * src2
   movq 8(%rsi), %rdx
   mulxq 0(%rcx), %r8, %r9
-  xor %r10, %r10
+  xor %r10d, %r10d
   adcxq 8(%rdi), %r8
   movq %r8, 8(%rdi)
   mulxq 8(%rcx), %r10, %r11
@@ -326,7 +326,7 @@ _fmul2_e:
   ;# Compute src1[2] * src2
   movq 16(%rsi), %rdx
   mulxq 0(%rcx), %r8, %r9
-  xor %r10, %r10
+  xor %r10d, %r10d
   adcxq 16(%rdi), %r8
   movq %r8, 16(%rdi)
   mulxq 8(%rcx), %r10, %r11
@@ -348,7 +348,7 @@ _fmul2_e:
   ;# Compute src1[3] * src2
   movq 24(%rsi), %rdx
   mulxq 0(%rcx), %r8, %r9
-  xor %r10, %r10
+  xor %r10d, %r10d
   adcxq 24(%rdi), %r8
   movq %r8, 24(%rdi)
   mulxq 8(%rcx), %r10, %r11
@@ -373,7 +373,7 @@ _fmul2_e:
   ;# Compute src1[0] * src2
   movq 32(%rsi), %rdx
   mulxq 32(%rcx), %r8, %r9
-  xor %r10, %r10
+  xor %r10d, %r10d
   movq %r8, 64(%rdi)
   
   mulxq 40(%rcx), %r10, %r11
@@ -391,7 +391,7 @@ _fmul2_e:
   ;# Compute src1[1] * src2
   movq 40(%rsi), %rdx
   mulxq 32(%rcx), %r8, %r9
-  xor %r10, %r10
+  xor %r10d, %r10d
   adcxq 72(%rdi), %r8
   movq %r8, 72(%rdi)
   mulxq 40(%rcx), %r10, %r11
@@ -413,7 +413,7 @@ _fmul2_e:
   ;# Compute src1[2] * src2
   movq 48(%rsi), %rdx
   mulxq 32(%rcx), %r8, %r9
-  xor %r10, %r10
+  xor %r10d, %r10d
   adcxq 80(%rdi), %r8
   movq %r8, 80(%rdi)
   mulxq 40(%rcx), %r10, %r11
@@ -435,7 +435,7 @@ _fmul2_e:
   ;# Compute src1[3] * src2
   movq 56(%rsi), %rdx
   mulxq 32(%rcx), %r8, %r9
-  xor %r10, %r10
+  xor %r10d, %r10d
   adcxq 88(%rdi), %r8
   movq %r8, 88(%rdi)
   mulxq 40(%rcx), %r10, %r11
@@ -464,7 +464,7 @@ _fmul2_e:
   ;# Step 1: Compute dst + carry == tmp_hi * 38 + tmp_lo
   mov $38, %rdx
   mulxq 32(%rsi), %r8, %r13
-  xor %rcx, %rcx
+  xor %ecx, %ecx
   adoxq 0(%rsi), %r8
   mulxq 40(%rsi), %r9, %rbx
   adcx %r13, %r9
@@ -497,7 +497,7 @@ _fmul2_e:
   ;# Step 1: Compute dst + carry == tmp_hi * 38 + tmp_lo
   mov $38, %rdx
   mulxq 96(%rsi), %r8, %r13
-  xor %rcx, %rcx
+  xor %ecx, %ecx
   adoxq 64(%rsi), %r8
   mulxq 104(%rsi), %r9, %rbx
   adcx %r13, %r9
@@ -545,7 +545,7 @@ _fsqr_e:
   movq 0(%rsi), %rdx
   ;# f[0]
   mulxq 8(%rsi), %r8, %r14
-  xor %r15, %r15
+  xor %r15d, %r15d
   ;# f[1]*f[0]
   mulxq 16(%rsi), %r9, %r10
   adcx %r14, %r9
@@ -569,7 +569,7 @@ _fsqr_e:
   ;# f[2]*f[1]
   
   ;# Step 2: Compute two parallel carry chains
-  xor %r15, %r15
+  xor %r15d, %r15d
   adox %rax, %r10
   adcx %r8, %r8
   adox %rcx, %r11
@@ -627,7 +627,7 @@ _fsqr_e:
   ;# Step 1: Compute dst + carry == tmp_hi * 38 + tmp_lo
   mov $38, %rdx
   mulxq 32(%rsi), %r8, %r13
-  xor %rcx, %rcx
+  xor %ecx, %ecx
   adoxq 0(%rsi), %r8
   mulxq 40(%rsi), %r9, %rbx
   adcx %r13, %r9
@@ -675,7 +675,7 @@ _fsqr2_e:
   movq 0(%rsi), %rdx
   ;# f[0]
   mulxq 8(%rsi), %r8, %r14
-  xor %r15, %r15
+  xor %r15d, %r15d
   ;# f[1]*f[0]
   mulxq 16(%rsi), %r9, %r10
   adcx %r14, %r9
@@ -699,7 +699,7 @@ _fsqr2_e:
   ;# f[2]*f[1]
   
   ;# Step 2: Compute two parallel carry chains
-  xor %r15, %r15
+  xor %r15d, %r15d
   adox %rax, %r10
   adcx %r8, %r8
   adox %rcx, %r11
@@ -754,7 +754,7 @@ _fsqr2_e:
   movq 32(%rsi), %rdx
   ;# f[0]
   mulxq 40(%rsi), %r8, %r14
-  xor %r15, %r15
+  xor %r15d, %r15d
   ;# f[1]*f[0]
   mulxq 48(%rsi), %r9, %r10
   adcx %r14, %r9
@@ -778,7 +778,7 @@ _fsqr2_e:
   ;# f[2]*f[1]
   
   ;# Step 2: Compute two parallel carry chains
-  xor %r15, %r15
+  xor %r15d, %r15d
   adox %rax, %r10
   adcx %r8, %r8
   adox %rcx, %r11
@@ -836,7 +836,7 @@ _fsqr2_e:
   ;# Step 1: Compute dst + carry == tmp_hi * 38 + tmp_lo
   mov $38, %rdx
   mulxq 32(%rsi), %r8, %r13
-  xor %rcx, %rcx
+  xor %ecx, %ecx
   adoxq 0(%rsi), %r8
   mulxq 40(%rsi), %r9, %rbx
   adcx %r13, %r9
@@ -869,7 +869,7 @@ _fsqr2_e:
   ;# Step 1: Compute dst + carry == tmp_hi * 38 + tmp_lo
   mov $38, %rdx
   mulxq 96(%rsi), %r8, %r13
-  xor %rcx, %rcx
+  xor %ecx, %ecx
   adoxq 64(%rsi), %r8
   mulxq 104(%rsi), %r9, %rbx
   adcx %r13, %r9

--- a/dist/portable-gcc-compatible/curve25519-x86_64-linux.S
+++ b/dist/portable-gcc-compatible/curve25519-x86_64-linux.S
@@ -4,11 +4,11 @@ add_scalar_e:
   push %rdi
   push %rsi
   ;# Clear registers to propagate the carry bit
-  xor %r8, %r8
-  xor %r9, %r9
-  xor %r10, %r10
-  xor %r11, %r11
-  xor %rax, %rax
+  xor %r8d, %r8d
+  xor %r9d, %r9d
+  xor %r10d, %r10d
+  xor %r11d, %r11d
+  xor %eax, %eax
   
   ;# Begin addition chain
   addq 0(%rsi), %rdx
@@ -44,7 +44,7 @@ fadd_e:
   cmovc %rdx, %rax
   
   ;# Step 2: Add carry*38 to the original sum
-  xor %rcx, %rcx
+  xor %ecx, %ecx
   add %rax, %r8
   adcx %rcx, %r9
   movq %r9, 8(%rdi)
@@ -149,7 +149,7 @@ fmul_e:
   ;# Compute src1[0] * src2
   movq 0(%rsi), %rdx
   mulxq 0(%rcx), %r8, %r9
-  xor %r10, %r10
+  xor %r10d, %r10d
   movq %r8, 0(%rdi)
   
   mulxq 8(%rcx), %r10, %r11
@@ -167,7 +167,7 @@ fmul_e:
   ;# Compute src1[1] * src2
   movq 8(%rsi), %rdx
   mulxq 0(%rcx), %r8, %r9
-  xor %r10, %r10
+  xor %r10d, %r10d
   adcxq 8(%rdi), %r8
   movq %r8, 8(%rdi)
   mulxq 8(%rcx), %r10, %r11
@@ -189,7 +189,7 @@ fmul_e:
   ;# Compute src1[2] * src2
   movq 16(%rsi), %rdx
   mulxq 0(%rcx), %r8, %r9
-  xor %r10, %r10
+  xor %r10d, %r10d
   adcxq 16(%rdi), %r8
   movq %r8, 16(%rdi)
   mulxq 8(%rcx), %r10, %r11
@@ -211,7 +211,7 @@ fmul_e:
   ;# Compute src1[3] * src2
   movq 24(%rsi), %rdx
   mulxq 0(%rcx), %r8, %r9
-  xor %r10, %r10
+  xor %r10d, %r10d
   adcxq 24(%rdi), %r8
   movq %r8, 24(%rdi)
   mulxq 8(%rcx), %r10, %r11
@@ -240,7 +240,7 @@ fmul_e:
   ;# Step 1: Compute dst + carry == tmp_hi * 38 + tmp_lo
   mov $38, %rdx
   mulxq 32(%rsi), %r8, %r13
-  xor %rcx, %rcx
+  xor %ecx, %ecx
   adoxq 0(%rsi), %r8
   mulxq 40(%rsi), %r9, %rbx
   adcx %r13, %r9
@@ -286,7 +286,7 @@ fmul2_e:
   ;# Compute src1[0] * src2
   movq 0(%rsi), %rdx
   mulxq 0(%rcx), %r8, %r9
-  xor %r10, %r10
+  xor %r10d, %r10d
   movq %r8, 0(%rdi)
   
   mulxq 8(%rcx), %r10, %r11
@@ -304,7 +304,7 @@ fmul2_e:
   ;# Compute src1[1] * src2
   movq 8(%rsi), %rdx
   mulxq 0(%rcx), %r8, %r9
-  xor %r10, %r10
+  xor %r10d, %r10d
   adcxq 8(%rdi), %r8
   movq %r8, 8(%rdi)
   mulxq 8(%rcx), %r10, %r11
@@ -326,7 +326,7 @@ fmul2_e:
   ;# Compute src1[2] * src2
   movq 16(%rsi), %rdx
   mulxq 0(%rcx), %r8, %r9
-  xor %r10, %r10
+  xor %r10d, %r10d
   adcxq 16(%rdi), %r8
   movq %r8, 16(%rdi)
   mulxq 8(%rcx), %r10, %r11
@@ -348,7 +348,7 @@ fmul2_e:
   ;# Compute src1[3] * src2
   movq 24(%rsi), %rdx
   mulxq 0(%rcx), %r8, %r9
-  xor %r10, %r10
+  xor %r10d, %r10d
   adcxq 24(%rdi), %r8
   movq %r8, 24(%rdi)
   mulxq 8(%rcx), %r10, %r11
@@ -373,7 +373,7 @@ fmul2_e:
   ;# Compute src1[0] * src2
   movq 32(%rsi), %rdx
   mulxq 32(%rcx), %r8, %r9
-  xor %r10, %r10
+  xor %r10d, %r10d
   movq %r8, 64(%rdi)
   
   mulxq 40(%rcx), %r10, %r11
@@ -391,7 +391,7 @@ fmul2_e:
   ;# Compute src1[1] * src2
   movq 40(%rsi), %rdx
   mulxq 32(%rcx), %r8, %r9
-  xor %r10, %r10
+  xor %r10d, %r10d
   adcxq 72(%rdi), %r8
   movq %r8, 72(%rdi)
   mulxq 40(%rcx), %r10, %r11
@@ -413,7 +413,7 @@ fmul2_e:
   ;# Compute src1[2] * src2
   movq 48(%rsi), %rdx
   mulxq 32(%rcx), %r8, %r9
-  xor %r10, %r10
+  xor %r10d, %r10d
   adcxq 80(%rdi), %r8
   movq %r8, 80(%rdi)
   mulxq 40(%rcx), %r10, %r11
@@ -435,7 +435,7 @@ fmul2_e:
   ;# Compute src1[3] * src2
   movq 56(%rsi), %rdx
   mulxq 32(%rcx), %r8, %r9
-  xor %r10, %r10
+  xor %r10d, %r10d
   adcxq 88(%rdi), %r8
   movq %r8, 88(%rdi)
   mulxq 40(%rcx), %r10, %r11
@@ -464,7 +464,7 @@ fmul2_e:
   ;# Step 1: Compute dst + carry == tmp_hi * 38 + tmp_lo
   mov $38, %rdx
   mulxq 32(%rsi), %r8, %r13
-  xor %rcx, %rcx
+  xor %ecx, %ecx
   adoxq 0(%rsi), %r8
   mulxq 40(%rsi), %r9, %rbx
   adcx %r13, %r9
@@ -497,7 +497,7 @@ fmul2_e:
   ;# Step 1: Compute dst + carry == tmp_hi * 38 + tmp_lo
   mov $38, %rdx
   mulxq 96(%rsi), %r8, %r13
-  xor %rcx, %rcx
+  xor %ecx, %ecx
   adoxq 64(%rsi), %r8
   mulxq 104(%rsi), %r9, %rbx
   adcx %r13, %r9
@@ -545,7 +545,7 @@ fsqr_e:
   movq 0(%rsi), %rdx
   ;# f[0]
   mulxq 8(%rsi), %r8, %r14
-  xor %r15, %r15
+  xor %r15d, %r15d
   ;# f[1]*f[0]
   mulxq 16(%rsi), %r9, %r10
   adcx %r14, %r9
@@ -569,7 +569,7 @@ fsqr_e:
   ;# f[2]*f[1]
   
   ;# Step 2: Compute two parallel carry chains
-  xor %r15, %r15
+  xor %r15d, %r15d
   adox %rax, %r10
   adcx %r8, %r8
   adox %rcx, %r11
@@ -627,7 +627,7 @@ fsqr_e:
   ;# Step 1: Compute dst + carry == tmp_hi * 38 + tmp_lo
   mov $38, %rdx
   mulxq 32(%rsi), %r8, %r13
-  xor %rcx, %rcx
+  xor %ecx, %ecx
   adoxq 0(%rsi), %r8
   mulxq 40(%rsi), %r9, %rbx
   adcx %r13, %r9
@@ -675,7 +675,7 @@ fsqr2_e:
   movq 0(%rsi), %rdx
   ;# f[0]
   mulxq 8(%rsi), %r8, %r14
-  xor %r15, %r15
+  xor %r15d, %r15d
   ;# f[1]*f[0]
   mulxq 16(%rsi), %r9, %r10
   adcx %r14, %r9
@@ -699,7 +699,7 @@ fsqr2_e:
   ;# f[2]*f[1]
   
   ;# Step 2: Compute two parallel carry chains
-  xor %r15, %r15
+  xor %r15d, %r15d
   adox %rax, %r10
   adcx %r8, %r8
   adox %rcx, %r11
@@ -754,7 +754,7 @@ fsqr2_e:
   movq 32(%rsi), %rdx
   ;# f[0]
   mulxq 40(%rsi), %r8, %r14
-  xor %r15, %r15
+  xor %r15d, %r15d
   ;# f[1]*f[0]
   mulxq 48(%rsi), %r9, %r10
   adcx %r14, %r9
@@ -778,7 +778,7 @@ fsqr2_e:
   ;# f[2]*f[1]
   
   ;# Step 2: Compute two parallel carry chains
-  xor %r15, %r15
+  xor %r15d, %r15d
   adox %rax, %r10
   adcx %r8, %r8
   adox %rcx, %r11
@@ -836,7 +836,7 @@ fsqr2_e:
   ;# Step 1: Compute dst + carry == tmp_hi * 38 + tmp_lo
   mov $38, %rdx
   mulxq 32(%rsi), %r8, %r13
-  xor %rcx, %rcx
+  xor %ecx, %ecx
   adoxq 0(%rsi), %r8
   mulxq 40(%rsi), %r9, %rbx
   adcx %r13, %r9
@@ -869,7 +869,7 @@ fsqr2_e:
   ;# Step 1: Compute dst + carry == tmp_hi * 38 + tmp_lo
   mov $38, %rdx
   mulxq 96(%rsi), %r8, %r13
-  xor %rcx, %rcx
+  xor %ecx, %ecx
   adoxq 64(%rsi), %r8
   mulxq 104(%rsi), %r9, %rbx
   adcx %r13, %r9

--- a/dist/portable-gcc-compatible/curve25519-x86_64-mingw.S
+++ b/dist/portable-gcc-compatible/curve25519-x86_64-mingw.S
@@ -7,11 +7,11 @@ add_scalar_e:
   mov %rdx, %rsi
   mov %r8, %rdx
   ;# Clear registers to propagate the carry bit
-  xor %r8, %r8
-  xor %r9, %r9
-  xor %r10, %r10
-  xor %r11, %r11
-  xor %rax, %rax
+  xor %r8d, %r8d
+  xor %r9d, %r9d
+  xor %r10d, %r10d
+  xor %r11d, %r11d
+  xor %eax, %eax
   
   ;# Begin addition chain
   addq 0(%rsi), %rdx
@@ -52,7 +52,7 @@ fadd_e:
   cmovc %rdx, %rax
   
   ;# Step 2: Add carry*38 to the original sum
-  xor %rcx, %rcx
+  xor %ecx, %ecx
   add %rax, %r8
   adcx %rcx, %r9
   movq %r9, 8(%rdi)
@@ -176,7 +176,7 @@ fmul_e:
   ;# Compute src1[0] * src2
   movq 0(%rsi), %rdx
   mulxq 0(%rcx), %r8, %r9
-  xor %r10, %r10
+  xor %r10d, %r10d
   movq %r8, 0(%rdi)
   
   mulxq 8(%rcx), %r10, %r11
@@ -194,7 +194,7 @@ fmul_e:
   ;# Compute src1[1] * src2
   movq 8(%rsi), %rdx
   mulxq 0(%rcx), %r8, %r9
-  xor %r10, %r10
+  xor %r10d, %r10d
   adcxq 8(%rdi), %r8
   movq %r8, 8(%rdi)
   mulxq 8(%rcx), %r10, %r11
@@ -216,7 +216,7 @@ fmul_e:
   ;# Compute src1[2] * src2
   movq 16(%rsi), %rdx
   mulxq 0(%rcx), %r8, %r9
-  xor %r10, %r10
+  xor %r10d, %r10d
   adcxq 16(%rdi), %r8
   movq %r8, 16(%rdi)
   mulxq 8(%rcx), %r10, %r11
@@ -238,7 +238,7 @@ fmul_e:
   ;# Compute src1[3] * src2
   movq 24(%rsi), %rdx
   mulxq 0(%rcx), %r8, %r9
-  xor %r10, %r10
+  xor %r10d, %r10d
   adcxq 24(%rdi), %r8
   movq %r8, 24(%rdi)
   mulxq 8(%rcx), %r10, %r11
@@ -267,7 +267,7 @@ fmul_e:
   ;# Step 1: Compute dst + carry == tmp_hi * 38 + tmp_lo
   mov $38, %rdx
   mulxq 32(%rsi), %r8, %r13
-  xor %rcx, %rcx
+  xor %ecx, %ecx
   adoxq 0(%rsi), %r8
   mulxq 40(%rsi), %r9, %rbx
   adcx %r13, %r9
@@ -320,7 +320,7 @@ fmul2_e:
   ;# Compute src1[0] * src2
   movq 0(%rsi), %rdx
   mulxq 0(%rcx), %r8, %r9
-  xor %r10, %r10
+  xor %r10d, %r10d
   movq %r8, 0(%rdi)
   
   mulxq 8(%rcx), %r10, %r11
@@ -338,7 +338,7 @@ fmul2_e:
   ;# Compute src1[1] * src2
   movq 8(%rsi), %rdx
   mulxq 0(%rcx), %r8, %r9
-  xor %r10, %r10
+  xor %r10d, %r10d
   adcxq 8(%rdi), %r8
   movq %r8, 8(%rdi)
   mulxq 8(%rcx), %r10, %r11
@@ -360,7 +360,7 @@ fmul2_e:
   ;# Compute src1[2] * src2
   movq 16(%rsi), %rdx
   mulxq 0(%rcx), %r8, %r9
-  xor %r10, %r10
+  xor %r10d, %r10d
   adcxq 16(%rdi), %r8
   movq %r8, 16(%rdi)
   mulxq 8(%rcx), %r10, %r11
@@ -382,7 +382,7 @@ fmul2_e:
   ;# Compute src1[3] * src2
   movq 24(%rsi), %rdx
   mulxq 0(%rcx), %r8, %r9
-  xor %r10, %r10
+  xor %r10d, %r10d
   adcxq 24(%rdi), %r8
   movq %r8, 24(%rdi)
   mulxq 8(%rcx), %r10, %r11
@@ -407,7 +407,7 @@ fmul2_e:
   ;# Compute src1[0] * src2
   movq 32(%rsi), %rdx
   mulxq 32(%rcx), %r8, %r9
-  xor %r10, %r10
+  xor %r10d, %r10d
   movq %r8, 64(%rdi)
   
   mulxq 40(%rcx), %r10, %r11
@@ -425,7 +425,7 @@ fmul2_e:
   ;# Compute src1[1] * src2
   movq 40(%rsi), %rdx
   mulxq 32(%rcx), %r8, %r9
-  xor %r10, %r10
+  xor %r10d, %r10d
   adcxq 72(%rdi), %r8
   movq %r8, 72(%rdi)
   mulxq 40(%rcx), %r10, %r11
@@ -447,7 +447,7 @@ fmul2_e:
   ;# Compute src1[2] * src2
   movq 48(%rsi), %rdx
   mulxq 32(%rcx), %r8, %r9
-  xor %r10, %r10
+  xor %r10d, %r10d
   adcxq 80(%rdi), %r8
   movq %r8, 80(%rdi)
   mulxq 40(%rcx), %r10, %r11
@@ -469,7 +469,7 @@ fmul2_e:
   ;# Compute src1[3] * src2
   movq 56(%rsi), %rdx
   mulxq 32(%rcx), %r8, %r9
-  xor %r10, %r10
+  xor %r10d, %r10d
   adcxq 88(%rdi), %r8
   movq %r8, 88(%rdi)
   mulxq 40(%rcx), %r10, %r11
@@ -498,7 +498,7 @@ fmul2_e:
   ;# Step 1: Compute dst + carry == tmp_hi * 38 + tmp_lo
   mov $38, %rdx
   mulxq 32(%rsi), %r8, %r13
-  xor %rcx, %rcx
+  xor %ecx, %ecx
   adoxq 0(%rsi), %r8
   mulxq 40(%rsi), %r9, %rbx
   adcx %r13, %r9
@@ -531,7 +531,7 @@ fmul2_e:
   ;# Step 1: Compute dst + carry == tmp_hi * 38 + tmp_lo
   mov $38, %rdx
   mulxq 96(%rsi), %r8, %r13
-  xor %rcx, %rcx
+  xor %ecx, %ecx
   adoxq 64(%rsi), %r8
   mulxq 104(%rsi), %r9, %rbx
   adcx %r13, %r9
@@ -585,7 +585,7 @@ fsqr_e:
   movq 0(%rsi), %rdx
   ;# f[0]
   mulxq 8(%rsi), %r8, %r14
-  xor %r15, %r15
+  xor %r15d, %r15d
   ;# f[1]*f[0]
   mulxq 16(%rsi), %r9, %r10
   adcx %r14, %r9
@@ -609,7 +609,7 @@ fsqr_e:
   ;# f[2]*f[1]
   
   ;# Step 2: Compute two parallel carry chains
-  xor %r15, %r15
+  xor %r15d, %r15d
   adox %rax, %r10
   adcx %r8, %r8
   adox %rcx, %r11
@@ -667,7 +667,7 @@ fsqr_e:
   ;# Step 1: Compute dst + carry == tmp_hi * 38 + tmp_lo
   mov $38, %rdx
   mulxq 32(%rsi), %r8, %r13
-  xor %rcx, %rcx
+  xor %ecx, %ecx
   adoxq 0(%rsi), %r8
   mulxq 40(%rsi), %r9, %rbx
   adcx %r13, %r9
@@ -721,7 +721,7 @@ fsqr2_e:
   movq 0(%rsi), %rdx
   ;# f[0]
   mulxq 8(%rsi), %r8, %r14
-  xor %r15, %r15
+  xor %r15d, %r15d
   ;# f[1]*f[0]
   mulxq 16(%rsi), %r9, %r10
   adcx %r14, %r9
@@ -745,7 +745,7 @@ fsqr2_e:
   ;# f[2]*f[1]
   
   ;# Step 2: Compute two parallel carry chains
-  xor %r15, %r15
+  xor %r15d, %r15d
   adox %rax, %r10
   adcx %r8, %r8
   adox %rcx, %r11
@@ -800,7 +800,7 @@ fsqr2_e:
   movq 32(%rsi), %rdx
   ;# f[0]
   mulxq 40(%rsi), %r8, %r14
-  xor %r15, %r15
+  xor %r15d, %r15d
   ;# f[1]*f[0]
   mulxq 48(%rsi), %r9, %r10
   adcx %r14, %r9
@@ -824,7 +824,7 @@ fsqr2_e:
   ;# f[2]*f[1]
   
   ;# Step 2: Compute two parallel carry chains
-  xor %r15, %r15
+  xor %r15d, %r15d
   adox %rax, %r10
   adcx %r8, %r8
   adox %rcx, %r11
@@ -882,7 +882,7 @@ fsqr2_e:
   ;# Step 1: Compute dst + carry == tmp_hi * 38 + tmp_lo
   mov $38, %rdx
   mulxq 32(%rsi), %r8, %r13
-  xor %rcx, %rcx
+  xor %ecx, %ecx
   adoxq 0(%rsi), %r8
   mulxq 40(%rsi), %r9, %rbx
   adcx %r13, %r9
@@ -915,7 +915,7 @@ fsqr2_e:
   ;# Step 1: Compute dst + carry == tmp_hi * 38 + tmp_lo
   mov $38, %rdx
   mulxq 96(%rsi), %r8, %r13
-  xor %rcx, %rcx
+  xor %ecx, %ecx
   adoxq 64(%rsi), %r8
   mulxq 104(%rsi), %r9, %rbx
   adcx %r13, %r9

--- a/dist/portable-gcc-compatible/curve25519-x86_64-msvc.asm
+++ b/dist/portable-gcc-compatible/curve25519-x86_64-msvc.asm
@@ -7,11 +7,11 @@ add_scalar_e proc
   mov rsi, rdx
   mov rdx, r8
   ;# Clear registers to propagate the carry bit
-  xor r8, r8
-  xor r9, r9
-  xor r10, r10
-  xor r11, r11
-  xor rax, rax
+  xor r8d, r8d
+  xor r9d, r9d
+  xor r10d, r10d
+  xor r11d, r11d
+  xor eax, eax
   
   ;# Begin addition chain
   add rdx, qword ptr [rsi + 0]
@@ -52,7 +52,7 @@ fadd_e proc
   cmovc rax, rdx
   
   ;# Step 2: Add carry*38 to the original sum
-  xor rcx, rcx
+  xor ecx, ecx
   add r8, rax
   adcx r9, rcx
   mov qword ptr [rdi + 8], r9
@@ -176,7 +176,7 @@ fmul_e proc
   ;# Compute src1[0] * src2
   mov rdx, qword ptr [rsi + 0]
   mulx r9, r8, qword ptr [rcx + 0]
-  xor r10, r10
+  xor r10d, r10d
   mov qword ptr [rdi + 0], r8
   
   mulx r11, r10, qword ptr [rcx + 8]
@@ -194,7 +194,7 @@ fmul_e proc
   ;# Compute src1[1] * src2
   mov rdx, qword ptr [rsi + 8]
   mulx r9, r8, qword ptr [rcx + 0]
-  xor r10, r10
+  xor r10d, r10d
   adcx r8, qword ptr [rdi + 8]
   mov qword ptr [rdi + 8], r8
   mulx r11, r10, qword ptr [rcx + 8]
@@ -216,7 +216,7 @@ fmul_e proc
   ;# Compute src1[2] * src2
   mov rdx, qword ptr [rsi + 16]
   mulx r9, r8, qword ptr [rcx + 0]
-  xor r10, r10
+  xor r10d, r10d
   adcx r8, qword ptr [rdi + 16]
   mov qword ptr [rdi + 16], r8
   mulx r11, r10, qword ptr [rcx + 8]
@@ -238,7 +238,7 @@ fmul_e proc
   ;# Compute src1[3] * src2
   mov rdx, qword ptr [rsi + 24]
   mulx r9, r8, qword ptr [rcx + 0]
-  xor r10, r10
+  xor r10d, r10d
   adcx r8, qword ptr [rdi + 24]
   mov qword ptr [rdi + 24], r8
   mulx r11, r10, qword ptr [rcx + 8]
@@ -267,7 +267,7 @@ fmul_e proc
   ;# Step 1: Compute dst + carry == tmp_hi * 38 + tmp_lo
   mov rdx, 38
   mulx r13, r8, qword ptr [rsi + 32]
-  xor rcx, rcx
+  xor ecx, ecx
   adox r8, qword ptr [rsi + 0]
   mulx rbx, r9, qword ptr [rsi + 40]
   adcx r9, r13
@@ -320,7 +320,7 @@ fmul2_e proc
   ;# Compute src1[0] * src2
   mov rdx, qword ptr [rsi + 0]
   mulx r9, r8, qword ptr [rcx + 0]
-  xor r10, r10
+  xor r10d, r10d
   mov qword ptr [rdi + 0], r8
   
   mulx r11, r10, qword ptr [rcx + 8]
@@ -338,7 +338,7 @@ fmul2_e proc
   ;# Compute src1[1] * src2
   mov rdx, qword ptr [rsi + 8]
   mulx r9, r8, qword ptr [rcx + 0]
-  xor r10, r10
+  xor r10d, r10d
   adcx r8, qword ptr [rdi + 8]
   mov qword ptr [rdi + 8], r8
   mulx r11, r10, qword ptr [rcx + 8]
@@ -360,7 +360,7 @@ fmul2_e proc
   ;# Compute src1[2] * src2
   mov rdx, qword ptr [rsi + 16]
   mulx r9, r8, qword ptr [rcx + 0]
-  xor r10, r10
+  xor r10d, r10d
   adcx r8, qword ptr [rdi + 16]
   mov qword ptr [rdi + 16], r8
   mulx r11, r10, qword ptr [rcx + 8]
@@ -382,7 +382,7 @@ fmul2_e proc
   ;# Compute src1[3] * src2
   mov rdx, qword ptr [rsi + 24]
   mulx r9, r8, qword ptr [rcx + 0]
-  xor r10, r10
+  xor r10d, r10d
   adcx r8, qword ptr [rdi + 24]
   mov qword ptr [rdi + 24], r8
   mulx r11, r10, qword ptr [rcx + 8]
@@ -407,7 +407,7 @@ fmul2_e proc
   ;# Compute src1[0] * src2
   mov rdx, qword ptr [rsi + 32]
   mulx r9, r8, qword ptr [rcx + 32]
-  xor r10, r10
+  xor r10d, r10d
   mov qword ptr [rdi + 64], r8
   
   mulx r11, r10, qword ptr [rcx + 40]
@@ -425,7 +425,7 @@ fmul2_e proc
   ;# Compute src1[1] * src2
   mov rdx, qword ptr [rsi + 40]
   mulx r9, r8, qword ptr [rcx + 32]
-  xor r10, r10
+  xor r10d, r10d
   adcx r8, qword ptr [rdi + 72]
   mov qword ptr [rdi + 72], r8
   mulx r11, r10, qword ptr [rcx + 40]
@@ -447,7 +447,7 @@ fmul2_e proc
   ;# Compute src1[2] * src2
   mov rdx, qword ptr [rsi + 48]
   mulx r9, r8, qword ptr [rcx + 32]
-  xor r10, r10
+  xor r10d, r10d
   adcx r8, qword ptr [rdi + 80]
   mov qword ptr [rdi + 80], r8
   mulx r11, r10, qword ptr [rcx + 40]
@@ -469,7 +469,7 @@ fmul2_e proc
   ;# Compute src1[3] * src2
   mov rdx, qword ptr [rsi + 56]
   mulx r9, r8, qword ptr [rcx + 32]
-  xor r10, r10
+  xor r10d, r10d
   adcx r8, qword ptr [rdi + 88]
   mov qword ptr [rdi + 88], r8
   mulx r11, r10, qword ptr [rcx + 40]
@@ -498,7 +498,7 @@ fmul2_e proc
   ;# Step 1: Compute dst + carry == tmp_hi * 38 + tmp_lo
   mov rdx, 38
   mulx r13, r8, qword ptr [rsi + 32]
-  xor rcx, rcx
+  xor ecx, ecx
   adox r8, qword ptr [rsi + 0]
   mulx rbx, r9, qword ptr [rsi + 40]
   adcx r9, r13
@@ -531,7 +531,7 @@ fmul2_e proc
   ;# Step 1: Compute dst + carry == tmp_hi * 38 + tmp_lo
   mov rdx, 38
   mulx r13, r8, qword ptr [rsi + 96]
-  xor rcx, rcx
+  xor ecx, ecx
   adox r8, qword ptr [rsi + 64]
   mulx rbx, r9, qword ptr [rsi + 104]
   adcx r9, r13
@@ -585,7 +585,7 @@ fsqr_e proc
   mov rdx, qword ptr [rsi + 0]
   ;# f[0]
   mulx r14, r8, qword ptr [rsi + 8]
-  xor r15, r15
+  xor r15d, r15d
   ;# f[1]*f[0]
   mulx r10, r9, qword ptr [rsi + 16]
   adcx r9, r14
@@ -609,7 +609,7 @@ fsqr_e proc
   ;# f[2]*f[1]
   
   ;# Step 2: Compute two parallel carry chains
-  xor r15, r15
+  xor r15d, r15d
   adox r10, rax
   adcx r8, r8
   adox r11, rcx
@@ -667,7 +667,7 @@ fsqr_e proc
   ;# Step 1: Compute dst + carry == tmp_hi * 38 + tmp_lo
   mov rdx, 38
   mulx r13, r8, qword ptr [rsi + 32]
-  xor rcx, rcx
+  xor ecx, ecx
   adox r8, qword ptr [rsi + 0]
   mulx rbx, r9, qword ptr [rsi + 40]
   adcx r9, r13
@@ -721,7 +721,7 @@ fsqr2_e proc
   mov rdx, qword ptr [rsi + 0]
   ;# f[0]
   mulx r14, r8, qword ptr [rsi + 8]
-  xor r15, r15
+  xor r15d, r15d
   ;# f[1]*f[0]
   mulx r10, r9, qword ptr [rsi + 16]
   adcx r9, r14
@@ -745,7 +745,7 @@ fsqr2_e proc
   ;# f[2]*f[1]
   
   ;# Step 2: Compute two parallel carry chains
-  xor r15, r15
+  xor r15d, r15d
   adox r10, rax
   adcx r8, r8
   adox r11, rcx
@@ -800,7 +800,7 @@ fsqr2_e proc
   mov rdx, qword ptr [rsi + 32]
   ;# f[0]
   mulx r14, r8, qword ptr [rsi + 40]
-  xor r15, r15
+  xor r15d, r15d
   ;# f[1]*f[0]
   mulx r10, r9, qword ptr [rsi + 48]
   adcx r9, r14
@@ -824,7 +824,7 @@ fsqr2_e proc
   ;# f[2]*f[1]
   
   ;# Step 2: Compute two parallel carry chains
-  xor r15, r15
+  xor r15d, r15d
   adox r10, rax
   adcx r8, r8
   adox r11, rcx
@@ -882,7 +882,7 @@ fsqr2_e proc
   ;# Step 1: Compute dst + carry == tmp_hi * 38 + tmp_lo
   mov rdx, 38
   mulx r13, r8, qword ptr [rsi + 32]
-  xor rcx, rcx
+  xor ecx, ecx
   adox r8, qword ptr [rsi + 0]
   mulx rbx, r9, qword ptr [rsi + 40]
   adcx r9, r13
@@ -915,7 +915,7 @@ fsqr2_e proc
   ;# Step 1: Compute dst + carry == tmp_hi * 38 + tmp_lo
   mov rdx, 38
   mulx r13, r8, qword ptr [rsi + 96]
-  xor rcx, rcx
+  xor ecx, ecx
   adox r8, qword ptr [rsi + 64]
   mulx rbx, r9, qword ptr [rsi + 104]
   adcx r9, r13

--- a/dist/vale/curve25519-inline.h
+++ b/dist/vale/curve25519-inline.h
@@ -10,11 +10,11 @@ static inline uint64_t add_scalar (uint64_t *out, uint64_t *f1, uint64_t f2)
 
   asm volatile(
     // Clear registers to propagate the carry bit
-    "  xor %%r8, %%r8;"
-    "  xor %%r9, %%r9;"
-    "  xor %%r10, %%r10;"
-    "  xor %%r11, %%r11;"
-    "  xor %1, %1;"
+    "  xor %%r8d, %%r8d;"
+    "  xor %%r9d, %%r9d;"
+    "  xor %%r10d, %%r10d;"
+    "  xor %%r11d, %%r11d;"
+    "  xor %k1, %k1;"
 
     // Begin addition chain
     "  addq 0(%3), %0;"
@@ -58,7 +58,7 @@ static inline void fadd (uint64_t *out, uint64_t *f1, uint64_t *f2)
     "  cmovc %0, %%rax;"
 
     // Step 2: Add carry*38 to the original sum
-    "  xor %%rcx, %%rcx;"
+    "  xor %%ecx, %%ecx;"
     "  add %%rax, %%r8;"
     "  adcx %%rcx, %%r9;"
     "  movq %%r9, 8(%1);"
@@ -131,7 +131,7 @@ static inline void fmul (uint64_t *out, uint64_t *f1, uint64_t *f2, uint64_t *tm
 
     // Compute src1[0] * src2
     "  movq 0(%1), %%rdx;"
-    "  mulxq 0(%2), %%r8, %%r9;"       "  xor %%r10, %%r10;"     "  movq %%r8, 0(%3);"
+    "  mulxq 0(%2), %%r8, %%r9;"       "  xor %%r10d, %%r10d;"     "  movq %%r8, 0(%3);"
     "  mulxq 8(%2), %%r10, %%r11;"     "  adox %%r9, %%r10;"     "  movq %%r10, 8(%3);"
     "  mulxq 16(%2), %%rbx, %%r13;"    "  adox %%r11, %%rbx;"
     "  mulxq 24(%2), %%r14, %%rdx;"    "  adox %%r13, %%r14;"    "  mov $0, %%rax;"
@@ -139,7 +139,7 @@ static inline void fmul (uint64_t *out, uint64_t *f1, uint64_t *f2, uint64_t *tm
 
     // Compute src1[1] * src2
     "  movq 8(%1), %%rdx;"
-    "  mulxq 0(%2), %%r8, %%r9;"       "  xor %%r10, %%r10;"     "  adcxq 8(%3), %%r8;"    "  movq %%r8, 8(%3);"
+    "  mulxq 0(%2), %%r8, %%r9;"       "  xor %%r10d, %%r10d;"     "  adcxq 8(%3), %%r8;"    "  movq %%r8, 8(%3);"
     "  mulxq 8(%2), %%r10, %%r11;"     "  adox %%r9, %%r10;"     "  adcx %%rbx, %%r10;"    "  movq %%r10, 16(%3);"
     "  mulxq 16(%2), %%rbx, %%r13;"    "  adox %%r11, %%rbx;"    "  adcx %%r14, %%rbx;"    "  mov $0, %%r8;"
     "  mulxq 24(%2), %%r14, %%rdx;"    "  adox %%r13, %%r14;"    "  adcx %%rax, %%r14;"    "  mov $0, %%rax;"
@@ -148,7 +148,7 @@ static inline void fmul (uint64_t *out, uint64_t *f1, uint64_t *f2, uint64_t *tm
 
     // Compute src1[2] * src2
     "  movq 16(%1), %%rdx;"
-    "  mulxq 0(%2), %%r8, %%r9;"       "  xor %%r10, %%r10;"    "  adcxq 16(%3), %%r8;"    "  movq %%r8, 16(%3);"
+    "  mulxq 0(%2), %%r8, %%r9;"       "  xor %%r10d, %%r10d;"    "  adcxq 16(%3), %%r8;"    "  movq %%r8, 16(%3);"
     "  mulxq 8(%2), %%r10, %%r11;"     "  adox %%r9, %%r10;"     "  adcx %%rbx, %%r10;"    "  movq %%r10, 24(%3);"
     "  mulxq 16(%2), %%rbx, %%r13;"    "  adox %%r11, %%rbx;"    "  adcx %%r14, %%rbx;"    "  mov $0, %%r8;"
     "  mulxq 24(%2), %%r14, %%rdx;"    "  adox %%r13, %%r14;"    "  adcx %%rax, %%r14;"    "  mov $0, %%rax;"
@@ -157,7 +157,7 @@ static inline void fmul (uint64_t *out, uint64_t *f1, uint64_t *f2, uint64_t *tm
 
     // Compute src1[3] * src2
     "  movq 24(%1), %%rdx;"
-    "  mulxq 0(%2), %%r8, %%r9;"       "  xor %%r10, %%r10;"    "  adcxq 24(%3), %%r8;"    "  movq %%r8, 24(%3);"
+    "  mulxq 0(%2), %%r8, %%r9;"       "  xor %%r10d, %%r10d;"    "  adcxq 24(%3), %%r8;"    "  movq %%r8, 24(%3);"
     "  mulxq 8(%2), %%r10, %%r11;"     "  adox %%r9, %%r10;"     "  adcx %%rbx, %%r10;"    "  movq %%r10, 32(%3);"
     "  mulxq 16(%2), %%rbx, %%r13;"    "  adox %%r11, %%rbx;"    "  adcx %%r14, %%rbx;"    "  movq %%rbx, 40(%3);"    "  mov $0, %%r8;"
     "  mulxq 24(%2), %%r14, %%rdx;"    "  adox %%r13, %%r14;"    "  adcx %%rax, %%r14;"    "  movq %%r14, 48(%3);"    "  mov $0, %%rax;"
@@ -172,7 +172,7 @@ static inline void fmul (uint64_t *out, uint64_t *f1, uint64_t *f2, uint64_t *tm
     // Step 1: Compute dst + carry == tmp_hi * 38 + tmp_lo
     "  mov $38, %%rdx;"
     "  mulxq 32(%1), %%r8, %%r13;"
-    "  xor %2, %2;"
+    "  xor %k2, %k2;"
     "  adoxq 0(%1), %%r8;"
     "  mulxq 40(%1), %%r9, %%rbx;"
     "  adcx %%r13, %%r9;"
@@ -219,7 +219,7 @@ static inline void fmul2 (uint64_t *out, uint64_t *f1, uint64_t *f2, uint64_t *t
 
     // Compute src1[0] * src2
     "  movq 0(%1), %%rdx;"
-    "  mulxq 0(%2), %%r8, %%r9;"       "  xor %%r10, %%r10;"     "  movq %%r8, 0(%3);"
+    "  mulxq 0(%2), %%r8, %%r9;"       "  xor %%r10d, %%r10d;"     "  movq %%r8, 0(%3);"
     "  mulxq 8(%2), %%r10, %%r11;"     "  adox %%r9, %%r10;"     "  movq %%r10, 8(%3);"
     "  mulxq 16(%2), %%rbx, %%r13;"    "  adox %%r11, %%rbx;"
     "  mulxq 24(%2), %%r14, %%rdx;"    "  adox %%r13, %%r14;"    "  mov $0, %%rax;"
@@ -227,7 +227,7 @@ static inline void fmul2 (uint64_t *out, uint64_t *f1, uint64_t *f2, uint64_t *t
 
     // Compute src1[1] * src2
     "  movq 8(%1), %%rdx;"
-    "  mulxq 0(%2), %%r8, %%r9;"       "  xor %%r10, %%r10;"     "  adcxq 8(%3), %%r8;"    "  movq %%r8, 8(%3);"
+    "  mulxq 0(%2), %%r8, %%r9;"       "  xor %%r10d, %%r10d;"     "  adcxq 8(%3), %%r8;"    "  movq %%r8, 8(%3);"
     "  mulxq 8(%2), %%r10, %%r11;"     "  adox %%r9, %%r10;"     "  adcx %%rbx, %%r10;"    "  movq %%r10, 16(%3);"
     "  mulxq 16(%2), %%rbx, %%r13;"    "  adox %%r11, %%rbx;"    "  adcx %%r14, %%rbx;"    "  mov $0, %%r8;"
     "  mulxq 24(%2), %%r14, %%rdx;"    "  adox %%r13, %%r14;"    "  adcx %%rax, %%r14;"    "  mov $0, %%rax;"
@@ -236,7 +236,7 @@ static inline void fmul2 (uint64_t *out, uint64_t *f1, uint64_t *f2, uint64_t *t
 
     // Compute src1[2] * src2
     "  movq 16(%1), %%rdx;"
-    "  mulxq 0(%2), %%r8, %%r9;"       "  xor %%r10, %%r10;"    "  adcxq 16(%3), %%r8;"    "  movq %%r8, 16(%3);"
+    "  mulxq 0(%2), %%r8, %%r9;"       "  xor %%r10d, %%r10d;"    "  adcxq 16(%3), %%r8;"    "  movq %%r8, 16(%3);"
     "  mulxq 8(%2), %%r10, %%r11;"     "  adox %%r9, %%r10;"     "  adcx %%rbx, %%r10;"    "  movq %%r10, 24(%3);"
     "  mulxq 16(%2), %%rbx, %%r13;"    "  adox %%r11, %%rbx;"    "  adcx %%r14, %%rbx;"    "  mov $0, %%r8;"
     "  mulxq 24(%2), %%r14, %%rdx;"    "  adox %%r13, %%r14;"    "  adcx %%rax, %%r14;"    "  mov $0, %%rax;"
@@ -245,7 +245,7 @@ static inline void fmul2 (uint64_t *out, uint64_t *f1, uint64_t *f2, uint64_t *t
 
     // Compute src1[3] * src2
     "  movq 24(%1), %%rdx;"
-    "  mulxq 0(%2), %%r8, %%r9;"       "  xor %%r10, %%r10;"    "  adcxq 24(%3), %%r8;"    "  movq %%r8, 24(%3);"
+    "  mulxq 0(%2), %%r8, %%r9;"       "  xor %%r10d, %%r10d;"    "  adcxq 24(%3), %%r8;"    "  movq %%r8, 24(%3);"
     "  mulxq 8(%2), %%r10, %%r11;"     "  adox %%r9, %%r10;"     "  adcx %%rbx, %%r10;"    "  movq %%r10, 32(%3);"
     "  mulxq 16(%2), %%rbx, %%r13;"    "  adox %%r11, %%rbx;"    "  adcx %%r14, %%rbx;"    "  movq %%rbx, 40(%3);"    "  mov $0, %%r8;"
     "  mulxq 24(%2), %%r14, %%rdx;"    "  adox %%r13, %%r14;"    "  adcx %%rax, %%r14;"    "  movq %%r14, 48(%3);"    "  mov $0, %%rax;"
@@ -255,7 +255,7 @@ static inline void fmul2 (uint64_t *out, uint64_t *f1, uint64_t *f2, uint64_t *t
 
     // Compute src1[0] * src2
     "  movq 32(%1), %%rdx;"
-    "  mulxq 32(%2), %%r8, %%r9;"       "  xor %%r10, %%r10;"     "  movq %%r8, 64(%3);"
+    "  mulxq 32(%2), %%r8, %%r9;"       "  xor %%r10d, %%r10d;"     "  movq %%r8, 64(%3);"
     "  mulxq 40(%2), %%r10, %%r11;"     "  adox %%r9, %%r10;"     "  movq %%r10, 72(%3);"
     "  mulxq 48(%2), %%rbx, %%r13;"    "  adox %%r11, %%rbx;"
     "  mulxq 56(%2), %%r14, %%rdx;"    "  adox %%r13, %%r14;"    "  mov $0, %%rax;"
@@ -263,7 +263,7 @@ static inline void fmul2 (uint64_t *out, uint64_t *f1, uint64_t *f2, uint64_t *t
 
     // Compute src1[1] * src2
     "  movq 40(%1), %%rdx;"
-    "  mulxq 32(%2), %%r8, %%r9;"       "  xor %%r10, %%r10;"     "  adcxq 72(%3), %%r8;"    "  movq %%r8, 72(%3);"
+    "  mulxq 32(%2), %%r8, %%r9;"       "  xor %%r10d, %%r10d;"     "  adcxq 72(%3), %%r8;"    "  movq %%r8, 72(%3);"
     "  mulxq 40(%2), %%r10, %%r11;"     "  adox %%r9, %%r10;"     "  adcx %%rbx, %%r10;"    "  movq %%r10, 80(%3);"
     "  mulxq 48(%2), %%rbx, %%r13;"    "  adox %%r11, %%rbx;"    "  adcx %%r14, %%rbx;"    "  mov $0, %%r8;"
     "  mulxq 56(%2), %%r14, %%rdx;"    "  adox %%r13, %%r14;"    "  adcx %%rax, %%r14;"    "  mov $0, %%rax;"
@@ -272,7 +272,7 @@ static inline void fmul2 (uint64_t *out, uint64_t *f1, uint64_t *f2, uint64_t *t
 
     // Compute src1[2] * src2
     "  movq 48(%1), %%rdx;"
-    "  mulxq 32(%2), %%r8, %%r9;"       "  xor %%r10, %%r10;"    "  adcxq 80(%3), %%r8;"    "  movq %%r8, 80(%3);"
+    "  mulxq 32(%2), %%r8, %%r9;"       "  xor %%r10d, %%r10d;"    "  adcxq 80(%3), %%r8;"    "  movq %%r8, 80(%3);"
     "  mulxq 40(%2), %%r10, %%r11;"     "  adox %%r9, %%r10;"     "  adcx %%rbx, %%r10;"    "  movq %%r10, 88(%3);"
     "  mulxq 48(%2), %%rbx, %%r13;"    "  adox %%r11, %%rbx;"    "  adcx %%r14, %%rbx;"    "  mov $0, %%r8;"
     "  mulxq 56(%2), %%r14, %%rdx;"    "  adox %%r13, %%r14;"    "  adcx %%rax, %%r14;"    "  mov $0, %%rax;"
@@ -281,7 +281,7 @@ static inline void fmul2 (uint64_t *out, uint64_t *f1, uint64_t *f2, uint64_t *t
 
     // Compute src1[3] * src2
     "  movq 56(%1), %%rdx;"
-    "  mulxq 32(%2), %%r8, %%r9;"       "  xor %%r10, %%r10;"    "  adcxq 88(%3), %%r8;"    "  movq %%r8, 88(%3);"
+    "  mulxq 32(%2), %%r8, %%r9;"       "  xor %%r10d, %%r10d;"    "  adcxq 88(%3), %%r8;"    "  movq %%r8, 88(%3);"
     "  mulxq 40(%2), %%r10, %%r11;"     "  adox %%r9, %%r10;"     "  adcx %%rbx, %%r10;"    "  movq %%r10, 96(%3);"
     "  mulxq 48(%2), %%rbx, %%r13;"    "  adox %%r11, %%rbx;"    "  adcx %%r14, %%rbx;"    "  movq %%rbx, 104(%3);"    "  mov $0, %%r8;"
     "  mulxq 56(%2), %%r14, %%rdx;"    "  adox %%r13, %%r14;"    "  adcx %%rax, %%r14;"    "  movq %%r14, 112(%3);"    "  mov $0, %%rax;"
@@ -296,7 +296,7 @@ static inline void fmul2 (uint64_t *out, uint64_t *f1, uint64_t *f2, uint64_t *t
     // Step 1: Compute dst + carry == tmp_hi * 38 + tmp_lo
     "  mov $38, %%rdx;"
     "  mulxq 32(%1), %%r8, %%r13;"
-    "  xor %2, %2;"
+    "  xor %k2, %k2;"
     "  adoxq 0(%1), %%r8;"
     "  mulxq 40(%1), %%r9, %%rbx;"
     "  adcx %%r13, %%r9;"
@@ -329,7 +329,7 @@ static inline void fmul2 (uint64_t *out, uint64_t *f1, uint64_t *f2, uint64_t *t
     // Step 1: Compute dst + carry == tmp_hi * 38 + tmp_lo
     "  mov $38, %%rdx;"
     "  mulxq 96(%1), %%r8, %%r13;"
-    "  xor %2, %2;"
+    "  xor %k2, %k2;"
     "  adoxq 64(%1), %%r8;"
     "  mulxq 104(%1), %%r9, %%rbx;"
     "  adcx %%r13, %%r9;"
@@ -502,7 +502,7 @@ static inline void fsqr (uint64_t *out, uint64_t *f, uint64_t *tmp)
 
     // Step 1: Compute all partial products
     "  movq 0(%1), %%rdx;"                                       // f[0]
-    "  mulxq 8(%1), %%r8, %%r14;"      "  xor %%r15, %%r15;"     // f[1]*f[0]
+    "  mulxq 8(%1), %%r8, %%r14;"      "  xor %%r15d, %%r15d;"     // f[1]*f[0]
     "  mulxq 16(%1), %%r9, %%r10;"     "  adcx %%r14, %%r9;"     // f[2]*f[0]
     "  mulxq 24(%1), %%rax, %%rcx;"    "  adcx %%rax, %%r10;"    // f[3]*f[0]
     "  movq 24(%1), %%rdx;"                                      // f[3]
@@ -512,7 +512,7 @@ static inline void fsqr (uint64_t *out, uint64_t *f, uint64_t *tmp)
     "  mulxq 16(%1), %%rax, %%rcx;"    "  mov $0, %%r14;"        // f[2]*f[1]
 
     // Step 2: Compute two parallel carry chains
-    "  xor %%r15, %%r15;"
+    "  xor %%r15d, %%r15d;"
     "  adox %%rax, %%r10;"
     "  adcx %%r8, %%r8;"
     "  adox %%rcx, %%r11;"
@@ -549,7 +549,7 @@ static inline void fsqr (uint64_t *out, uint64_t *f, uint64_t *tmp)
     // Step 1: Compute dst + carry == tmp_hi * 38 + tmp_lo
     "  mov $38, %%rdx;"
     "  mulxq 32(%1), %%r8, %%r13;"
-    "  xor %%rcx, %%rcx;"
+    "  xor %%ecx, %%ecx;"
     "  adoxq 0(%1), %%r8;"
     "  mulxq 40(%1), %%r9, %%rbx;"
     "  adcx %%r13, %%r9;"
@@ -593,7 +593,7 @@ static inline void fsqr2 (uint64_t *out, uint64_t *f, uint64_t *tmp)
   asm volatile(
     // Step 1: Compute all partial products
     "  movq 0(%1), %%rdx;"                                       // f[0]
-    "  mulxq 8(%1), %%r8, %%r14;"      "  xor %%r15, %%r15;"     // f[1]*f[0]
+    "  mulxq 8(%1), %%r8, %%r14;"      "  xor %%r15d, %%r15d;"     // f[1]*f[0]
     "  mulxq 16(%1), %%r9, %%r10;"     "  adcx %%r14, %%r9;"     // f[2]*f[0]
     "  mulxq 24(%1), %%rax, %%rcx;"    "  adcx %%rax, %%r10;"    // f[3]*f[0]
     "  movq 24(%1), %%rdx;"                                      // f[3]
@@ -603,7 +603,7 @@ static inline void fsqr2 (uint64_t *out, uint64_t *f, uint64_t *tmp)
     "  mulxq 16(%1), %%rax, %%rcx;"    "  mov $0, %%r14;"        // f[2]*f[1]
 
     // Step 2: Compute two parallel carry chains
-    "  xor %%r15, %%r15;"
+    "  xor %%r15d, %%r15d;"
     "  adox %%rax, %%r10;"
     "  adcx %%r8, %%r8;"
     "  adox %%rcx, %%r11;"
@@ -633,7 +633,7 @@ static inline void fsqr2 (uint64_t *out, uint64_t *f, uint64_t *tmp)
 
     // Step 1: Compute all partial products
     "  movq 32(%1), %%rdx;"                                       // f[0]
-    "  mulxq 40(%1), %%r8, %%r14;"      "  xor %%r15, %%r15;"     // f[1]*f[0]
+    "  mulxq 40(%1), %%r8, %%r14;"      "  xor %%r15d, %%r15d;"     // f[1]*f[0]
     "  mulxq 48(%1), %%r9, %%r10;"     "  adcx %%r14, %%r9;"     // f[2]*f[0]
     "  mulxq 56(%1), %%rax, %%rcx;"    "  adcx %%rax, %%r10;"    // f[3]*f[0]
     "  movq 56(%1), %%rdx;"                                      // f[3]
@@ -643,7 +643,7 @@ static inline void fsqr2 (uint64_t *out, uint64_t *f, uint64_t *tmp)
     "  mulxq 48(%1), %%rax, %%rcx;"    "  mov $0, %%r14;"        // f[2]*f[1]
 
     // Step 2: Compute two parallel carry chains
-    "  xor %%r15, %%r15;"
+    "  xor %%r15d, %%r15d;"
     "  adox %%rax, %%r10;"
     "  adcx %%r8, %%r8;"
     "  adox %%rcx, %%r11;"
@@ -678,7 +678,7 @@ static inline void fsqr2 (uint64_t *out, uint64_t *f, uint64_t *tmp)
     // Step 1: Compute dst + carry == tmp_hi * 38 + tmp_lo
     "  mov $38, %%rdx;"
     "  mulxq 32(%1), %%r8, %%r13;"
-    "  xor %%rcx, %%rcx;"
+    "  xor %%ecx, %%ecx;"
     "  adoxq 0(%1), %%r8;"
     "  mulxq 40(%1), %%r9, %%rbx;"
     "  adcx %%r13, %%r9;"
@@ -711,7 +711,7 @@ static inline void fsqr2 (uint64_t *out, uint64_t *f, uint64_t *tmp)
     // Step 1: Compute dst + carry == tmp_hi * 38 + tmp_lo
     "  mov $38, %%rdx;"
     "  mulxq 96(%1), %%r8, %%r13;"
-    "  xor %%rcx, %%rcx;"
+    "  xor %%ecx, %%ecx;"
     "  adoxq 64(%1), %%r8;"
     "  mulxq 104(%1), %%r9, %%rbx;"
     "  adcx %%r13, %%r9;"

--- a/dist/vale/curve25519-x86_64-darwin.S
+++ b/dist/vale/curve25519-x86_64-darwin.S
@@ -4,11 +4,11 @@ _add_scalar_e:
   push %rdi
   push %rsi
   ;# Clear registers to propagate the carry bit
-  xor %r8, %r8
-  xor %r9, %r9
-  xor %r10, %r10
-  xor %r11, %r11
-  xor %rax, %rax
+  xor %r8d, %r8d
+  xor %r9d, %r9d
+  xor %r10d, %r10d
+  xor %r11d, %r11d
+  xor %eax, %eax
   
   ;# Begin addition chain
   addq 0(%rsi), %rdx
@@ -44,7 +44,7 @@ _fadd_e:
   cmovc %rdx, %rax
   
   ;# Step 2: Add carry*38 to the original sum
-  xor %rcx, %rcx
+  xor %ecx, %ecx
   add %rax, %r8
   adcx %rcx, %r9
   movq %r9, 8(%rdi)
@@ -149,7 +149,7 @@ _fmul_e:
   ;# Compute src1[0] * src2
   movq 0(%rsi), %rdx
   mulxq 0(%rcx), %r8, %r9
-  xor %r10, %r10
+  xor %r10d, %r10d
   movq %r8, 0(%rdi)
   
   mulxq 8(%rcx), %r10, %r11
@@ -167,7 +167,7 @@ _fmul_e:
   ;# Compute src1[1] * src2
   movq 8(%rsi), %rdx
   mulxq 0(%rcx), %r8, %r9
-  xor %r10, %r10
+  xor %r10d, %r10d
   adcxq 8(%rdi), %r8
   movq %r8, 8(%rdi)
   mulxq 8(%rcx), %r10, %r11
@@ -189,7 +189,7 @@ _fmul_e:
   ;# Compute src1[2] * src2
   movq 16(%rsi), %rdx
   mulxq 0(%rcx), %r8, %r9
-  xor %r10, %r10
+  xor %r10d, %r10d
   adcxq 16(%rdi), %r8
   movq %r8, 16(%rdi)
   mulxq 8(%rcx), %r10, %r11
@@ -211,7 +211,7 @@ _fmul_e:
   ;# Compute src1[3] * src2
   movq 24(%rsi), %rdx
   mulxq 0(%rcx), %r8, %r9
-  xor %r10, %r10
+  xor %r10d, %r10d
   adcxq 24(%rdi), %r8
   movq %r8, 24(%rdi)
   mulxq 8(%rcx), %r10, %r11
@@ -240,7 +240,7 @@ _fmul_e:
   ;# Step 1: Compute dst + carry == tmp_hi * 38 + tmp_lo
   mov $38, %rdx
   mulxq 32(%rsi), %r8, %r13
-  xor %rcx, %rcx
+  xor %ecx, %ecx
   adoxq 0(%rsi), %r8
   mulxq 40(%rsi), %r9, %rbx
   adcx %r13, %r9
@@ -286,7 +286,7 @@ _fmul2_e:
   ;# Compute src1[0] * src2
   movq 0(%rsi), %rdx
   mulxq 0(%rcx), %r8, %r9
-  xor %r10, %r10
+  xor %r10d, %r10d
   movq %r8, 0(%rdi)
   
   mulxq 8(%rcx), %r10, %r11
@@ -304,7 +304,7 @@ _fmul2_e:
   ;# Compute src1[1] * src2
   movq 8(%rsi), %rdx
   mulxq 0(%rcx), %r8, %r9
-  xor %r10, %r10
+  xor %r10d, %r10d
   adcxq 8(%rdi), %r8
   movq %r8, 8(%rdi)
   mulxq 8(%rcx), %r10, %r11
@@ -326,7 +326,7 @@ _fmul2_e:
   ;# Compute src1[2] * src2
   movq 16(%rsi), %rdx
   mulxq 0(%rcx), %r8, %r9
-  xor %r10, %r10
+  xor %r10d, %r10d
   adcxq 16(%rdi), %r8
   movq %r8, 16(%rdi)
   mulxq 8(%rcx), %r10, %r11
@@ -348,7 +348,7 @@ _fmul2_e:
   ;# Compute src1[3] * src2
   movq 24(%rsi), %rdx
   mulxq 0(%rcx), %r8, %r9
-  xor %r10, %r10
+  xor %r10d, %r10d
   adcxq 24(%rdi), %r8
   movq %r8, 24(%rdi)
   mulxq 8(%rcx), %r10, %r11
@@ -373,7 +373,7 @@ _fmul2_e:
   ;# Compute src1[0] * src2
   movq 32(%rsi), %rdx
   mulxq 32(%rcx), %r8, %r9
-  xor %r10, %r10
+  xor %r10d, %r10d
   movq %r8, 64(%rdi)
   
   mulxq 40(%rcx), %r10, %r11
@@ -391,7 +391,7 @@ _fmul2_e:
   ;# Compute src1[1] * src2
   movq 40(%rsi), %rdx
   mulxq 32(%rcx), %r8, %r9
-  xor %r10, %r10
+  xor %r10d, %r10d
   adcxq 72(%rdi), %r8
   movq %r8, 72(%rdi)
   mulxq 40(%rcx), %r10, %r11
@@ -413,7 +413,7 @@ _fmul2_e:
   ;# Compute src1[2] * src2
   movq 48(%rsi), %rdx
   mulxq 32(%rcx), %r8, %r9
-  xor %r10, %r10
+  xor %r10d, %r10d
   adcxq 80(%rdi), %r8
   movq %r8, 80(%rdi)
   mulxq 40(%rcx), %r10, %r11
@@ -435,7 +435,7 @@ _fmul2_e:
   ;# Compute src1[3] * src2
   movq 56(%rsi), %rdx
   mulxq 32(%rcx), %r8, %r9
-  xor %r10, %r10
+  xor %r10d, %r10d
   adcxq 88(%rdi), %r8
   movq %r8, 88(%rdi)
   mulxq 40(%rcx), %r10, %r11
@@ -464,7 +464,7 @@ _fmul2_e:
   ;# Step 1: Compute dst + carry == tmp_hi * 38 + tmp_lo
   mov $38, %rdx
   mulxq 32(%rsi), %r8, %r13
-  xor %rcx, %rcx
+  xor %ecx, %ecx
   adoxq 0(%rsi), %r8
   mulxq 40(%rsi), %r9, %rbx
   adcx %r13, %r9
@@ -497,7 +497,7 @@ _fmul2_e:
   ;# Step 1: Compute dst + carry == tmp_hi * 38 + tmp_lo
   mov $38, %rdx
   mulxq 96(%rsi), %r8, %r13
-  xor %rcx, %rcx
+  xor %ecx, %ecx
   adoxq 64(%rsi), %r8
   mulxq 104(%rsi), %r9, %rbx
   adcx %r13, %r9
@@ -545,7 +545,7 @@ _fsqr_e:
   movq 0(%rsi), %rdx
   ;# f[0]
   mulxq 8(%rsi), %r8, %r14
-  xor %r15, %r15
+  xor %r15d, %r15d
   ;# f[1]*f[0]
   mulxq 16(%rsi), %r9, %r10
   adcx %r14, %r9
@@ -569,7 +569,7 @@ _fsqr_e:
   ;# f[2]*f[1]
   
   ;# Step 2: Compute two parallel carry chains
-  xor %r15, %r15
+  xor %r15d, %r15d
   adox %rax, %r10
   adcx %r8, %r8
   adox %rcx, %r11
@@ -627,7 +627,7 @@ _fsqr_e:
   ;# Step 1: Compute dst + carry == tmp_hi * 38 + tmp_lo
   mov $38, %rdx
   mulxq 32(%rsi), %r8, %r13
-  xor %rcx, %rcx
+  xor %ecx, %ecx
   adoxq 0(%rsi), %r8
   mulxq 40(%rsi), %r9, %rbx
   adcx %r13, %r9
@@ -675,7 +675,7 @@ _fsqr2_e:
   movq 0(%rsi), %rdx
   ;# f[0]
   mulxq 8(%rsi), %r8, %r14
-  xor %r15, %r15
+  xor %r15d, %r15d
   ;# f[1]*f[0]
   mulxq 16(%rsi), %r9, %r10
   adcx %r14, %r9
@@ -699,7 +699,7 @@ _fsqr2_e:
   ;# f[2]*f[1]
   
   ;# Step 2: Compute two parallel carry chains
-  xor %r15, %r15
+  xor %r15d, %r15d
   adox %rax, %r10
   adcx %r8, %r8
   adox %rcx, %r11
@@ -754,7 +754,7 @@ _fsqr2_e:
   movq 32(%rsi), %rdx
   ;# f[0]
   mulxq 40(%rsi), %r8, %r14
-  xor %r15, %r15
+  xor %r15d, %r15d
   ;# f[1]*f[0]
   mulxq 48(%rsi), %r9, %r10
   adcx %r14, %r9
@@ -778,7 +778,7 @@ _fsqr2_e:
   ;# f[2]*f[1]
   
   ;# Step 2: Compute two parallel carry chains
-  xor %r15, %r15
+  xor %r15d, %r15d
   adox %rax, %r10
   adcx %r8, %r8
   adox %rcx, %r11
@@ -836,7 +836,7 @@ _fsqr2_e:
   ;# Step 1: Compute dst + carry == tmp_hi * 38 + tmp_lo
   mov $38, %rdx
   mulxq 32(%rsi), %r8, %r13
-  xor %rcx, %rcx
+  xor %ecx, %ecx
   adoxq 0(%rsi), %r8
   mulxq 40(%rsi), %r9, %rbx
   adcx %r13, %r9
@@ -869,7 +869,7 @@ _fsqr2_e:
   ;# Step 1: Compute dst + carry == tmp_hi * 38 + tmp_lo
   mov $38, %rdx
   mulxq 96(%rsi), %r8, %r13
-  xor %rcx, %rcx
+  xor %ecx, %ecx
   adoxq 64(%rsi), %r8
   mulxq 104(%rsi), %r9, %rbx
   adcx %r13, %r9

--- a/dist/vale/curve25519-x86_64-linux.S
+++ b/dist/vale/curve25519-x86_64-linux.S
@@ -4,11 +4,11 @@ add_scalar_e:
   push %rdi
   push %rsi
   ;# Clear registers to propagate the carry bit
-  xor %r8, %r8
-  xor %r9, %r9
-  xor %r10, %r10
-  xor %r11, %r11
-  xor %rax, %rax
+  xor %r8d, %r8d
+  xor %r9d, %r9d
+  xor %r10d, %r10d
+  xor %r11d, %r11d
+  xor %eax, %eax
   
   ;# Begin addition chain
   addq 0(%rsi), %rdx
@@ -44,7 +44,7 @@ fadd_e:
   cmovc %rdx, %rax
   
   ;# Step 2: Add carry*38 to the original sum
-  xor %rcx, %rcx
+  xor %ecx, %ecx
   add %rax, %r8
   adcx %rcx, %r9
   movq %r9, 8(%rdi)
@@ -149,7 +149,7 @@ fmul_e:
   ;# Compute src1[0] * src2
   movq 0(%rsi), %rdx
   mulxq 0(%rcx), %r8, %r9
-  xor %r10, %r10
+  xor %r10d, %r10d
   movq %r8, 0(%rdi)
   
   mulxq 8(%rcx), %r10, %r11
@@ -167,7 +167,7 @@ fmul_e:
   ;# Compute src1[1] * src2
   movq 8(%rsi), %rdx
   mulxq 0(%rcx), %r8, %r9
-  xor %r10, %r10
+  xor %r10d, %r10d
   adcxq 8(%rdi), %r8
   movq %r8, 8(%rdi)
   mulxq 8(%rcx), %r10, %r11
@@ -189,7 +189,7 @@ fmul_e:
   ;# Compute src1[2] * src2
   movq 16(%rsi), %rdx
   mulxq 0(%rcx), %r8, %r9
-  xor %r10, %r10
+  xor %r10d, %r10d
   adcxq 16(%rdi), %r8
   movq %r8, 16(%rdi)
   mulxq 8(%rcx), %r10, %r11
@@ -211,7 +211,7 @@ fmul_e:
   ;# Compute src1[3] * src2
   movq 24(%rsi), %rdx
   mulxq 0(%rcx), %r8, %r9
-  xor %r10, %r10
+  xor %r10d, %r10d
   adcxq 24(%rdi), %r8
   movq %r8, 24(%rdi)
   mulxq 8(%rcx), %r10, %r11
@@ -240,7 +240,7 @@ fmul_e:
   ;# Step 1: Compute dst + carry == tmp_hi * 38 + tmp_lo
   mov $38, %rdx
   mulxq 32(%rsi), %r8, %r13
-  xor %rcx, %rcx
+  xor %ecx, %ecx
   adoxq 0(%rsi), %r8
   mulxq 40(%rsi), %r9, %rbx
   adcx %r13, %r9
@@ -286,7 +286,7 @@ fmul2_e:
   ;# Compute src1[0] * src2
   movq 0(%rsi), %rdx
   mulxq 0(%rcx), %r8, %r9
-  xor %r10, %r10
+  xor %r10d, %r10d
   movq %r8, 0(%rdi)
   
   mulxq 8(%rcx), %r10, %r11
@@ -304,7 +304,7 @@ fmul2_e:
   ;# Compute src1[1] * src2
   movq 8(%rsi), %rdx
   mulxq 0(%rcx), %r8, %r9
-  xor %r10, %r10
+  xor %r10d, %r10d
   adcxq 8(%rdi), %r8
   movq %r8, 8(%rdi)
   mulxq 8(%rcx), %r10, %r11
@@ -326,7 +326,7 @@ fmul2_e:
   ;# Compute src1[2] * src2
   movq 16(%rsi), %rdx
   mulxq 0(%rcx), %r8, %r9
-  xor %r10, %r10
+  xor %r10d, %r10d
   adcxq 16(%rdi), %r8
   movq %r8, 16(%rdi)
   mulxq 8(%rcx), %r10, %r11
@@ -348,7 +348,7 @@ fmul2_e:
   ;# Compute src1[3] * src2
   movq 24(%rsi), %rdx
   mulxq 0(%rcx), %r8, %r9
-  xor %r10, %r10
+  xor %r10d, %r10d
   adcxq 24(%rdi), %r8
   movq %r8, 24(%rdi)
   mulxq 8(%rcx), %r10, %r11
@@ -373,7 +373,7 @@ fmul2_e:
   ;# Compute src1[0] * src2
   movq 32(%rsi), %rdx
   mulxq 32(%rcx), %r8, %r9
-  xor %r10, %r10
+  xor %r10d, %r10d
   movq %r8, 64(%rdi)
   
   mulxq 40(%rcx), %r10, %r11
@@ -391,7 +391,7 @@ fmul2_e:
   ;# Compute src1[1] * src2
   movq 40(%rsi), %rdx
   mulxq 32(%rcx), %r8, %r9
-  xor %r10, %r10
+  xor %r10d, %r10d
   adcxq 72(%rdi), %r8
   movq %r8, 72(%rdi)
   mulxq 40(%rcx), %r10, %r11
@@ -413,7 +413,7 @@ fmul2_e:
   ;# Compute src1[2] * src2
   movq 48(%rsi), %rdx
   mulxq 32(%rcx), %r8, %r9
-  xor %r10, %r10
+  xor %r10d, %r10d
   adcxq 80(%rdi), %r8
   movq %r8, 80(%rdi)
   mulxq 40(%rcx), %r10, %r11
@@ -435,7 +435,7 @@ fmul2_e:
   ;# Compute src1[3] * src2
   movq 56(%rsi), %rdx
   mulxq 32(%rcx), %r8, %r9
-  xor %r10, %r10
+  xor %r10d, %r10d
   adcxq 88(%rdi), %r8
   movq %r8, 88(%rdi)
   mulxq 40(%rcx), %r10, %r11
@@ -464,7 +464,7 @@ fmul2_e:
   ;# Step 1: Compute dst + carry == tmp_hi * 38 + tmp_lo
   mov $38, %rdx
   mulxq 32(%rsi), %r8, %r13
-  xor %rcx, %rcx
+  xor %ecx, %ecx
   adoxq 0(%rsi), %r8
   mulxq 40(%rsi), %r9, %rbx
   adcx %r13, %r9
@@ -497,7 +497,7 @@ fmul2_e:
   ;# Step 1: Compute dst + carry == tmp_hi * 38 + tmp_lo
   mov $38, %rdx
   mulxq 96(%rsi), %r8, %r13
-  xor %rcx, %rcx
+  xor %ecx, %ecx
   adoxq 64(%rsi), %r8
   mulxq 104(%rsi), %r9, %rbx
   adcx %r13, %r9
@@ -545,7 +545,7 @@ fsqr_e:
   movq 0(%rsi), %rdx
   ;# f[0]
   mulxq 8(%rsi), %r8, %r14
-  xor %r15, %r15
+  xor %r15d, %r15d
   ;# f[1]*f[0]
   mulxq 16(%rsi), %r9, %r10
   adcx %r14, %r9
@@ -569,7 +569,7 @@ fsqr_e:
   ;# f[2]*f[1]
   
   ;# Step 2: Compute two parallel carry chains
-  xor %r15, %r15
+  xor %r15d, %r15d
   adox %rax, %r10
   adcx %r8, %r8
   adox %rcx, %r11
@@ -627,7 +627,7 @@ fsqr_e:
   ;# Step 1: Compute dst + carry == tmp_hi * 38 + tmp_lo
   mov $38, %rdx
   mulxq 32(%rsi), %r8, %r13
-  xor %rcx, %rcx
+  xor %ecx, %ecx
   adoxq 0(%rsi), %r8
   mulxq 40(%rsi), %r9, %rbx
   adcx %r13, %r9
@@ -675,7 +675,7 @@ fsqr2_e:
   movq 0(%rsi), %rdx
   ;# f[0]
   mulxq 8(%rsi), %r8, %r14
-  xor %r15, %r15
+  xor %r15d, %r15d
   ;# f[1]*f[0]
   mulxq 16(%rsi), %r9, %r10
   adcx %r14, %r9
@@ -699,7 +699,7 @@ fsqr2_e:
   ;# f[2]*f[1]
   
   ;# Step 2: Compute two parallel carry chains
-  xor %r15, %r15
+  xor %r15d, %r15d
   adox %rax, %r10
   adcx %r8, %r8
   adox %rcx, %r11
@@ -754,7 +754,7 @@ fsqr2_e:
   movq 32(%rsi), %rdx
   ;# f[0]
   mulxq 40(%rsi), %r8, %r14
-  xor %r15, %r15
+  xor %r15d, %r15d
   ;# f[1]*f[0]
   mulxq 48(%rsi), %r9, %r10
   adcx %r14, %r9
@@ -778,7 +778,7 @@ fsqr2_e:
   ;# f[2]*f[1]
   
   ;# Step 2: Compute two parallel carry chains
-  xor %r15, %r15
+  xor %r15d, %r15d
   adox %rax, %r10
   adcx %r8, %r8
   adox %rcx, %r11
@@ -836,7 +836,7 @@ fsqr2_e:
   ;# Step 1: Compute dst + carry == tmp_hi * 38 + tmp_lo
   mov $38, %rdx
   mulxq 32(%rsi), %r8, %r13
-  xor %rcx, %rcx
+  xor %ecx, %ecx
   adoxq 0(%rsi), %r8
   mulxq 40(%rsi), %r9, %rbx
   adcx %r13, %r9
@@ -869,7 +869,7 @@ fsqr2_e:
   ;# Step 1: Compute dst + carry == tmp_hi * 38 + tmp_lo
   mov $38, %rdx
   mulxq 96(%rsi), %r8, %r13
-  xor %rcx, %rcx
+  xor %ecx, %ecx
   adoxq 64(%rsi), %r8
   mulxq 104(%rsi), %r9, %rbx
   adcx %r13, %r9

--- a/dist/vale/curve25519-x86_64-mingw.S
+++ b/dist/vale/curve25519-x86_64-mingw.S
@@ -7,11 +7,11 @@ add_scalar_e:
   mov %rdx, %rsi
   mov %r8, %rdx
   ;# Clear registers to propagate the carry bit
-  xor %r8, %r8
-  xor %r9, %r9
-  xor %r10, %r10
-  xor %r11, %r11
-  xor %rax, %rax
+  xor %r8d, %r8d
+  xor %r9d, %r9d
+  xor %r10d, %r10d
+  xor %r11d, %r11d
+  xor %eax, %eax
   
   ;# Begin addition chain
   addq 0(%rsi), %rdx
@@ -52,7 +52,7 @@ fadd_e:
   cmovc %rdx, %rax
   
   ;# Step 2: Add carry*38 to the original sum
-  xor %rcx, %rcx
+  xor %ecx, %ecx
   add %rax, %r8
   adcx %rcx, %r9
   movq %r9, 8(%rdi)
@@ -176,7 +176,7 @@ fmul_e:
   ;# Compute src1[0] * src2
   movq 0(%rsi), %rdx
   mulxq 0(%rcx), %r8, %r9
-  xor %r10, %r10
+  xor %r10d, %r10d
   movq %r8, 0(%rdi)
   
   mulxq 8(%rcx), %r10, %r11
@@ -194,7 +194,7 @@ fmul_e:
   ;# Compute src1[1] * src2
   movq 8(%rsi), %rdx
   mulxq 0(%rcx), %r8, %r9
-  xor %r10, %r10
+  xor %r10d, %r10d
   adcxq 8(%rdi), %r8
   movq %r8, 8(%rdi)
   mulxq 8(%rcx), %r10, %r11
@@ -216,7 +216,7 @@ fmul_e:
   ;# Compute src1[2] * src2
   movq 16(%rsi), %rdx
   mulxq 0(%rcx), %r8, %r9
-  xor %r10, %r10
+  xor %r10d, %r10d
   adcxq 16(%rdi), %r8
   movq %r8, 16(%rdi)
   mulxq 8(%rcx), %r10, %r11
@@ -238,7 +238,7 @@ fmul_e:
   ;# Compute src1[3] * src2
   movq 24(%rsi), %rdx
   mulxq 0(%rcx), %r8, %r9
-  xor %r10, %r10
+  xor %r10d, %r10d
   adcxq 24(%rdi), %r8
   movq %r8, 24(%rdi)
   mulxq 8(%rcx), %r10, %r11
@@ -267,7 +267,7 @@ fmul_e:
   ;# Step 1: Compute dst + carry == tmp_hi * 38 + tmp_lo
   mov $38, %rdx
   mulxq 32(%rsi), %r8, %r13
-  xor %rcx, %rcx
+  xor %ecx, %ecx
   adoxq 0(%rsi), %r8
   mulxq 40(%rsi), %r9, %rbx
   adcx %r13, %r9
@@ -320,7 +320,7 @@ fmul2_e:
   ;# Compute src1[0] * src2
   movq 0(%rsi), %rdx
   mulxq 0(%rcx), %r8, %r9
-  xor %r10, %r10
+  xor %r10d, %r10d
   movq %r8, 0(%rdi)
   
   mulxq 8(%rcx), %r10, %r11
@@ -338,7 +338,7 @@ fmul2_e:
   ;# Compute src1[1] * src2
   movq 8(%rsi), %rdx
   mulxq 0(%rcx), %r8, %r9
-  xor %r10, %r10
+  xor %r10d, %r10d
   adcxq 8(%rdi), %r8
   movq %r8, 8(%rdi)
   mulxq 8(%rcx), %r10, %r11
@@ -360,7 +360,7 @@ fmul2_e:
   ;# Compute src1[2] * src2
   movq 16(%rsi), %rdx
   mulxq 0(%rcx), %r8, %r9
-  xor %r10, %r10
+  xor %r10d, %r10d
   adcxq 16(%rdi), %r8
   movq %r8, 16(%rdi)
   mulxq 8(%rcx), %r10, %r11
@@ -382,7 +382,7 @@ fmul2_e:
   ;# Compute src1[3] * src2
   movq 24(%rsi), %rdx
   mulxq 0(%rcx), %r8, %r9
-  xor %r10, %r10
+  xor %r10d, %r10d
   adcxq 24(%rdi), %r8
   movq %r8, 24(%rdi)
   mulxq 8(%rcx), %r10, %r11
@@ -407,7 +407,7 @@ fmul2_e:
   ;# Compute src1[0] * src2
   movq 32(%rsi), %rdx
   mulxq 32(%rcx), %r8, %r9
-  xor %r10, %r10
+  xor %r10d, %r10d
   movq %r8, 64(%rdi)
   
   mulxq 40(%rcx), %r10, %r11
@@ -425,7 +425,7 @@ fmul2_e:
   ;# Compute src1[1] * src2
   movq 40(%rsi), %rdx
   mulxq 32(%rcx), %r8, %r9
-  xor %r10, %r10
+  xor %r10d, %r10d
   adcxq 72(%rdi), %r8
   movq %r8, 72(%rdi)
   mulxq 40(%rcx), %r10, %r11
@@ -447,7 +447,7 @@ fmul2_e:
   ;# Compute src1[2] * src2
   movq 48(%rsi), %rdx
   mulxq 32(%rcx), %r8, %r9
-  xor %r10, %r10
+  xor %r10d, %r10d
   adcxq 80(%rdi), %r8
   movq %r8, 80(%rdi)
   mulxq 40(%rcx), %r10, %r11
@@ -469,7 +469,7 @@ fmul2_e:
   ;# Compute src1[3] * src2
   movq 56(%rsi), %rdx
   mulxq 32(%rcx), %r8, %r9
-  xor %r10, %r10
+  xor %r10d, %r10d
   adcxq 88(%rdi), %r8
   movq %r8, 88(%rdi)
   mulxq 40(%rcx), %r10, %r11
@@ -498,7 +498,7 @@ fmul2_e:
   ;# Step 1: Compute dst + carry == tmp_hi * 38 + tmp_lo
   mov $38, %rdx
   mulxq 32(%rsi), %r8, %r13
-  xor %rcx, %rcx
+  xor %ecx, %ecx
   adoxq 0(%rsi), %r8
   mulxq 40(%rsi), %r9, %rbx
   adcx %r13, %r9
@@ -531,7 +531,7 @@ fmul2_e:
   ;# Step 1: Compute dst + carry == tmp_hi * 38 + tmp_lo
   mov $38, %rdx
   mulxq 96(%rsi), %r8, %r13
-  xor %rcx, %rcx
+  xor %ecx, %ecx
   adoxq 64(%rsi), %r8
   mulxq 104(%rsi), %r9, %rbx
   adcx %r13, %r9
@@ -585,7 +585,7 @@ fsqr_e:
   movq 0(%rsi), %rdx
   ;# f[0]
   mulxq 8(%rsi), %r8, %r14
-  xor %r15, %r15
+  xor %r15d, %r15d
   ;# f[1]*f[0]
   mulxq 16(%rsi), %r9, %r10
   adcx %r14, %r9
@@ -609,7 +609,7 @@ fsqr_e:
   ;# f[2]*f[1]
   
   ;# Step 2: Compute two parallel carry chains
-  xor %r15, %r15
+  xor %r15d, %r15d
   adox %rax, %r10
   adcx %r8, %r8
   adox %rcx, %r11
@@ -667,7 +667,7 @@ fsqr_e:
   ;# Step 1: Compute dst + carry == tmp_hi * 38 + tmp_lo
   mov $38, %rdx
   mulxq 32(%rsi), %r8, %r13
-  xor %rcx, %rcx
+  xor %ecx, %ecx
   adoxq 0(%rsi), %r8
   mulxq 40(%rsi), %r9, %rbx
   adcx %r13, %r9
@@ -721,7 +721,7 @@ fsqr2_e:
   movq 0(%rsi), %rdx
   ;# f[0]
   mulxq 8(%rsi), %r8, %r14
-  xor %r15, %r15
+  xor %r15d, %r15d
   ;# f[1]*f[0]
   mulxq 16(%rsi), %r9, %r10
   adcx %r14, %r9
@@ -745,7 +745,7 @@ fsqr2_e:
   ;# f[2]*f[1]
   
   ;# Step 2: Compute two parallel carry chains
-  xor %r15, %r15
+  xor %r15d, %r15d
   adox %rax, %r10
   adcx %r8, %r8
   adox %rcx, %r11
@@ -800,7 +800,7 @@ fsqr2_e:
   movq 32(%rsi), %rdx
   ;# f[0]
   mulxq 40(%rsi), %r8, %r14
-  xor %r15, %r15
+  xor %r15d, %r15d
   ;# f[1]*f[0]
   mulxq 48(%rsi), %r9, %r10
   adcx %r14, %r9
@@ -824,7 +824,7 @@ fsqr2_e:
   ;# f[2]*f[1]
   
   ;# Step 2: Compute two parallel carry chains
-  xor %r15, %r15
+  xor %r15d, %r15d
   adox %rax, %r10
   adcx %r8, %r8
   adox %rcx, %r11
@@ -882,7 +882,7 @@ fsqr2_e:
   ;# Step 1: Compute dst + carry == tmp_hi * 38 + tmp_lo
   mov $38, %rdx
   mulxq 32(%rsi), %r8, %r13
-  xor %rcx, %rcx
+  xor %ecx, %ecx
   adoxq 0(%rsi), %r8
   mulxq 40(%rsi), %r9, %rbx
   adcx %r13, %r9
@@ -915,7 +915,7 @@ fsqr2_e:
   ;# Step 1: Compute dst + carry == tmp_hi * 38 + tmp_lo
   mov $38, %rdx
   mulxq 96(%rsi), %r8, %r13
-  xor %rcx, %rcx
+  xor %ecx, %ecx
   adoxq 64(%rsi), %r8
   mulxq 104(%rsi), %r9, %rbx
   adcx %r13, %r9

--- a/dist/vale/curve25519-x86_64-msvc.asm
+++ b/dist/vale/curve25519-x86_64-msvc.asm
@@ -7,11 +7,11 @@ add_scalar_e proc
   mov rsi, rdx
   mov rdx, r8
   ;# Clear registers to propagate the carry bit
-  xor r8, r8
-  xor r9, r9
-  xor r10, r10
-  xor r11, r11
-  xor rax, rax
+  xor r8d, r8d
+  xor r9d, r9d
+  xor r10d, r10d
+  xor r11d, r11d
+  xor eax, eax
   
   ;# Begin addition chain
   add rdx, qword ptr [rsi + 0]
@@ -52,7 +52,7 @@ fadd_e proc
   cmovc rax, rdx
   
   ;# Step 2: Add carry*38 to the original sum
-  xor rcx, rcx
+  xor ecx, ecx
   add r8, rax
   adcx r9, rcx
   mov qword ptr [rdi + 8], r9
@@ -176,7 +176,7 @@ fmul_e proc
   ;# Compute src1[0] * src2
   mov rdx, qword ptr [rsi + 0]
   mulx r9, r8, qword ptr [rcx + 0]
-  xor r10, r10
+  xor r10d, r10d
   mov qword ptr [rdi + 0], r8
   
   mulx r11, r10, qword ptr [rcx + 8]
@@ -194,7 +194,7 @@ fmul_e proc
   ;# Compute src1[1] * src2
   mov rdx, qword ptr [rsi + 8]
   mulx r9, r8, qword ptr [rcx + 0]
-  xor r10, r10
+  xor r10d, r10d
   adcx r8, qword ptr [rdi + 8]
   mov qword ptr [rdi + 8], r8
   mulx r11, r10, qword ptr [rcx + 8]
@@ -216,7 +216,7 @@ fmul_e proc
   ;# Compute src1[2] * src2
   mov rdx, qword ptr [rsi + 16]
   mulx r9, r8, qword ptr [rcx + 0]
-  xor r10, r10
+  xor r10d, r10d
   adcx r8, qword ptr [rdi + 16]
   mov qword ptr [rdi + 16], r8
   mulx r11, r10, qword ptr [rcx + 8]
@@ -238,7 +238,7 @@ fmul_e proc
   ;# Compute src1[3] * src2
   mov rdx, qword ptr [rsi + 24]
   mulx r9, r8, qword ptr [rcx + 0]
-  xor r10, r10
+  xor r10d, r10d
   adcx r8, qword ptr [rdi + 24]
   mov qword ptr [rdi + 24], r8
   mulx r11, r10, qword ptr [rcx + 8]
@@ -267,7 +267,7 @@ fmul_e proc
   ;# Step 1: Compute dst + carry == tmp_hi * 38 + tmp_lo
   mov rdx, 38
   mulx r13, r8, qword ptr [rsi + 32]
-  xor rcx, rcx
+  xor ecx, ecx
   adox r8, qword ptr [rsi + 0]
   mulx rbx, r9, qword ptr [rsi + 40]
   adcx r9, r13
@@ -320,7 +320,7 @@ fmul2_e proc
   ;# Compute src1[0] * src2
   mov rdx, qword ptr [rsi + 0]
   mulx r9, r8, qword ptr [rcx + 0]
-  xor r10, r10
+  xor r10d, r10d
   mov qword ptr [rdi + 0], r8
   
   mulx r11, r10, qword ptr [rcx + 8]
@@ -338,7 +338,7 @@ fmul2_e proc
   ;# Compute src1[1] * src2
   mov rdx, qword ptr [rsi + 8]
   mulx r9, r8, qword ptr [rcx + 0]
-  xor r10, r10
+  xor r10d, r10d
   adcx r8, qword ptr [rdi + 8]
   mov qword ptr [rdi + 8], r8
   mulx r11, r10, qword ptr [rcx + 8]
@@ -360,7 +360,7 @@ fmul2_e proc
   ;# Compute src1[2] * src2
   mov rdx, qword ptr [rsi + 16]
   mulx r9, r8, qword ptr [rcx + 0]
-  xor r10, r10
+  xor r10d, r10d
   adcx r8, qword ptr [rdi + 16]
   mov qword ptr [rdi + 16], r8
   mulx r11, r10, qword ptr [rcx + 8]
@@ -382,7 +382,7 @@ fmul2_e proc
   ;# Compute src1[3] * src2
   mov rdx, qword ptr [rsi + 24]
   mulx r9, r8, qword ptr [rcx + 0]
-  xor r10, r10
+  xor r10d, r10d
   adcx r8, qword ptr [rdi + 24]
   mov qword ptr [rdi + 24], r8
   mulx r11, r10, qword ptr [rcx + 8]
@@ -407,7 +407,7 @@ fmul2_e proc
   ;# Compute src1[0] * src2
   mov rdx, qword ptr [rsi + 32]
   mulx r9, r8, qword ptr [rcx + 32]
-  xor r10, r10
+  xor r10d, r10d
   mov qword ptr [rdi + 64], r8
   
   mulx r11, r10, qword ptr [rcx + 40]
@@ -425,7 +425,7 @@ fmul2_e proc
   ;# Compute src1[1] * src2
   mov rdx, qword ptr [rsi + 40]
   mulx r9, r8, qword ptr [rcx + 32]
-  xor r10, r10
+  xor r10d, r10d
   adcx r8, qword ptr [rdi + 72]
   mov qword ptr [rdi + 72], r8
   mulx r11, r10, qword ptr [rcx + 40]
@@ -447,7 +447,7 @@ fmul2_e proc
   ;# Compute src1[2] * src2
   mov rdx, qword ptr [rsi + 48]
   mulx r9, r8, qword ptr [rcx + 32]
-  xor r10, r10
+  xor r10d, r10d
   adcx r8, qword ptr [rdi + 80]
   mov qword ptr [rdi + 80], r8
   mulx r11, r10, qword ptr [rcx + 40]
@@ -469,7 +469,7 @@ fmul2_e proc
   ;# Compute src1[3] * src2
   mov rdx, qword ptr [rsi + 56]
   mulx r9, r8, qword ptr [rcx + 32]
-  xor r10, r10
+  xor r10d, r10d
   adcx r8, qword ptr [rdi + 88]
   mov qword ptr [rdi + 88], r8
   mulx r11, r10, qword ptr [rcx + 40]
@@ -498,7 +498,7 @@ fmul2_e proc
   ;# Step 1: Compute dst + carry == tmp_hi * 38 + tmp_lo
   mov rdx, 38
   mulx r13, r8, qword ptr [rsi + 32]
-  xor rcx, rcx
+  xor ecx, ecx
   adox r8, qword ptr [rsi + 0]
   mulx rbx, r9, qword ptr [rsi + 40]
   adcx r9, r13
@@ -531,7 +531,7 @@ fmul2_e proc
   ;# Step 1: Compute dst + carry == tmp_hi * 38 + tmp_lo
   mov rdx, 38
   mulx r13, r8, qword ptr [rsi + 96]
-  xor rcx, rcx
+  xor ecx, ecx
   adox r8, qword ptr [rsi + 64]
   mulx rbx, r9, qword ptr [rsi + 104]
   adcx r9, r13
@@ -585,7 +585,7 @@ fsqr_e proc
   mov rdx, qword ptr [rsi + 0]
   ;# f[0]
   mulx r14, r8, qword ptr [rsi + 8]
-  xor r15, r15
+  xor r15d, r15d
   ;# f[1]*f[0]
   mulx r10, r9, qword ptr [rsi + 16]
   adcx r9, r14
@@ -609,7 +609,7 @@ fsqr_e proc
   ;# f[2]*f[1]
   
   ;# Step 2: Compute two parallel carry chains
-  xor r15, r15
+  xor r15d, r15d
   adox r10, rax
   adcx r8, r8
   adox r11, rcx
@@ -667,7 +667,7 @@ fsqr_e proc
   ;# Step 1: Compute dst + carry == tmp_hi * 38 + tmp_lo
   mov rdx, 38
   mulx r13, r8, qword ptr [rsi + 32]
-  xor rcx, rcx
+  xor ecx, ecx
   adox r8, qword ptr [rsi + 0]
   mulx rbx, r9, qword ptr [rsi + 40]
   adcx r9, r13
@@ -721,7 +721,7 @@ fsqr2_e proc
   mov rdx, qword ptr [rsi + 0]
   ;# f[0]
   mulx r14, r8, qword ptr [rsi + 8]
-  xor r15, r15
+  xor r15d, r15d
   ;# f[1]*f[0]
   mulx r10, r9, qword ptr [rsi + 16]
   adcx r9, r14
@@ -745,7 +745,7 @@ fsqr2_e proc
   ;# f[2]*f[1]
   
   ;# Step 2: Compute two parallel carry chains
-  xor r15, r15
+  xor r15d, r15d
   adox r10, rax
   adcx r8, r8
   adox r11, rcx
@@ -800,7 +800,7 @@ fsqr2_e proc
   mov rdx, qword ptr [rsi + 32]
   ;# f[0]
   mulx r14, r8, qword ptr [rsi + 40]
-  xor r15, r15
+  xor r15d, r15d
   ;# f[1]*f[0]
   mulx r10, r9, qword ptr [rsi + 48]
   adcx r9, r14
@@ -824,7 +824,7 @@ fsqr2_e proc
   ;# f[2]*f[1]
   
   ;# Step 2: Compute two parallel carry chains
-  xor r15, r15
+  xor r15d, r15d
   adox r10, rax
   adcx r8, r8
   adox r11, rcx
@@ -882,7 +882,7 @@ fsqr2_e proc
   ;# Step 1: Compute dst + carry == tmp_hi * 38 + tmp_lo
   mov rdx, 38
   mulx r13, r8, qword ptr [rsi + 32]
-  xor rcx, rcx
+  xor ecx, ecx
   adox r8, qword ptr [rsi + 0]
   mulx rbx, r9, qword ptr [rsi + 40]
   adcx r9, r13
@@ -915,7 +915,7 @@ fsqr2_e proc
   ;# Step 1: Compute dst + carry == tmp_hi * 38 + tmp_lo
   mov rdx, 38
   mulx r13, r8, qword ptr [rsi + 96]
-  xor rcx, rcx
+  xor ecx, ecx
   adox r8, qword ptr [rsi + 64]
   mulx rbx, r9, qword ptr [rsi + 104]
   adcx r9, r13

--- a/vale/specs/hardware/Vale.X64.Instructions_s.fst
+++ b/vale/specs/hardware/Vale.X64.Instructions_s.fst
@@ -44,7 +44,9 @@ let ins_IMul64 = make_ins (fun dst src -> print_s "imul" [P64 dst; P64 src])
 
 let ins_And64 = make_ins (fun dst src -> print_s "and" [P64 dst; P64 src])
 
-let ins_Xor64 = make_ins (fun dst src -> print_s "xor" [P64 dst; P64 src])
+let ins_Xor64 = make_ins (fun dst src -> print_s "xor"
+  // special idiom for zeroing r: xor64 r, r --> xor32 r, r
+  (if OReg? dst && dst = src then [P32 dst; P32 src] else [P64 dst; P64 src]))
 
 let ins_Shr64 = make_ins (fun dst amt -> print_s "shr" [P64 dst; PShift amt])
 


### PR DESCRIPTION
(suggested by Uros Bizjak for WireGuard crypto to save some code bytes)