### PR TITLE
aarch64 and iOS targets

### DIFF
--- a/.ci/script.sh
+++ b/.ci/script.sh
@@ -24,7 +24,7 @@ if [[ $ARM_CROSS_CI == "aarch64-none-linux-gnu" ]]; then
 fi
 
 # Cross compile for aarch64-apple-darwin. Build only.
-if [ -z "$CROSS_CI" ]; then
+if [ ! -z "$CROSS_CI" ]; then
   pushd dist/gcc-compatible
   rm -rf *.o *.d libevercrypt.a
   ./configure -target $CROSS_CI --disable-ocaml

--- a/.ci/script.sh
+++ b/.ci/script.sh
@@ -26,6 +26,7 @@ fi
 # Cross compile for aarch64-apple-darwin. Build only.
 if [[ $CROSS_CI == "aarch64-apple-darwin" ]]; then
   pushd dist/gcc-compatible
+  make clean
   ./configure -target aarch64-apple-darwin
   make -j
   popd

--- a/.ci/script.sh
+++ b/.ci/script.sh
@@ -27,7 +27,7 @@ fi
 if [[ $CROSS_CI == "aarch64-apple-darwin" ]]; then
   pushd dist/gcc-compatible
   make clean
-  ./configure -target aarch64-apple-darwin
+  ./configure -target aarch64-apple-darwin --disable-ocaml
   make -j
   popd
   exit 0

--- a/.ci/script.sh
+++ b/.ci/script.sh
@@ -28,7 +28,7 @@ if [ -z "$CROSS_CI" ]; then
   pushd dist/gcc-compatible
   rm -rf *.o *.d libevercrypt.a
   ./configure -target $CROSS_CI --disable-ocaml
-  make -j
+  make -j libevercrypt.a
   popd
   exit 0
 fi

--- a/.ci/script.sh
+++ b/.ci/script.sh
@@ -24,10 +24,10 @@ if [[ $ARM_CROSS_CI == "aarch64-none-linux-gnu" ]]; then
 fi
 
 # Cross compile for aarch64-apple-darwin. Build only.
-if [[ $CROSS_CI == "aarch64-apple-darwin" ]]; then
+if [ -z "$CROSS_CI" ]; then
   pushd dist/gcc-compatible
   rm -rf *.o *.d libevercrypt.a
-  ./configure -target aarch64-apple-darwin --disable-ocaml
+  ./configure -target $CROSS_CI --disable-ocaml
   make -j
   popd
   exit 0

--- a/.ci/script.sh
+++ b/.ci/script.sh
@@ -26,7 +26,7 @@ fi
 # Cross compile for aarch64-apple-darwin. Build only.
 if [[ $CROSS_CI == "aarch64-apple-darwin" ]]; then
   pushd dist/gcc-compatible
-  make clean
+  rm -rf *.o *.d libevercrypt.a
   ./configure -target aarch64-apple-darwin --disable-ocaml
   make -j
   popd

--- a/.ci/script.sh
+++ b/.ci/script.sh
@@ -23,7 +23,7 @@ if [[ $ARM_CROSS_CI == "aarch64-none-linux-gnu" ]]; then
   exit 0
 fi
 
-# Cross compile for aarch64-apple-darwin. Build only.
+# Cross compile for other targets. Build and static library only.
 if [ ! -z "$CROSS_CI" ]; then
   pushd dist/gcc-compatible
   rm -rf *.o *.d libevercrypt.a

--- a/.ci/script.sh
+++ b/.ci/script.sh
@@ -23,6 +23,15 @@ if [[ $ARM_CROSS_CI == "aarch64-none-linux-gnu" ]]; then
   exit 0
 fi
 
+# Cross compile for aarch64-apple-darwin. Build only.
+if [[ $CROSS_CI == "aarch64-apple-darwin" ]]; then
+  pushd dist/gcc-compatible
+  ./configure -target aarch64-apple-darwin
+  make -j
+  popd
+  exit 0
+fi
+
 if [[ $TARGET == "IA32" ]]; then
   # Test 32-bit build; Tests don't work here yet.
   pushd dist/gcc-compatible

--- a/.github/workflows/dist.yml
+++ b/.github/workflows/dist.yml
@@ -19,17 +19,23 @@ jobs:
       matrix:
         os:
           - macos-latest
-          # - ubuntu-latest
-          # - windows-latest
+          - ubuntu-latest
+          - windows-latest
     runs-on: ${{ matrix.os }}
 
     steps:
       - uses: actions/checkout@v2
-      # - name: Run CI script
-      #   run: .ci/script.sh
+      - name: Run CI script
+        run: .ci/script.sh
       - name: Apple Silicon Build
         if: matrix.os == 'macos-latest'
         run: |
           sudo rm -Rf /Library/Developer/CommandLineTools/SDKs/*
           sudo xcode-select -s /Applications/Xcode_12.4.app
           CROSS_CI="aarch64-apple-darwin" .ci/script.sh
+      - name: iOS aarch64
+        if: matrix.os == 'macos-latest'
+        run: |
+          sudo rm -Rf /Library/Developer/CommandLineTools/SDKs/*
+          sudo xcode-select -s /Applications/Xcode_12.4.app
+          CROSS_CI="aarch64-apple-ios" .ci/script.sh

--- a/.github/workflows/dist.yml
+++ b/.github/workflows/dist.yml
@@ -21,9 +21,13 @@ jobs:
           - macos-latest
           - ubuntu-latest
           - windows-latest
+          - macos-11.0
     runs-on: ${{ matrix.os }}
 
     steps:
       - uses: actions/checkout@v2
       - name: Run CI script
         run: .ci/script.sh
+      - name: Apple Silicon Build
+        if: matrix.os == 'macos-11.0'
+        run: CROSS_CI="aarch64-apple-darwin" .ci/script.sh

--- a/.github/workflows/dist.yml
+++ b/.github/workflows/dist.yml
@@ -21,7 +21,6 @@ jobs:
           - macos-latest
           - ubuntu-latest
           - windows-latest
-          - macos-11.0
     runs-on: ${{ matrix.os }}
 
     steps:
@@ -29,5 +28,5 @@ jobs:
       - name: Run CI script
         run: .ci/script.sh
       - name: Apple Silicon Build
-        if: matrix.os == 'macos-11.0'
+        if: matrix.os == 'macos-latest'
         run: CROSS_CI="aarch64-apple-darwin" .ci/script.sh

--- a/.github/workflows/dist.yml
+++ b/.github/workflows/dist.yml
@@ -27,6 +27,3 @@ jobs:
       - uses: actions/checkout@v2
       - name: Run CI script
         run: .ci/script.sh
-      - name: Apple Silicon Build
-        if: matrix.os == 'macos-latest'
-        run: CROSS_CI="aarch64-apple-darwin" .ci/script.sh

--- a/.github/workflows/dist.yml
+++ b/.github/workflows/dist.yml
@@ -19,16 +19,16 @@ jobs:
       matrix:
         os:
           - macos-latest
-          - ubuntu-latest
-          - windows-latest
+          # - ubuntu-latest
+          # - windows-latest
     runs-on: ${{ matrix.os }}
 
     steps:
       - uses: actions/checkout@v2
-      - name: Run CI script
-        run: .ci/script.sh
+      # - name: Run CI script
+      #   run: .ci/script.sh
       - name: Apple Silicon Build
         if: matrix.os == 'macos-latest'
         run: |
-          sudo xcode-select -s "/Applications/Xcode_12.4.app
+          sudo xcode-select -s /Applications/Xcode_12.4.app
           CROSS_CI="aarch64-apple-darwin" .ci/script.sh

--- a/.github/workflows/dist.yml
+++ b/.github/workflows/dist.yml
@@ -30,5 +30,6 @@ jobs:
       - name: Apple Silicon Build
         if: matrix.os == 'macos-latest'
         run: |
+          sudo rm -Rf /Library/Developer/CommandLineTools/SDKs/*
           sudo xcode-select -s /Applications/Xcode_12.4.app
           CROSS_CI="aarch64-apple-darwin" .ci/script.sh

--- a/.github/workflows/dist.yml
+++ b/.github/workflows/dist.yml
@@ -27,3 +27,8 @@ jobs:
       - uses: actions/checkout@v2
       - name: Run CI script
         run: .ci/script.sh
+      - name: Apple Silicon Build
+        if: matrix.os == 'macos-latest'
+        run: |
+          sudo xcode-select -s "/Applications/Xcode_12.4.app
+          CROSS_CI="aarch64-apple-darwin" .ci/script.sh

--- a/.github/workflows/dist.yml
+++ b/.github/workflows/dist.yml
@@ -39,3 +39,9 @@ jobs:
           sudo rm -Rf /Library/Developer/CommandLineTools/SDKs/*
           sudo xcode-select -s /Applications/Xcode_12.4.app
           CROSS_CI="aarch64-apple-ios" .ci/script.sh
+      - name: iOS x64 simulator
+        if: matrix.os == 'macos-latest'
+        run: |
+          sudo rm -Rf /Library/Developer/CommandLineTools/SDKs/*
+          sudo xcode-select -s /Applications/Xcode_12.4.app
+          CROSS_CI="x86_64-apple-ios-simulator" .ci/script.sh

--- a/dist/configure
+++ b/dist/configure
@@ -199,6 +199,7 @@ show_help () {
   printf "                    * aarch64-none-linux-gnu\n"
   printf "                    * aarch64-apple-darwin\n"
   printf "                    * aarch64-apple-ios\n"
+  printf "                    * x86_64-apple-ios-simulator\n"
   printf "    --disable-bzero Do not use explicit_bzero (binary will work with an old GLIBC)\n"
   printf "    --disable-ocaml Disable OCAML bindings\n"
   printf "\n"
@@ -307,6 +308,15 @@ if [ ! -z "$build_target" ]; then
     target_abi="ios"
     CROSS_TARGET="-target arm64-apple-ios"
     CROSS_SYSROOT="-isysroot $(xcrun --sdk iphoneos --show-sdk-path) -arch arm64"
+    # CROSS_INCLUDES="-I$SYSROOT/usr/include/"
+  elif [[ "$build_target" == "x86_64-apple-ios-simulator" ]]; then
+    # Cross compiling for x86_64-apple-ios (emulator only)
+    # (presumably on x86_64-apple-darwin).
+    target_arch="x86_64"
+    target_sys="apple"
+    target_abi="ios-simulator"
+    CROSS_TARGET="-target x86_64-apple-ios-simulator"
+    CROSS_SYSROOT="-isysroot $(xcrun --sdk iphonesimulator --show-sdk-path)"
   else
     show_help
     exit 0

--- a/dist/configure
+++ b/dist/configure
@@ -168,7 +168,11 @@ int main () {
   return 0;
 }
 EOF
-  $CC $CROSS_CFLAGS -DHACL_CAN_COMPILE_VEC128 -I. -march=armv8-a+simd -c $file -o /dev/null
+  if [[ $target_arch == "aarch64" ]] && [[ $target_abi == "darwin" ]]; then
+    $CC $CROSS_CFLAGS -DHACL_CAN_COMPILE_VEC128 -I. -c $file -o /dev/null
+  else
+    $CC $CROSS_CFLAGS -DHACL_CAN_COMPILE_VEC128 -I. -march=armv8-a+simd -c $file -o /dev/null
+  fi
 }
 
 # We only detect the 64-bit version of the z-architecture (s390x).
@@ -189,6 +193,7 @@ show_help () {
   printf "                    Currently supported triples are:\n"
   printf "                    * aarch64-none-linux-android\n"
   printf "                    * aarch64-none-linux-gnu\n"
+  printf "                    * aarch64-apple-darwin\n"
   printf "    --disable-bzero Do not use explicit_bzero (binary will work with an old GLIBC)\n"
   printf "    --disable-ocaml Disable OCAML bindings\n"
   printf "\n"
@@ -280,6 +285,13 @@ if [ ! -z "$build_target" ]; then
     target_sys=$(uname)
     target_abi="native"
     echo "MARCH = ia32" >> Makefile.config
+  elif [[ "$build_target" == "aarch64-apple-darwin" ]]; then
+    # Cross compiling for aarch64-apple-darwin (presumably on x86_64-apple-darwin).
+    target_arch="aarch64"
+    target_sys="apple"
+    target_abi="darwin"
+    # See https://developer.apple.com/documentation/apple-silicon/building-a-universal-macos-binary
+    CROSS_TARGET="-target arm64-apple-macos11"
   else
     show_help
     exit 0

--- a/dist/configure
+++ b/dist/configure
@@ -44,6 +44,10 @@ detect_ocaml () {
 }
 
 check_no_bug81300 () {
+  if [[ "$cross_build" == "1" ]]; then
+    # We don't want to build anything with march=native
+    return 0
+  fi
   # Perform the check only if lib_intrinsics.h is present. In practice,
   # lib_intrinsics.h is present in all the directories which contain libintvector.h,
   # but mozilla. If lib_intrinsics.h is not present, assume there is no bug and
@@ -194,6 +198,7 @@ show_help () {
   printf "                    * aarch64-none-linux-android\n"
   printf "                    * aarch64-none-linux-gnu\n"
   printf "                    * aarch64-apple-darwin\n"
+  printf "                    * aarch64-apple-ios\n"
   printf "    --disable-bzero Do not use explicit_bzero (binary will work with an old GLIBC)\n"
   printf "    --disable-ocaml Disable OCAML bindings\n"
   printf "\n"
@@ -207,6 +212,7 @@ echo -n > config.h
 # Default arguments
 disable_ocaml=0
 disable_bzero=0
+cross_build=0
 
 # Parse command line arguments.
 all_args=("$@")
@@ -232,6 +238,7 @@ done
 # target_{arch,sys,abi} accordingly; otherwise, query the host via uname for
 # these parameteres and assume we don't do cross-compilation.
 if [ ! -z "$build_target" ]; then
+  cross_build=1
   echo "Doing cross build for $build_target. Make sure that your toolchain is configured properly."
   if [[ "$build_target" == "aarch64-none-linux-android" ]]; then
     # NOTE: We assume that the Android environment is set up correctly.
@@ -292,6 +299,14 @@ if [ ! -z "$build_target" ]; then
     target_abi="darwin"
     # See https://developer.apple.com/documentation/apple-silicon/building-a-universal-macos-binary
     CROSS_TARGET="-target arm64-apple-macos11"
+  elif [[ "$build_target" == "aarch64-apple-ios" ]]; then
+    # Cross compiling for aarch64-apple-ios
+    # (presumably on x86_64-apple-darwin or aarch64-apple-darwin).
+    target_arch="aarch64"
+    target_sys="apple"
+    target_abi="ios"
+    CROSS_TARGET="-target arm64-apple-ios"
+    CROSS_SYSROOT="-isysroot $(xcrun --sdk iphoneos --show-sdk-path) -arch arm64"
   else
     show_help
     exit 0

--- a/dist/gcc-compatible/configure
+++ b/dist/gcc-compatible/configure
@@ -194,6 +194,8 @@ show_help () {
   printf "                    * aarch64-none-linux-android\n"
   printf "                    * aarch64-none-linux-gnu\n"
   printf "                    * aarch64-apple-darwin\n"
+  printf "                    * aarch64-apple-ios\n"
+  printf "                    * x86_64-apple-ios\n"
   printf "    --disable-bzero Do not use explicit_bzero (binary will work with an old GLIBC)\n"
   printf "    --disable-ocaml Disable OCAML bindings\n"
   printf "\n"
@@ -292,6 +294,13 @@ if [ ! -z "$build_target" ]; then
     target_abi="darwin"
     # See https://developer.apple.com/documentation/apple-silicon/building-a-universal-macos-binary
     CROSS_TARGET="-target arm64-apple-macos11"
+  elif [[ "$build_target" == "aarch64-apple-ios" ]]; then
+    # Cross compiling for aarch64-apple-ios
+    # (presumably on x86_64-apple-darwin or aarch64-apple-darwin).
+    target_arch="aarch64"
+    target_sys="apple"
+    target_abi="ios"
+    CROSS_TARGET="-target arm64-apple-darwin"
   else
     show_help
     exit 0

--- a/dist/gcc-compatible/configure
+++ b/dist/gcc-compatible/configure
@@ -199,6 +199,7 @@ show_help () {
   printf "                    * aarch64-none-linux-gnu\n"
   printf "                    * aarch64-apple-darwin\n"
   printf "                    * aarch64-apple-ios\n"
+  printf "                    * x86_64-apple-ios-simulator\n"
   printf "    --disable-bzero Do not use explicit_bzero (binary will work with an old GLIBC)\n"
   printf "    --disable-ocaml Disable OCAML bindings\n"
   printf "\n"
@@ -307,6 +308,15 @@ if [ ! -z "$build_target" ]; then
     target_abi="ios"
     CROSS_TARGET="-target arm64-apple-ios"
     CROSS_SYSROOT="-isysroot $(xcrun --sdk iphoneos --show-sdk-path) -arch arm64"
+    # CROSS_INCLUDES="-I$SYSROOT/usr/include/"
+  elif [[ "$build_target" == "x86_64-apple-ios-simulator" ]]; then
+    # Cross compiling for x86_64-apple-ios (emulator only)
+    # (presumably on x86_64-apple-darwin).
+    target_arch="x86_64"
+    target_sys="apple"
+    target_abi="ios-simulator"
+    CROSS_TARGET="-target x86_64-apple-ios-simulator"
+    CROSS_SYSROOT="-isysroot $(xcrun --sdk iphonesimulator --show-sdk-path)"
   else
     show_help
     exit 0

--- a/dist/gcc-compatible/configure
+++ b/dist/gcc-compatible/configure
@@ -44,6 +44,10 @@ detect_ocaml () {
 }
 
 check_no_bug81300 () {
+  if [[ "$cross_build" == "1" ]]; then
+    # We don't want to build anything with march=native
+    return 0
+  fi
   # Perform the check only if lib_intrinsics.h is present. In practice,
   # lib_intrinsics.h is present in all the directories which contain libintvector.h,
   # but mozilla. If lib_intrinsics.h is not present, assume there is no bug and
@@ -195,7 +199,6 @@ show_help () {
   printf "                    * aarch64-none-linux-gnu\n"
   printf "                    * aarch64-apple-darwin\n"
   printf "                    * aarch64-apple-ios\n"
-  printf "                    * x86_64-apple-ios\n"
   printf "    --disable-bzero Do not use explicit_bzero (binary will work with an old GLIBC)\n"
   printf "    --disable-ocaml Disable OCAML bindings\n"
   printf "\n"
@@ -209,6 +212,7 @@ echo -n > config.h
 # Default arguments
 disable_ocaml=0
 disable_bzero=0
+cross_build=0
 
 # Parse command line arguments.
 all_args=("$@")
@@ -234,6 +238,7 @@ done
 # target_{arch,sys,abi} accordingly; otherwise, query the host via uname for
 # these parameteres and assume we don't do cross-compilation.
 if [ ! -z "$build_target" ]; then
+  cross_build=1
   echo "Doing cross build for $build_target. Make sure that your toolchain is configured properly."
   if [[ "$build_target" == "aarch64-none-linux-android" ]]; then
     # NOTE: We assume that the Android environment is set up correctly.
@@ -300,7 +305,8 @@ if [ ! -z "$build_target" ]; then
     target_arch="aarch64"
     target_sys="apple"
     target_abi="ios"
-    CROSS_TARGET="-target arm64-apple-darwin"
+    CROSS_TARGET="-target arm64-apple-ios"
+    CROSS_SYSROOT="-isysroot $(xcrun --sdk iphoneos --show-sdk-path) -arch arm64"
   else
     show_help
     exit 0

--- a/dist/gcc-compatible/configure
+++ b/dist/gcc-compatible/configure
@@ -168,7 +168,11 @@ int main () {
   return 0;
 }
 EOF
-  $CC $CROSS_CFLAGS -DHACL_CAN_COMPILE_VEC128 -I. -march=armv8-a+simd -c $file -o /dev/null
+  if [[ $target_arch == "aarch64" ]] && [[ $target_abi == "darwin" ]]; then
+    $CC $CROSS_CFLAGS -DHACL_CAN_COMPILE_VEC128 -I. -c $file -o /dev/null
+  else
+    $CC $CROSS_CFLAGS -DHACL_CAN_COMPILE_VEC128 -I. -march=armv8-a+simd -c $file -o /dev/null
+  fi
 }
 
 # We only detect the 64-bit version of the z-architecture (s390x).
@@ -189,6 +193,7 @@ show_help () {
   printf "                    Currently supported triples are:\n"
   printf "                    * aarch64-none-linux-android\n"
   printf "                    * aarch64-none-linux-gnu\n"
+  printf "                    * aarch64-apple-darwin\n"
   printf "    --disable-bzero Do not use explicit_bzero (binary will work with an old GLIBC)\n"
   printf "    --disable-ocaml Disable OCAML bindings\n"
   printf "\n"
@@ -280,6 +285,13 @@ if [ ! -z "$build_target" ]; then
     target_sys=$(uname)
     target_abi="native"
     echo "MARCH = ia32" >> Makefile.config
+  elif [[ "$build_target" == "aarch64-apple-darwin" ]]; then
+    # Cross compiling for aarch64-apple-darwin (presumably on x86_64-apple-darwin).
+    target_arch="aarch64"
+    target_sys="apple"
+    target_abi="darwin"
+    # See https://developer.apple.com/documentation/apple-silicon/building-a-universal-macos-binary
+    CROSS_TARGET="-target arm64-apple-macos11"
   else
     show_help
     exit 0


### PR DESCRIPTION
This PR adds `aarch64-apple-darwin`, `aarch64-apple-ios`, and `x86_64-apple-ios-simulator` targets to build on arm based macOS, for iOS, and for the x64 iOS simulator.