### PR TITLE
drop some inlines in the bignum library to fix Windows build

### DIFF
--- a/code/bignum/Hacl.Bignum.Convert.fst
+++ b/code/bignum/Hacl.Bignum.Convert.fst
@@ -187,7 +187,6 @@ let mk_bn_to_bytes_be #t len b res =
 
 [@CInline]
 let bn_to_bytes_be_uint32 len : bn_to_bytes_be_st U32 len = mk_bn_to_bytes_be #U32 len
-[@CInline]
 let bn_to_bytes_be_uint64 len : bn_to_bytes_be_st U64 len = mk_bn_to_bytes_be #U64 len
 
 

--- a/code/bignum/Hacl.Bignum.Lib.fst
+++ b/code/bignum/Hacl.Bignum.Lib.fst
@@ -133,9 +133,7 @@ let mk_bn_get_top_index #t len b =
   res
 
 
-[@CInline]
 let bn_get_top_index_u32 len: bn_get_top_index_st U32 len = mk_bn_get_top_index #U32 len
-[@CInline]
 let bn_get_top_index_u64 len: bn_get_top_index_st U64 len = mk_bn_get_top_index #U64 len
 
 


### PR DESCRIPTION
This should be the minimum to fix the Windows build (also see #436 ).