### PR TITLE
Don't inline point_negate

### DIFF
--- a/code/ed25519/Hacl.Impl.Ed25519.PointNegate.fst
+++ b/code/ed25519/Hacl.Impl.Ed25519.PointNegate.fst
@@ -23,7 +23,6 @@ val point_negate: p:F51.point -> out:F51.point ->
     F51.point_inv_t h1 out /\
     F51.point_eval h1 out == SC.((-x1) % prime, y1, z1, (-t1) % prime)))
 
-[@CInline]
 let point_negate p out =
   push_frame ();
   let zero = create 5ul (u64 0) in


### PR DESCRIPTION
I'm not entirely sure why, but in-lining the point negation breaks the Windows build. The function is only declared as extern but compiled (optimized?) out.

> 01F 00000000 UNDEF  notype ()    External     | Hacl_Impl_Ed25519_PointNegate_point_negate

You can also see the error on the `evercrypt-sys` build: https://github.com/franziskuskiefer/evercrypt-rust/runs/2075276459
Not in-lining fixes this for me locally but I'm happy to consider other solutions.

Note that our CI here currently doesn't catch this because it only builds the library and doesn't actually use it.