### PR TITLE
don't use libintvector.h on 32-bit arm

### DIFF
--- a/dist/c89-compatible/INFO.txt
+++ b/dist/c89-compatible/INFO.txt
@@ -1,4 +1,4 @@
 This code was generated with the following toolchain.
-F* version: 0e284e249aefb378ac63d4f8e251372f636d965d
+F* version: 9ac1d8b6f4575008f380bbd3640d6b06c817db3e
 KreMLin version: f3656741e080d038f5f96a2864666e58ba34b831
 Vale version: 0.3.13

--- a/dist/c89-compatible/libintvector.h
+++ b/dist/c89-compatible/libintvector.h
@@ -419,7 +419,8 @@ typedef __m256i Lib_IntVector_Intrinsics_vec256;
   (_mm256_permute2x128_si256(x1, x2, 0x31))
 
 
-#elif defined(__aarch64__) || defined(_M_ARM64) || defined(__arm__) || defined(_M_ARM)
+#elif (defined(__aarch64__) || defined(_M_ARM64) || defined(__arm__) || defined(_M_ARM)) \
+      && !defined(__ARM_32BIT_STATE)
 #include <arm_neon.h>
 
 typedef uint32x4_t Lib_IntVector_Intrinsics_vec128;

--- a/dist/ccf/INFO.txt
+++ b/dist/ccf/INFO.txt
@@ -1,4 +1,4 @@
 This code was generated with the following toolchain.
-F* version: 0e284e249aefb378ac63d4f8e251372f636d965d
+F* version: 9ac1d8b6f4575008f380bbd3640d6b06c817db3e
 KreMLin version: f3656741e080d038f5f96a2864666e58ba34b831
 Vale version: 0.3.13

--- a/dist/configure
+++ b/dist/configure
@@ -101,9 +101,9 @@ detect_x64 () {
 }
 
 detect_arm () {
-  # On Raspberry pi, uname -m is armv6l so we need to cut!
-  [[ $target_arch == "arm" ]] || [[ $target_arch == "aarch64" ]] || \
-    [[ $(echo $target_arch | cut -c 1-3) == "arm" ]]
+  # On Raspberry pi, uname -m is armv6l or armv7l so we need to cut!
+  [[ $(echo $target_arch | cut -c 1-3) == "arm" ]] || \
+  [[ $target_arch == "aarch64" ]]
 }
 
 detect_arm_cc () {

--- a/dist/gcc-compatible/INFO.txt
+++ b/dist/gcc-compatible/INFO.txt
@@ -1,4 +1,4 @@
 This code was generated with the following toolchain.
-F* version: 0e284e249aefb378ac63d4f8e251372f636d965d
+F* version: 9ac1d8b6f4575008f380bbd3640d6b06c817db3e
 KreMLin version: f3656741e080d038f5f96a2864666e58ba34b831
 Vale version: 0.3.13

--- a/dist/gcc-compatible/configure
+++ b/dist/gcc-compatible/configure
@@ -101,7 +101,9 @@ detect_x64 () {
 }
 
 detect_arm () {
-  [[ $target_arch == "arm" ]] || [[ $target_arch == "aarch64" ]];
+  # On Raspberry pi, uname -m is armv6l or armv7l so we need to cut!
+  [[ $(echo $target_arch | cut -c 1-3) == "arm" ]] || \
+  [[ $target_arch == "aarch64" ]]
 }
 
 detect_arm_cc () {

--- a/dist/gcc-compatible/libintvector.h
+++ b/dist/gcc-compatible/libintvector.h
@@ -419,7 +419,8 @@ typedef __m256i Lib_IntVector_Intrinsics_vec256;
   (_mm256_permute2x128_si256(x1, x2, 0x31))
 
 
-#elif defined(__aarch64__) || defined(_M_ARM64) || defined(__arm__) || defined(_M_ARM)
+#elif (defined(__aarch64__) || defined(_M_ARM64) || defined(__arm__) || defined(_M_ARM)) \
+      && !defined(__ARM_32BIT_STATE)
 #include <arm_neon.h>
 
 typedef uint32x4_t Lib_IntVector_Intrinsics_vec128;

--- a/dist/gcc64-only/INFO.txt
+++ b/dist/gcc64-only/INFO.txt
@@ -1,4 +1,4 @@
 This code was generated with the following toolchain.
-F* version: 0e284e249aefb378ac63d4f8e251372f636d965d
+F* version: 9ac1d8b6f4575008f380bbd3640d6b06c817db3e
 KreMLin version: f3656741e080d038f5f96a2864666e58ba34b831
 Vale version: 0.3.13

--- a/dist/gcc64-only/libintvector.h
+++ b/dist/gcc64-only/libintvector.h
@@ -419,7 +419,8 @@ typedef __m256i Lib_IntVector_Intrinsics_vec256;
   (_mm256_permute2x128_si256(x1, x2, 0x31))
 
 
-#elif defined(__aarch64__) || defined(_M_ARM64) || defined(__arm__) || defined(_M_ARM)
+#elif (defined(__aarch64__) || defined(_M_ARM64) || defined(__arm__) || defined(_M_ARM)) \
+      && !defined(__ARM_32BIT_STATE)
 #include <arm_neon.h>
 
 typedef uint32x4_t Lib_IntVector_Intrinsics_vec128;

--- a/dist/linux/INFO.txt
+++ b/dist/linux/INFO.txt
@@ -1,4 +1,4 @@
 This code was generated with the following toolchain.
-F* version: 0e284e249aefb378ac63d4f8e251372f636d965d
+F* version: 9ac1d8b6f4575008f380bbd3640d6b06c817db3e
 KreMLin version: f3656741e080d038f5f96a2864666e58ba34b831
 Vale version: 0.3.13

--- a/dist/linux/libintvector.h
+++ b/dist/linux/libintvector.h
@@ -419,7 +419,8 @@ typedef __m256i Lib_IntVector_Intrinsics_vec256;
   (_mm256_permute2x128_si256(x1, x2, 0x31))
 
 
-#elif defined(__aarch64__) || defined(_M_ARM64) || defined(__arm__) || defined(_M_ARM)
+#elif (defined(__aarch64__) || defined(_M_ARM64) || defined(__arm__) || defined(_M_ARM)) \
+      && !defined(__ARM_32BIT_STATE)
 #include <arm_neon.h>
 
 typedef uint32x4_t Lib_IntVector_Intrinsics_vec128;

--- a/dist/merkle-tree/INFO.txt
+++ b/dist/merkle-tree/INFO.txt
@@ -1,4 +1,4 @@
 This code was generated with the following toolchain.
-F* version: 0e284e249aefb378ac63d4f8e251372f636d965d
+F* version: 9ac1d8b6f4575008f380bbd3640d6b06c817db3e
 KreMLin version: f3656741e080d038f5f96a2864666e58ba34b831
 Vale version: 0.3.13

--- a/dist/mitls/INFO.txt
+++ b/dist/mitls/INFO.txt
@@ -1,4 +1,4 @@
 This code was generated with the following toolchain.
-F* version: 0e284e249aefb378ac63d4f8e251372f636d965d
+F* version: 9ac1d8b6f4575008f380bbd3640d6b06c817db3e
 KreMLin version: f3656741e080d038f5f96a2864666e58ba34b831
 Vale version: 0.3.13

--- a/dist/mitls/libintvector.h
+++ b/dist/mitls/libintvector.h
@@ -419,7 +419,8 @@ typedef __m256i Lib_IntVector_Intrinsics_vec256;
   (_mm256_permute2x128_si256(x1, x2, 0x31))
 
 
-#elif defined(__aarch64__) || defined(_M_ARM64) || defined(__arm__) || defined(_M_ARM)
+#elif (defined(__aarch64__) || defined(_M_ARM64) || defined(__arm__) || defined(_M_ARM)) \
+      && !defined(__ARM_32BIT_STATE)
 #include <arm_neon.h>
 
 typedef uint32x4_t Lib_IntVector_Intrinsics_vec128;

--- a/dist/mozilla/INFO.txt
+++ b/dist/mozilla/INFO.txt
@@ -1,4 +1,4 @@
 This code was generated with the following toolchain.
-F* version: 0e284e249aefb378ac63d4f8e251372f636d965d
+F* version: 9ac1d8b6f4575008f380bbd3640d6b06c817db3e
 KreMLin version: f3656741e080d038f5f96a2864666e58ba34b831
 Vale version: 0.3.13

--- a/dist/mozilla/libintvector.h
+++ b/dist/mozilla/libintvector.h
@@ -419,7 +419,8 @@ typedef __m256i Lib_IntVector_Intrinsics_vec256;
   (_mm256_permute2x128_si256(x1, x2, 0x31))
 
 
-#elif defined(__aarch64__) || defined(_M_ARM64) || defined(__arm__) || defined(_M_ARM)
+#elif (defined(__aarch64__) || defined(_M_ARM64) || defined(__arm__) || defined(_M_ARM)) \
+      && !defined(__ARM_32BIT_STATE)
 #include <arm_neon.h>
 
 typedef uint32x4_t Lib_IntVector_Intrinsics_vec128;

--- a/dist/msvc-compatible/INFO.txt
+++ b/dist/msvc-compatible/INFO.txt
@@ -1,4 +1,4 @@
 This code was generated with the following toolchain.
-F* version: 0e284e249aefb378ac63d4f8e251372f636d965d
+F* version: 9ac1d8b6f4575008f380bbd3640d6b06c817db3e
 KreMLin version: f3656741e080d038f5f96a2864666e58ba34b831
 Vale version: 0.3.13

--- a/dist/msvc-compatible/libintvector.h
+++ b/dist/msvc-compatible/libintvector.h
@@ -419,7 +419,8 @@ typedef __m256i Lib_IntVector_Intrinsics_vec256;
   (_mm256_permute2x128_si256(x1, x2, 0x31))
 
 
-#elif defined(__aarch64__) || defined(_M_ARM64) || defined(__arm__) || defined(_M_ARM)
+#elif (defined(__aarch64__) || defined(_M_ARM64) || defined(__arm__) || defined(_M_ARM)) \
+      && !defined(__ARM_32BIT_STATE)
 #include <arm_neon.h>
 
 typedef uint32x4_t Lib_IntVector_Intrinsics_vec128;

--- a/dist/portable-gcc-compatible/INFO.txt
+++ b/dist/portable-gcc-compatible/INFO.txt
@@ -1,4 +1,4 @@
 This code was generated with the following toolchain.
-F* version: 0e284e249aefb378ac63d4f8e251372f636d965d
+F* version: 9ac1d8b6f4575008f380bbd3640d6b06c817db3e
 KreMLin version: f3656741e080d038f5f96a2864666e58ba34b831
 Vale version: 0.3.13

--- a/dist/portable-gcc-compatible/libintvector.h
+++ b/dist/portable-gcc-compatible/libintvector.h
@@ -419,7 +419,8 @@ typedef __m256i Lib_IntVector_Intrinsics_vec256;
   (_mm256_permute2x128_si256(x1, x2, 0x31))
 
 
-#elif defined(__aarch64__) || defined(_M_ARM64) || defined(__arm__) || defined(_M_ARM)
+#elif (defined(__aarch64__) || defined(_M_ARM64) || defined(__arm__) || defined(_M_ARM)) \
+      && !defined(__ARM_32BIT_STATE)
 #include <arm_neon.h>
 
 typedef uint32x4_t Lib_IntVector_Intrinsics_vec128;

--- a/dist/wasm/INFO.txt
+++ b/dist/wasm/INFO.txt
@@ -1,4 +1,4 @@
 This code was generated with the following toolchain.
-F* version: 0e284e249aefb378ac63d4f8e251372f636d965d
+F* version: 9ac1d8b6f4575008f380bbd3640d6b06c817db3e
 KreMLin version: f3656741e080d038f5f96a2864666e58ba34b831
 Vale version: 0.3.13

--- a/lib/c/libintvector.h
+++ b/lib/c/libintvector.h
@@ -419,7 +419,8 @@ typedef __m256i Lib_IntVector_Intrinsics_vec256;
   (_mm256_permute2x128_si256(x1, x2, 0x31))
 
 
-#elif defined(__aarch64__) || defined(_M_ARM64) || defined(__arm__) || defined(_M_ARM)
+#elif (defined(__aarch64__) || defined(_M_ARM64) || defined(__arm__) || defined(_M_ARM)) \
+      && !defined(__ARM_32BIT_STATE)
 #include <arm_neon.h>
 
 typedef uint32x4_t Lib_IntVector_Intrinsics_vec128;


### PR DESCRIPTION
`libintvector.h` shouldn't be used on 32-bit ARM. I added `!defined(__ARM_32BIT_STATE)` for this.