### PR TITLE
Do not return a promise when calling into the wasm code

### DIFF
--- a/bindings/js/api.js
+++ b/bindings/js/api.js
@@ -258,10 +258,6 @@ var HaclWasm = (function() {
     throw "Unimplemented !";
   };
 
-  var checkObj = {
-    checkIfInitialized: checkIfInitialized,
-  };
-
   var api_obj = {};
 
   // Creating object by mapping from api.json structure
@@ -271,14 +267,24 @@ var HaclWasm = (function() {
         api_obj[key_module] = {};
       }
       api_obj[key_module][key_func] = function(...args) {
-        return checkIfInitialized().then(function() {
-          return callWithProto(api_json[key_module][key_func], args);
-        });
+        if (isInitialized === false) {
+           throw 'Uninitialized';
+        };
+        return callWithProto(api_json[key_module][key_func], args);
       };
     });
   });
 
-  return Object.assign(checkObj, api_obj);
+  var getInitializedHaclModule = async function () {
+    await checkIfInitialized();
+    return api_obj;
+  };
+
+  var checkObj = {
+    getInitializedHaclModule: getInitializedHaclModule,
+  };
+
+  return checkObj;
 })();
 
 if (typeof module !== "undefined") {

--- a/bindings/js/api_test.js
+++ b/bindings/js/api_test.js
@@ -89,7 +89,7 @@ var passTest = async function(func_sig, func, msg, t) {
   console.log("Test #" + (t + 1) + " passed !");
 };
 
-async function checkTestVectors(func_sig, func, msg) {
+function checkTestVectors(func_sig, func, msg) {
   var number_of_tests = Infinity;
   func_sig.args.map(function(arg) {
     if (arg.tests !== undefined) {
@@ -104,18 +104,18 @@ async function checkTestVectors(func_sig, func, msg) {
     console.warn("No tests for " + msg + "!");
   }
   for (var t = 0; t < number_of_tests; t++) {
-    await passTest(func_sig, func, msg, t);
+    passTest(func_sig, func, msg, t);
   }
 }
 
-HaclWasm.checkIfInitialized().then(async function() {
+HaclWasm.getInitializedHaclModule().then(function(Hacl) {
   var tests = [];
   Promise.all(Object.keys(test_vectors).map(function(key_module) {
     Object.keys(test_vectors[key_module]).map(function(key_func) {
-      tests.push([test_vectors[key_module][key_func], HaclWasm[key_module][key_func], key_module + "." + key_func]);
+      tests.push([test_vectors[key_module][key_func], Hacl[key_module][key_func], key_module + "." + key_func]);
     });
   }));
   for (var i = 0; i < tests.length; i++) {
-    await checkTestVectors.apply(null, tests[i]);
+    checkTestVectors.apply(null, tests[i]);
   }
 });


### PR DESCRIPTION
This is a WIP of the general idea that I'm working towards. Ideally, instead of `api.js` giving me a fully realised module which contains functions that return promises (promises that are due to initialisation), I'd rather `api.js` give me a promise of something (module, object, whatever) which contains functions that return their result immediately.