### PR TITLE
Make the vector store_le/load_le functions more specialized

### DIFF
--- a/lib/Lib.IntVector.Intrinsics.fsti
+++ b/lib/Lib.IntVector.Intrinsics.fsti
@@ -83,10 +83,17 @@ val vec128_load32: u:uint32 -> vec128
 val vec128_load32s: x0:uint32 -> x1:uint32 -> x2:uint32 -> x3:uint32 -> vec128
 
 
-val vec128_load_le: b:lbuffer uint8 16ul -> ST vec128
+val vec128_load32_le: b:lbuffer uint8 16ul -> ST vec128
 			   (requires (fun h -> live h b))
 			   (ensures (fun h0 _ h1 ->  h1 == h0))
 
+val vec128_load64_le: b:lbuffer uint8 16ul -> ST vec128
+			   (requires (fun h -> live h b))
+			   (ensures (fun h0 _ h1 ->  h1 == h0))
+
+val vec128_load128_le: b:lbuffer uint8 16ul -> ST vec128
+			   (requires (fun h -> live h b))
+			   (ensures (fun h0 _ h1 ->  h1 == h0))
 
 val vec128_load_be: b:lbuffer uint8 16ul -> ST vec128
 			   (requires (fun h -> live h b))
@@ -103,10 +110,17 @@ val vec128_load64_be: b:lbuffer uint8 16ul -> ST vec128
 			   (ensures (fun h0 _ h1 ->  h1 == h0))
 
 
-val vec128_store_le: b:lbuffer uint8 16ul -> vec128 -> ST unit
+val vec128_store32_le: b:lbuffer uint8 16ul -> vec128 -> ST unit
 			   (requires (fun h -> live h b))
 			   (ensures (fun h0 _ h1 ->  live h1 b /\ modifies (loc b) h0 h1))
 
+val vec128_store64_le: b:lbuffer uint8 16ul -> vec128 -> ST unit
+			   (requires (fun h -> live h b))
+			   (ensures (fun h0 _ h1 ->  live h1 b /\ modifies (loc b) h0 h1))
+
+val vec128_store128_le: b:lbuffer uint8 16ul -> vec128 -> ST unit
+			   (requires (fun h -> live h b))
+			   (ensures (fun h0 _ h1 ->  live h1 b /\ modifies (loc b) h0 h1))
 
 val vec128_store_be: b:lbuffer uint8 16ul -> vec128 -> ST unit
 			   (requires (fun h -> live h b))
@@ -256,7 +270,15 @@ val vec256_load128s: x0:uint128 -> x1:uint128 -> vec256
 
 
 
-val vec256_load_le: b:lbuffer uint8 32ul -> ST vec256
+val vec256_load32_le: b:lbuffer uint8 32ul -> ST vec256
+			   (requires (fun h -> live h b))
+			   (ensures (fun h0 _ h1 ->  h1 == h0))
+
+val vec256_load64_le: b:lbuffer uint8 32ul -> ST vec256
+			   (requires (fun h -> live h b))
+			   (ensures (fun h0 _ h1 ->  h1 == h0))
+
+val vec256_load128_le: b:lbuffer uint8 32ul -> ST vec256
 			   (requires (fun h -> live h b))
 			   (ensures (fun h0 _ h1 ->  h1 == h0))
 
@@ -266,7 +288,15 @@ val vec256_load_be: b:lbuffer uint8 32ul -> ST vec256
 			   (ensures (fun h0 _ h1 ->  h1 == h0))
 
 
-val vec256_store_le: b:lbuffer uint8 32ul -> vec256 -> ST unit
+val vec256_store32_le: b:lbuffer uint8 32ul -> vec256 -> ST unit
+			   (requires (fun h -> live h b))
+			   (ensures (fun h0 _ h1 ->  live h1 b /\ modifies (loc b) h0 h1))
+
+val vec256_store64_le: b:lbuffer uint8 32ul -> vec256 -> ST unit
+			   (requires (fun h -> live h b))
+			   (ensures (fun h0 _ h1 ->  live h1 b /\ modifies (loc b) h0 h1))
+
+val vec256_store128_le: b:lbuffer uint8 32ul -> vec256 -> ST unit
 			   (requires (fun h -> live h b))
 			   (ensures (fun h0 _ h1 ->  live h1 b /\ modifies (loc b) h0 h1))
 

--- a/lib/Lib.IntVector.fst
+++ b/lib/Lib.IntVector.fst
@@ -466,13 +466,13 @@ let vec_from_bytes_be t w b = admit()
 
 let vec_load_le t w b =
   match t,w with
-  | U128,1 -> vec128_load_le b
+  | U128,1 -> vec128_load128_le b // unused for now, and no implementation in libintvector.h
   | _,1 -> Lib.ByteBuffer.uint_from_bytes_le #t #SEC b
-  | U32,4 -> vec128_load_le b
-  | U64,2 -> vec128_load_le b
-  | U32,8 -> vec256_load_le b
-  | U64,4 -> vec256_load_le b
-  | U128,2 -> vec256_load_le b
+  | U32,4 -> vec128_load32_le b
+  | U64,2 -> vec128_load64_le b
+  | U32,8 -> vec256_load32_le b
+  | U64,4 -> vec256_load64_le b
+  | U128,2 -> vec256_load128_le b // unused for now, and no implementation in libintvector.h
 
 let vec_load_be t w b =
   match t,w with
@@ -486,13 +486,13 @@ let vec_to_bytes_be #vt #w v = admit()
 
 let vec_store_le #t #w b v =
   match t,w with
-  | U128,1 -> vec128_store_le b v
+  | U128,1 -> vec128_store128_le b v // unused for now, and no implementation in libintvector.h
   | _,1 -> Lib.ByteBuffer.uint_to_bytes_le #t #SEC b v
-  | U32,4 -> vec128_store_le b v
-  | U64,2 -> vec128_store_le b v
-  | U32,8 -> vec256_store_le b v
-  | U64,4 -> vec256_store_le b v
-  | U128,2 -> vec256_store_le b v
+  | U32,4 -> vec128_store32_le b v
+  | U64,2 -> vec128_store64_le b v
+  | U32,8 -> vec256_store32_le b v
+  | U64,4 -> vec256_store64_le b v
+  | U128,2 -> vec256_store128_le b v // unused for now, and no implementation in libintvector.h
 
 let vec_store_be #t #w b v =
   match t,w with

--- a/lib/c/libintvector.h
+++ b/lib/c/libintvector.h
@@ -101,10 +101,16 @@ typedef __m128i Lib_IntVector_Intrinsics_vec128;
 #define Lib_IntVector_Intrinsics_vec128_rotate_right_lanes64(x0, x1)	\
   (_mm_shuffle_epi32(x0, _MM_SHUFFLE((2*x1+3)%4,(2*x1+2)%4,(2*x1+1)%4,(2*x1)%4)))
 
-#define Lib_IntVector_Intrinsics_vec128_load_le(x0) \
+#define Lib_IntVector_Intrinsics_vec128_load32_le(x0) \
   (_mm_loadu_si128((__m128i*)(x0)))
 
-#define Lib_IntVector_Intrinsics_vec128_store_le(x0, x1) \
+#define Lib_IntVector_Intrinsics_vec128_load64_le(x0) \
+  (_mm_loadu_si128((__m128i*)(x0)))
+
+#define Lib_IntVector_Intrinsics_vec128_store32_le(x0, x1) \
+  (_mm_storeu_si128((__m128i*)(x0), x1))
+
+#define Lib_IntVector_Intrinsics_vec128_store64_le(x0, x1) \
   (_mm_storeu_si128((__m128i*)(x0), x1))
 
 #define Lib_IntVector_Intrinsics_vec128_load_be(x0)		\
@@ -315,7 +321,10 @@ typedef __m256i Lib_IntVector_Intrinsics_vec256;
 #define Lib_IntVector_Intrinsics_vec256_rotate_right_lanes64(x0, x1)	\
   (_mm256_permute4x64_epi64(x0, _MM_SHUFFLE((x1+3)%4,(x1+2)%4,(x1+1)%4,x1%4)))
 
-#define Lib_IntVector_Intrinsics_vec256_load_le(x0) \
+#define Lib_IntVector_Intrinsics_vec256_load32_le(x0) \
+  (_mm256_loadu_si256((__m256i*)(x0)))
+
+#define Lib_IntVector_Intrinsics_vec256_load64_le(x0) \
   (_mm256_loadu_si256((__m256i*)(x0)))
 
 #define Lib_IntVector_Intrinsics_vec256_load32_be(x0)		\
@@ -325,7 +334,10 @@ typedef __m256i Lib_IntVector_Intrinsics_vec256;
   (_mm256_shuffle_epi8(_mm256_loadu_si256((__m256i*)(x0)), _mm256_set_epi8(8, 9, 10, 11, 12, 13, 14, 15, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 0, 1, 2, 3, 4, 5, 6, 7)))
 
 
-#define Lib_IntVector_Intrinsics_vec256_store_le(x0, x1) \
+#define Lib_IntVector_Intrinsics_vec256_store32_le(x0, x1) \
+  (_mm256_storeu_si256((__m256i*)(x0), x1))
+
+#define Lib_IntVector_Intrinsics_vec256_store64_le(x0, x1) \
   (_mm256_storeu_si256((__m256i*)(x0), x1))
 
 #define Lib_IntVector_Intrinsics_vec256_store32_be(x0, x1)	\
@@ -503,10 +515,16 @@ typedef uint32x4_t Lib_IntVector_Intrinsics_vec128;
   (_mm_shuffle_epi32(x0, _MM_SHUFFLE(2*x1+1,2*x1,2*x2+1,2*x2)))
 */
 
-#define Lib_IntVector_Intrinsics_vec128_load_le(x0) \
+#define Lib_IntVector_Intrinsics_vec128_load32_le(x0) \
   (vld1q_u32((const uint32_t*) (x0)))
 
-#define Lib_IntVector_Intrinsics_vec128_store_le(x0, x1) \
+#define Lib_IntVector_Intrinsics_vec128_load64_le(x0) \
+  (vld1q_u32((const uint32_t*) (x0)))
+
+#define Lib_IntVector_Intrinsics_vec128_store32_le(x0, x1) \
+  (vst1q_u32((uint32_t*)(x0),(x1)))
+
+#define Lib_IntVector_Intrinsics_vec128_store64_le(x0, x1) \
   (vst1q_u32((uint32_t*)(x0),(x1)))
 
 /*


### PR DESCRIPTION
This PR is necessary to add support for the IBMz vectorized implementations.

It makes a case disjunction on the type of vector elements in `store_le` and `load_le`.
The reason is that on x64 and on IBMz (which is big-endian), the consistency between the elements' order and the endianess is not the same.
For instance, if a vector 128 interpreted as an array of `uint32_t` has the following representation:
```
vector(uint32): [0x00112233, 0x44556677, 0x8899aabb, 0xccddeeff]
```

then, reinterpreted as an array of `uint64_t`, we get:
```
vector(uint64)(x64):  [0x4455667700112233, 0xccddeeff8899aabb]
vector(uint64)(IBMz): [0x0011223344556677, 0x8899aabbccddeeff]
```

When reading from bytes/writing to bytes, we thus need to know what kind of elements the vector stores, otherwise the data gets messed up.

Note that this is not a problem for the other vector operations, because even though the underlying vector type is the same, those operations are guarded by their types in the HACL code. In other words, it is not possible to use both `add32` and `add64` on the same vector, because there will be a typing issue in F*. In a sense, this PR simply makes the `store_le` and `load_le` operations consistent with the rest.

Finally, note that I added too many cases in `Lib.IntVector.fst` without the corresponding implementation in `libintvector.h`, rather than using generic `load_le`/`store_le` functions for the currently unused cases. The reason is that I think it's better to have compilation errors in the future when updating the code, rather than potentially nasty runtime errors because of endianess.