### PR TITLE
Changes to use of nested assert norms in support of upstream F* changes

### DIFF
--- a/code/sha3/Hacl.Impl.SHA3.fst
+++ b/code/sha3/Hacl.Impl.SHA3.fst
@@ -516,9 +516,7 @@ let squeeze s rateInBytes outputByteLen output =
   storeState remOut s last;
   let h1 = ST.get() in
   Seq.lemma_split (as_seq h1 output) (v outBlocks * v rateInBytes);
-  assert_norm (norm [delta]
-    S.squeeze (as_seq h0 s) (v rateInBytes) (v outputByteLen) ==
-    S.squeeze (as_seq h0 s) (v rateInBytes) (v outputByteLen))
+  norm_spec [delta_only [`%S.squeeze]] (S.squeeze (as_seq h0 s) (v rateInBytes) (v outputByteLen))
 
 val keccak:
     rate:size_t{v rate % 8 == 0 /\ v rate / 8 > 0 /\ v rate <= 1600}

--- a/lib/Lib.Buffer.fst
+++ b/lib/Lib.Buffer.fst
@@ -386,9 +386,8 @@ let fill_blocks #t h0 len n output a_spec refl footprint spec impl =
   );
   assert (Seq.equal
     (as_seq h0 (gsub output (size 0) (size 0 *! len))) FStar.Seq.empty);
-  assert_norm (
-    Seq.generate_blocks (v len) (v n) (v n) a_spec (spec h0) (refl h0 0) ==
-    norm [delta] Seq.generate_blocks (v len) (v n) (v n) a_spec (spec h0) (refl h0 0));
+  norm_spec [delta_only [`%Seq.generate_blocks]]
+            (Seq.generate_blocks (v len) (v n) (v n) a_spec (spec h0) (refl h0 0));
   let h1 = ST.get() in
   assert(refl' h1 (v n) == Loop.repeat_gen (v n)
          (Sequence.generate_blocks_a t (v len) (v n) a_spec)

--- a/lib/Lib.ByteBuffer.fst
+++ b/lib/Lib.ByteBuffer.fst
@@ -260,8 +260,7 @@ let uints_to_bytes_le #t #l len o i =
   let spec (h:mem) = BS.uints_to_bytes_le_inner (as_seq h i) in
   fill_blocks h0 (size (numbytes t)) len o a_spec (fun _ _ -> ()) (fun _ -> loc_none) spec
     (fun j -> uint_to_bytes_le (sub o (mul_mod j (size (numbytes t))) (size (numbytes t))) i.(j));
-  assert_norm (BS.uints_to_bytes_le (as_seq h0 i) ==
-               norm [delta] BS.uints_to_bytes_le (as_seq h0 i))
+  norm_spec [delta_only [`%BS.uints_to_bytes_le]] (BS.uints_to_bytes_le (as_seq h0 i))
 
 let uints_to_bytes_be #t #l len o i =
   let h0 = ST.get () in
@@ -271,8 +270,7 @@ let uints_to_bytes_be #t #l len o i =
   let spec (h:mem) = BS.uints_to_bytes_be_inner (as_seq h i) in
   fill_blocks h0 (size (numbytes t)) len o a_spec (fun _ _ -> ()) (fun _ -> loc_none) spec
     (fun j -> uint_to_bytes_be (sub o (mul_mod j (size (numbytes t))) (size (numbytes t))) i.(j));
-  assert_norm (BS.uints_to_bytes_be (as_seq h0 i) ==
-               norm [delta] BS.uints_to_bytes_be (as_seq h0 i))
+  norm_spec [delta_only [`%BS.uints_to_bytes_be]] (BS.uints_to_bytes_be (as_seq h0 i))
 
 let uint_at_index_le #t #l #len i idx =
   let b = sub i (idx *! (size (numbytes t))) (size (numbytes t)) in
@@ -281,3 +279,4 @@ let uint_at_index_le #t #l #len i idx =
 let uint_at_index_be #t #l #len i idx =
   let b = sub i (idx *! (size (numbytes t))) (size (numbytes t)) in
   uint_from_bytes_be b
+  


### PR DESCRIPTION
Thanks @polubelova.

This also works without the upcoming F* changes so it should be mergeable.
Also, as a general point of style, `norm_spec` instead of assert_norm for these usages should be more idiomatic.