### PR TITLE
Freebsd

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -184,7 +184,7 @@ ifeq ($(shell uname -s),Darwin)
   ifeq (,$(shell which gtime))
     $(error gtime not found; try brew install gnu-time)
   endif
-  TIME := gtime
+  TIME := gtime -q -f '%E'
 else
   ifeq ($(shell uname -s),FreeBSD)
     SED := sed
@@ -193,7 +193,7 @@ else
   else
     SED := sed
     SEDi := -i
-    TIME := /usr/bin/time
+    TIME := /usr/bin/time -q -f '%E'
   endif
 endif
 
@@ -220,7 +220,7 @@ SHELL:=$(shell which bash)
 ifeq (,$(NOSHORTLOG))
 run-with-log = \
   @echo "$(subst ",\",$1)" > $3.cmd; \
-  $(TIME) -q -f '%E' -o $3.time sh -c "$(subst ",\",$1)" > $3.out 2> >( tee $3.err 1>&2 ); \
+  $(TIME) -o $3.time sh -c "$(subst ",\",$1)" > $3.out 2> >( tee $3.err 1>&2 ); \
   ret=$$?; \
   time=$$(cat $3.time); \
   if [ $$ret -eq 0 ]; then \

--- a/Makefile
+++ b/Makefile
@@ -160,7 +160,7 @@ min-test:
 TO_CLEAN=$(foreach ext,checked checked.lax out cmd err time dump types.vaf krml cmx cmo cmi o d a,-or -iname '*.$(ext)')
 clean:
 	find . -iname '.depend*' $(TO_CLEAN) -delete
-	find obj -depth 1 -name .gitignore -o -delete
+	find obj -maxdepth 1 -mindepth 1 -not -name .gitignore -delete
 
 
 #################

--- a/Makefile
+++ b/Makefile
@@ -180,13 +180,21 @@ ifeq ($(shell uname -s),Darwin)
     $(error gsed not found; try brew install gnu-sed)
   endif
   SED := gsed
+  SEDi := -i
   ifeq (,$(shell which gtime))
     $(error gtime not found; try brew install gnu-time)
   endif
   TIME := gtime
 else
-  SED := sed
-  TIME := /usr/bin/time
+  ifeq ($(shell uname -s),FreeBSD)
+    SED := sed
+    SEDi := -i ''
+    TIME := /usr/bin/time
+  else
+    SED := sed
+    SEDi := -i
+    TIME := /usr/bin/time
+  endif
 endif
 
 ifneq ($(OS),Windows_NT)
@@ -200,7 +208,7 @@ endif
 # Pretty-printing helper #
 ##########################
 
-SHELL=/bin/bash
+SHELL:=$(shell which bash)
 
 # A helper to generate pretty logs, callable as:
 #   $(call run-with-log,CMD,TXT,STEM)
@@ -270,8 +278,8 @@ ifndef MAKE_RESTARTS
 	@if ! [ -f .didhelp ]; then echo "💡 Did you know? If your dependency graph didn't change (e.g. no files added or removed, no reference to a new module in your code), run NODEPEND=1 make <your-target> to skip dependency graph regeneration!"; touch .didhelp; fi
 	$(call run-with-log,\
 	  $(FSTAR_NO_FLAGS) --dep $* $(notdir $(FSTAR_ROOTS)) --warn_error '-285' $(FSTAR_DEPEND_FLAGS) \
-	    --extract '-* +FStar.Kremlin.Endianness +Vale.Arch +Vale.X64 -Vale.X64.MemoryAdapters +Vale.Def +Vale.Lib +Vale.Bignum.X64 -Vale.Lib.Tactics +Vale.Math +Vale.Transformers +Vale.AES +Vale.Interop +Vale.Arch.Types +Vale.Arch.BufferFriend +Vale.Lib.X64 +Vale.SHA.X64 +Vale.SHA.SHA_helpers +Vale.Curve25519.X64 +Vale.Poly1305.X64 +Vale.Inline +Vale.AsLowStar +Vale.Test +Spec +Lib -Lib.IntVector -Lib.Memzero0 -Lib.Buffer +C -C.String -C.Failure' > $@ && \
-	  $(SED) -i 's!$(HACL_HOME)/obj/\(.*.checked\)!obj/\1!;s!/bin/../ulib/!/ulib/!g' $@ \
+	    --extract '-* +FStar.Kremlin.Endianness +Vale.Arch +Vale.X64 -Vale.X64.MemoryAdapters +Vale.Def +Vale.Lib +Vale.Bignum.X64 -Vale.Lib.Tactics +Vale.Math +Vale.Transformers +Vale.AES +Vale.Interop +Vale.Arch.Types +Vale.Arch.BufferFriend +Vale.Lib.X64 +Vale.SHA.X64 +Vale.SHA.SHA_helpers +Vale.Curve25519.X64 +Vale.Poly1305.X64 +Vale.Inline +Vale.AsLowStar +Vale.Test +Spec +Lib -Lib.IntVector +C -C.String -C.Failure' > $@ && \
+	  $(SED) $(SEDi) 's!$(HACL_HOME)/obj/\(.*.checked\)!obj/\1!;s!/bin/../ulib/!/ulib/!g' $@ \
 	  ,[FSTAR-DEPEND ($*)],$(call to-obj-dir,$@))
 
 .vale-depend: .fstar-depend-make .FORCE
@@ -281,7 +289,7 @@ ifndef MAKE_RESTARTS
 	    $(addprefix -in ,$(VALE_ROOTS)) \
 	    -dep $< \
 	    > $@ && \
-	  $(SED) -i 's!$(HACL_HOME)/obj/\(.*.checked\)!obj/\1!g' $@ \
+	  $(SED) $(SEDi) 's!$(HACL_HOME)/obj/\(.*.checked\)!obj/\1!g' $@ \
 	  ,[VALE-DEPEND],$(call to-obj-dir,$@))
 
 .PHONY: .FORCE

--- a/Makefile
+++ b/Makefile
@@ -160,7 +160,7 @@ min-test:
 TO_CLEAN=$(foreach ext,checked checked.lax out cmd err time dump types.vaf krml cmx cmo cmi o d a,-or -iname '*.$(ext)')
 clean:
 	find . -iname '.depend*' $(TO_CLEAN) -delete
-	rm -rf obj/*
+	find obj -depth 1 -name .gitignore -o -delete
 
 
 #################
@@ -179,22 +179,17 @@ ifeq ($(shell uname -s),Darwin)
   ifeq (,$(shell which gsed))
     $(error gsed not found; try brew install gnu-sed)
   endif
-  SED := gsed
-  SEDi := -i
+  SED := gsed -i
   ifeq (,$(shell which gtime))
     $(error gtime not found; try brew install gnu-time)
   endif
   TIME := gtime -q -f '%E'
-else
-  ifeq ($(shell uname -s),FreeBSD)
-    SED := sed
-    SEDi := -i ''
+else ifeq ($(shell uname -s),FreeBSD)
+    SED := sed -i ''
     TIME := /usr/bin/time
-  else
-    SED := sed
-    SEDi := -i
-    TIME := /usr/bin/time -q -f '%E'
-  endif
+else
+  SED := sed -i
+  TIME := /usr/bin/time -q -f '%E'
 endif
 
 ifneq ($(OS),Windows_NT)
@@ -278,8 +273,8 @@ ifndef MAKE_RESTARTS
 	@if ! [ -f .didhelp ]; then echo "💡 Did you know? If your dependency graph didn't change (e.g. no files added or removed, no reference to a new module in your code), run NODEPEND=1 make <your-target> to skip dependency graph regeneration!"; touch .didhelp; fi
 	$(call run-with-log,\
 	  $(FSTAR_NO_FLAGS) --dep $* $(notdir $(FSTAR_ROOTS)) --warn_error '-285' $(FSTAR_DEPEND_FLAGS) \
-	    --extract '-* +FStar.Kremlin.Endianness +Vale.Arch +Vale.X64 -Vale.X64.MemoryAdapters +Vale.Def +Vale.Lib +Vale.Bignum.X64 -Vale.Lib.Tactics +Vale.Math +Vale.Transformers +Vale.AES +Vale.Interop +Vale.Arch.Types +Vale.Arch.BufferFriend +Vale.Lib.X64 +Vale.SHA.X64 +Vale.SHA.SHA_helpers +Vale.Curve25519.X64 +Vale.Poly1305.X64 +Vale.Inline +Vale.AsLowStar +Vale.Test +Spec +Lib -Lib.IntVector +C -C.String -C.Failure' > $@ && \
-	  $(SED) $(SEDi) 's!$(HACL_HOME)/obj/\(.*.checked\)!obj/\1!;s!/bin/../ulib/!/ulib/!g' $@ \
+	    --extract '-* +FStar.Kremlin.Endianness +Vale.Arch +Vale.X64 -Vale.X64.MemoryAdapters +Vale.Def +Vale.Lib +Vale.Bignum.X64 -Vale.Lib.Tactics +Vale.Math +Vale.Transformers +Vale.AES +Vale.Interop +Vale.Arch.Types +Vale.Arch.BufferFriend +Vale.Lib.X64 +Vale.SHA.X64 +Vale.SHA.SHA_helpers +Vale.Curve25519.X64 +Vale.Poly1305.X64 +Vale.Inline +Vale.AsLowStar +Vale.Test +Spec +Lib -Lib.IntVector -Lib.Memzero0 -Lib.Buffer +C -C.String -C.Failure' > $@ && \
+	  $(SED) 's!$(HACL_HOME)/obj/\(.*.checked\)!obj/\1!;s!/bin/../ulib/!/ulib/!g' $@ \
 	  ,[FSTAR-DEPEND ($*)],$(call to-obj-dir,$@))
 
 .vale-depend: .fstar-depend-make .FORCE
@@ -289,7 +284,7 @@ ifndef MAKE_RESTARTS
 	    $(addprefix -in ,$(VALE_ROOTS)) \
 	    -dep $< \
 	    > $@ && \
-	  $(SED) $(SEDi) 's!$(HACL_HOME)/obj/\(.*.checked\)!obj/\1!g' $@ \
+	  $(SED) 's!$(HACL_HOME)/obj/\(.*.checked\)!obj/\1!g' $@ \
 	  ,[VALE-DEPEND],$(call to-obj-dir,$@))
 
 .PHONY: .FORCE

--- a/bindings/ocaml/hacl-star.opam
+++ b/bindings/ocaml/hacl-star.opam
@@ -21,6 +21,3 @@ build: [
 run-test: [
   ["dune" "runtest" "-p" name "-j" jobs]
 ]
-available: [
-  os-family != "bsd"
-]

--- a/code/bignum/Hacl.Impl.Exponentiation.fst
+++ b/code/bignum/Hacl.Impl.Exponentiation.fst
@@ -429,6 +429,8 @@ val table_select_ct:
    (Math.Lemmas.lemma_mult_le_right (v len) (v i + 1) (v table_len);
     as_seq h1 res == LSeq.sub (as_seq h0 table) (v i * v len) (v len)))
 
+
+#push-options "--z3rlimit_factor 2 --fuel 100 --ifuel 100"
 let table_select_ct #a_t len table_len table i res =
   let h0 = ST.get () in
   copy res (sub table 0ul len);
@@ -453,6 +455,7 @@ let table_select_ct #a_t len table_len table i res =
       (if v i = v j + 1 then LSeq.sub (as_seq h0 table) (v i * v len) (v len) else as_seq h2 res));
     assert (inv h3 (v j + 1))
     )
+#pop-options
 
 //////////////////////////////////////////////////////////
 

--- a/code/old/Makefile.old
+++ b/code/old/Makefile.old
@@ -43,7 +43,7 @@ all-test: test
 clean: $(addsuffix -clean, $(DIRECTORIES) experimental)
 	rm -rf *~ *.exe *.out
 
-SHELL=/bin/bash
+SHELL:=$(shell which bash)
 
 .PHONY: clean-
 clean-c:

--- a/code/old/lib/kremlin/mk_int.sh
+++ b/code/old/lib/kremlin/mk_int.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Taken from the FStar repository
 

--- a/code/old/lib/mk_int.sh
+++ b/code/old/lib/mk_int.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Taken from the FStar repository
 

--- a/dist/Makefile.tmpl
+++ b/dist/Makefile.tmpl
@@ -50,6 +50,10 @@ else ifeq ($(OS),Windows_NT)
   VARIANT	= -mingw
   SO		= dll
   LDFLAGS	= -Wl,--out-implib,libevercrypt.dll.a
+else ifeq ($(UNAME),FreeBSD)
+  CFLAGS	+= -fPIC
+  VARIANT	= -freebsd
+  SO 		= so
 endif
 
 # 2. Parameters we want to compile with, for the generated Makefile

--- a/dist/configure
+++ b/dist/configure
@@ -141,7 +141,7 @@ EOF
 # -------------------------
 
 detect_x64 () {
-  [[ $target_arch == "x86_64" ]]
+  [[ $target_arch == "x86_64" ]] || [[ $target_arch == "amd64" ]]
 }
 
 detect_x86 () {

--- a/specs/make_md5_tests.sh
+++ b/specs/make_md5_tests.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # From: RFC 1321, section A.5 (https://www.ietf.org/rfc/rfc1321.txt)
 

--- a/specs/make_sha1_tests.sh
+++ b/specs/make_sha1_tests.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # From
 # e.g. https://csrc.nist.gov/CSRC/media/Projects/Cryptographic-Algorithm-Validation-Program/documents/shs/shabytetestvectors.zip

--- a/tests/benchmark/benchmark-all.sh
+++ b/tests/benchmark/benchmark-all.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 nob_cpus() {
 	echo "[+] Setting non-boot CPUs to status $1"

--- a/tests/benchmark/env.sh
+++ b/tests/benchmark/env.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 nob_cpus() {
     echo "[+] Setting non-boot CPUs to status $1"

--- a/tools/blast-staticconfig.sh
+++ b/tools/blast-staticconfig.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 

--- a/tools/findpython3.sh
+++ b/tools/findpython3.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 set -o pipefail

--- a/tools/get_vale.sh
+++ b/tools/get_vale.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 

--- a/vale/run_scons.sh
+++ b/vale/run_scons.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Platform-independent invocation of SCons
 # Inspired from the Everest script


### PR DESCRIPTION
These changes extend support to build the "all" target on FreeBSD 12.

They replace some Lilnux-isms (e.g. /bin/bash) with portable usage, add detection of amd64, increase fuel and rlimit for a failed proof, and work around an issue of exceeding command-line limits in "m obj/*".

