### PR TITLE
Enable -O2 for Merkle tree benchmarks in debug mode

### DIFF
--- a/tests/benchmark/bench_merkle.cpp
+++ b/tests/benchmark/bench_merkle.cpp
@@ -261,7 +261,7 @@ class MerklePathVerification : public Benchmark
 
 void bench_merkle_insert(const BenchmarkSettings & s)
 {
-  size_t data_sizes[] = { 1024, 2048, 4096, 8192, 16384, 32768, 65536 };
+  size_t data_sizes[] = { 1024, 2048, 4096, 8192, 16384, 32768, 65536, 131072, 262144, 524288, 1048576 };
   std::string data_filename = "bench_merkle_insert.csv";
 
   std::list<Benchmark*> todo;
@@ -305,7 +305,7 @@ void bench_merkle_insert(const BenchmarkSettings & s)
 
 void bench_merkle_get_path(const BenchmarkSettings & s)
 {
-  size_t data_sizes[] = { 1024, 2048, 4096, 8192, 16384, 32768, 65536 };
+  size_t data_sizes[] = { 1024, 2048, 4096, 8192, 16384, 32768, 65536, 131072, 262144, 524288, 1048576 };
   std::string data_filename = "bench_merkle_get_path.csv";
 
   std::list<Benchmark*> todo;
@@ -349,7 +349,7 @@ void bench_merkle_get_path(const BenchmarkSettings & s)
 
 void bench_merkle_verify(const BenchmarkSettings & s)
 {
-  size_t data_sizes[] = { 1024, 2048, 4096, 8192, 16384, 32768, 65536 };
+  size_t data_sizes[] = { 1024, 2048, 4096, 8192, 16384, 32768, 65536, 131072, 262144, 524288, 1048576 };
   std::string data_filename = "bench_merkle_verify.csv";
 
   std::list<Benchmark*> todo;

--- a/tests/benchmark/libevercrypt/CMakeLists.txt
+++ b/tests/benchmark/libevercrypt/CMakeLists.txt
@@ -89,6 +89,7 @@ endif()
 # Hacl_Poly1305_256.o: CFLAGS += -mavx -mavx2
 set_source_files_properties(${EVERCRYPT_SRC_DIR}/Hacl_Poly1305_128.c PROPERTIES COMPILE_FLAGS "-mavx")
 set_source_files_properties(${EVERCRYPT_SRC_DIR}/Hacl_Poly1305_256.c PROPERTIES COMPILE_FLAGS "-mavx -mavx2")
+set_source_files_properties(${EVERCRYPT_SRC_DIR}/MerkleTree.c PROPERTIES COMPILE_FLAGS $<$<CONFIG:DEBUG>:-O2>)
 
 target_link_libraries(evercrypt PUBLIC kremlib)
 


### PR DESCRIPTION
The Merkle tree benchmarks ran out of stack space because tail-call optimization isn't performed in debug mode. This fix enables `-O2` on `MerkleTree.c` in debug mode. In release mode everything worked as expected. The main offending function was `LowStar.RVector.free_elems` in case someone wants to de-recursify it. 