### PR TITLE
Makefile: missing openssl include for handwritten tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1131,6 +1131,7 @@ LDFLAGS 	+= -L$(OPENSSL_HOME)
 
 CFLAGS += -Wall -Wextra -g \
   -Wno-int-conversion -Wno-unused-parameter \
+  -I$(OPENSSL_HOME)/include \
   -O3 -march=native -mtune=native -I$(KREMLIN_HOME)/kremlib/dist/minimal \
   -I$(KREMLIN_HOME)/include -Idist/gcc-compatible
 


### PR DESCRIPTION
In `Makefile`, `CFLAGS` and `LDFLAGS` are defined for the purpose of compiling the handwritten tests in `tests/`. There, `LDFLAGS` is set with the path to OpenSSL, but not `CFLAGS`. From what I understood from @msprotz , this is just an overlook; I am surprised that this works in our current CI.

But then, I started writing a standalone Everest Dockerfile at https://github.com/project-everest/everest/blob/_taramana_ppxlib/.docker/build/linux/Dockerfile.OCaml , and if I run it from a clone of Everest master, then, at the ./everest test step, I get the following error:

```
cc -I/home/test/everest/kremlin/include -I../dist/gcc-compatible -I/home/test/everest/kremlin/kremlib/dist/minimal -I../secure_api/merkle_tree -O3 -Wall -Wextra -g -Wno-int-conversion -Wno-unused-parameter -O3 -march=native -mtune=native -I/home/test/everest/kremlin/kremlib/dist/minimal -I/home/test/everest/kremlin/include -Idist/gcc-compatible    -c -o sha2-test.o sha2-test.c
sha2-test.c:12:10: fatal error: openssl/sha.h: No such file or directory
   12 | #include <openssl/sha.h>
      |          ^~~~~~~~~~~~~~~
compilation terminated.
make[2]: *** [<builtin>: sha2-test.o] Error 1
rm rsapss-test.o chacha20-test.o blake2s-32-test-streaming.o merkle_tree_test.o ffdhe-test.o salsa20-test.o blake2s-128-test-streaming.o bignum4096-test.o blake2-test.o
make[2]: Leaving directory '/home/test/everest/hacl-star/tests'
make[1]: *** [Makefile:1173: test-handwritten] Error 2
make[1]: Leaving directory '/home/test/everest/hacl-star'
make: *** [Makefile:114: test-staged] Error 2
make: Leaving directory '/home/test/everest/hacl-star'
The command '/bin/bash --login -c ./everest --yes test' returned a non-zero code: 2
```

This PR solves this issue by adding `-I$(OPENSSL_HOME)/include` to the `CFLAGS +=` line in `Makefile` .