### PR TITLE
Deprecate two phase tc option

### DIFF
--- a/vale/SConstruct
+++ b/vale/SConstruct
@@ -380,8 +380,8 @@ verify_options = [
   ('specs/*/*.fsti', BuildOptions(fstar_default_args())),
 
   # .fst/.fsti files default to this set of options
-  ('.fst', BuildOptions(fstar_default_args() + ' --use_two_phase_tc false')),
-  ('.fsti', BuildOptions(fstar_default_args() + ' --use_two_phase_tc false')),
+  ('.fst', BuildOptions(fstar_default_args())),
+  ('.fsti', BuildOptions(fstar_default_args())),
 
   ('code/arch/x64/X64.Leakage_Ins.fst', None),
   ('code/arch/x64/X64.Leakage_Ins_Xmm.fst', None),
@@ -401,7 +401,7 @@ verify_options = [
   ('obj/external/*.fst', BuildOptions('--cache_checked_modules --admit_smt_queries true')),
 
   # .vaf files default to this set of options when compiling .fst/.fsti
-  ('.vaf', BuildOptions(fstar_default_args() + ' --use_two_phase_tc false'))
+  ('.vaf', BuildOptions(fstar_default_args()))
 ]
 
 verify_options_dict = { k:v for (k,v) in verify_options}

--- a/vale/code/crypto/aes/Vale.AES.GHash.fst
+++ b/vale/code/crypto/aes/Vale.AES.GHash.fst
@@ -5,7 +5,7 @@ open Vale.Math.Poly2.Words
 
 friend Vale.AES.OptPublic
 
-#reset-options "--use_two_phase_tc true"
+#reset-options
 
 let shift_gf128_key_1 (h:poly) : poly =
   shift_key_1 128 gf128_modulus_low_terms h

--- a/vale/code/crypto/aes/Vale.AES.GHash.fsti
+++ b/vale/code/crypto/aes/Vale.AES.GHash.fsti
@@ -20,7 +20,7 @@ open FStar.Mul
 open FStar.Calc
 open Vale.AES.OptPublic
 
-#reset-options "--use_two_phase_tc true"
+#reset-options
 
 let poly128 = p:poly{degree p < 128}
 


### PR DESCRIPTION
This option is true by default, and I think it is safe to say that unsetting it is not supported/maintained.