### PR TITLE
Proof regressions for F* changes related to #2288

### DIFF
--- a/code/bignum/Hacl.Spec.Bignum.Lib.fst
+++ b/code/bignum/Hacl.Spec.Bignum.Lib.fst
@@ -486,7 +486,8 @@ let bn_get_bits_limb_lemma #t #nLen n ind =
       logor_disjoint p1 p2 (pbits - j);
       assert (v p3 == v p1 + v p2);
       bn_eval_index n (i + 1);
-      assert (res == v p1 + v p2) end
+      assert (res == v p1 + v p2);
+      assert (ind / bits t + 1 < nLen && 0 < ind % bits t) end
     else begin
       bn_eval_bound n nLen;
       assert (bn_v n < pow2 (nLen * pbits));
@@ -497,7 +498,6 @@ let bn_get_bits_limb_lemma #t #nLen n ind =
       assert (res == v p1)
     end
   end
-
 
 val bn_get_bits:
     #t:limb_t

--- a/code/streaming/Hacl.Streaming.Functor.fst
+++ b/code/streaming/Hacl.Streaming.Functor.fst
@@ -711,7 +711,7 @@ let split_at_last_rest_eq (#index : Type0) (c: block index)
 // This rlimit is a bit crazy, but this proof is not stable. It usually
 // goes through fast, but a high rlimit is a security against regression failures.
 #restart-solver
-#push-options "--z3rlimit 1000 --z3cliopt smt.arith.nl=false"
+#push-options "--z3rlimit 100 --z3cliopt smt.arith.nl=false"
 let update_small #index c i t t' p data len =
   [@inline_let] let _ = c.state.invariant_loc_in_footprint #i in
   [@inline_let] let _ = c.key.invariant_loc_in_footprint #i in
@@ -767,6 +767,9 @@ let update_small #index c i t t' p data len =
     S.length blocks + S.length rest = U64.v total_len /\
     S.length b = U64.v total_len /\
     U64.v total_len <= c.max_input_length i /\
+    S.equal (B.as_seq h1 buf) (B.as_seq h2 buf) /\
+    B.as_seq h1 buf == B.as_seq h2 buf /\
+    S.equal (S.slice (B.as_seq h1 buf) 0 (S.length rest)) rest /\
     S.equal (S.slice (B.as_seq h2 buf) 0 (S.length rest)) rest
   );
 

--- a/vale/code/arch/x64/Vale.X64.QuickCodes.fst
+++ b/vale/code/arch/x64/Vale.X64.QuickCodes.fst
@@ -135,8 +135,8 @@ let update_state_mods_weaken (mods mods':mods_t) (s' s:vale_state) : Lemma
   update_state_mods_to mods' s' s
 
 let call_QPURE
-    (#a:Type0) (#cs:codes) (r:range) (msg:string) (pre:((unit -> GTot Type0) -> GTot Type0))
-    (l:unit -> PURE unit pre) (qcs:quickCodes a cs) (mods:mods_t) (k:vale_state -> a -> Type0) (s0:vale_state)
+    (#a:Type0) (#cs:codes) (r:range) (msg:string) (pre:((unit -> GTot Type0) -> GTot Type0){is_monotonic pre})
+    (l:unit -> PURE unit (as_pure_wp pre)) (qcs:quickCodes a cs) (mods:mods_t) (k:vale_state -> a -> Type0) (s0:vale_state)
   : Lemma
   (requires
     (forall (p:unit -> GTot Type0).{:pattern pre p}


### PR DESCRIPTION
Proof regressions for F* PR https://github.com/FStarLang/FStar/pull/2288.

Nothing major here. The hacl proofs were just brittle, I checked that the emitted query did not change, there were a few more defns. in the SMT context.

Vale code needs changes because it uses the `PURE` effect directly, so we need to prove the monotonicity of its wps.