### PR TITLE
Add _GNU_SOURCE/_BSD_SOURCE explicit_bzero

### DIFF
--- a/lib/c/Lib_Memzero0.c
+++ b/lib/c/Lib_Memzero0.c
@@ -36,7 +36,7 @@ void Lib_Memzero0_memzero(void *dst, uint64_t len) {
     SecureZeroMemory(dst, len);
   #elif defined(__APPLE__) && defined(__MACH__)
     memset_s(dst, len_, 0, len_);
-  #elif (defined(__linux__) && !defined(LINUX_NO_EXPLICIT_BZERO)) || defined(__FreeBSD__)
+  #elif (defined(__linux__) && !defined(LINUX_NO_EXPLICIT_BZERO)) || defined(__FreeBSD__) || defined(_GNU_SOURCE) || defined(_BSD_SOURCE)
     explicit_bzero(dst, len_);
   #elif defined(__NetBSD__)
     explicit_memset(dst, 0, len_);


### PR DESCRIPTION
CCF uses the MUSL library (as provided by Open Enclave), which defines `bzero` [here](https://github.com/openenclave/openenclave/blob/048a5c3df27220fbbba13bcfaba1ebf15a3d15cd/3rdparty/musl/musl/include/strings.h#L18) and `explicit_bzero` [there](https://github.com/openenclave/openenclave/blob/048a5c3df27220fbbba13bcfaba1ebf15a3d15cd/3rdparty/musl/musl/include/string.h#L81). The build warning message explicitly asks for a pull request, so here you go!

Full disclosure: I have no idea about the security implications of adding `defined(_GNU_SOURCE) || defined(_BSD_SOURCE)` here. 