### PR TITLE
Fix the build for ARM

### DIFF
--- a/dist/configure
+++ b/dist/configure
@@ -162,8 +162,8 @@ detect_arm_neon () {
 
 int main () {
   uint8_t block[32] = { 0 };
-  Lib_IntVector_Intrinsics_vec128 b1 = Lib_IntVector_Intrinsics_vec128_load_le(block);
-  Lib_IntVector_Intrinsics_vec128 b2 = Lib_IntVector_Intrinsics_vec128_load_le(block + 16);
+  Lib_IntVector_Intrinsics_vec128 b1 = Lib_IntVector_Intrinsics_vec128_load32_le(block);
+  Lib_IntVector_Intrinsics_vec128 b2 = Lib_IntVector_Intrinsics_vec128_load32_le(block + 16);
   Lib_IntVector_Intrinsics_vec128 test = Lib_IntVector_Intrinsics_vec128_interleave_high64(b1, b2);
   return 0;
 }

--- a/dist/gcc-compatible/configure
+++ b/dist/gcc-compatible/configure
@@ -162,8 +162,8 @@ detect_arm_neon () {
 
 int main () {
   uint8_t block[32] = { 0 };
-  Lib_IntVector_Intrinsics_vec128 b1 = Lib_IntVector_Intrinsics_vec128_load_le(block);
-  Lib_IntVector_Intrinsics_vec128 b2 = Lib_IntVector_Intrinsics_vec128_load_le(block + 16);
+  Lib_IntVector_Intrinsics_vec128 b1 = Lib_IntVector_Intrinsics_vec128_load32_le(block);
+  Lib_IntVector_Intrinsics_vec128 b2 = Lib_IntVector_Intrinsics_vec128_load32_le(block + 16);
   Lib_IntVector_Intrinsics_vec128 test = Lib_IntVector_Intrinsics_vec128_interleave_high64(b1, b2);
   return 0;
 }


### PR DESCRIPTION
Fixes the ARM neon detection in the configure file, which currently makes the build fail and was not detected by the CI before the merge of https://github.com/project-everest/hacl-star/pull/408