### PR TITLE
Explicitly declare Power9 option in dist/configure

### DIFF
--- a/dist/configure
+++ b/dist/configure
@@ -207,6 +207,7 @@ show_help () {
   printf "                    * x86_64-apple-ios-simulator\n"
   printf "    --disable-bzero Do not use explicit_bzero (binary will work with an old GLIBC)\n"
   printf "    --disable-ocaml Disable OCAML bindings\n"
+  printf "    --enable-power9 Enable Power ISA v3.0 instruction set for PowerPC architecture\n"
   printf "\n"
 }
 
@@ -218,6 +219,7 @@ echo -n > config.h
 # Default arguments
 disable_ocaml=0
 disable_bzero=0
+enable_power9=0
 cross_build=0
 
 # Parse command line arguments.
@@ -227,6 +229,7 @@ while [ $# -gt 0 ]; do
         -target) build_target="$2"; shift ;;
         --disable-ocaml) disable_ocaml=1 ;;
         --disable-bzero) disable_bzero=1 ;;
+        --enable-power9) enable_power9=1 ;;
         --help) show_help; exit 0 ;;
         *) show_help; exit 2 ;;
     esac
@@ -428,7 +431,12 @@ if detect_powerpc; then
   echo "TARGET_ARCHITECTURE = PowerPC64" >> Makefile.config
   echo "#define TARGET_ARCHITECTURE TARGET_ARCHITECTURE_ID_POWERPC64" >> config.h
   compile_vec128=true
-  echo "CFLAGS_128 = -mpowerpc64 -mcpu=native -mtune=native -mabi=altivec" >> Makefile.config
+  if [[ "$enable_power9" == "1" ]]; then
+    echo "... enable Power ISA v3.0 instruction set"
+    echo "CFLAGS_128 = -mpowerpc64 -mabi=altivec -mpower9-vector" >> Makefile.config
+  else
+    echo "CFLAGS_128 = -mpowerpc64 -mabi=altivec" >> Makefile.config
+  fi
 fi
 
 if $compile_intrinsics; then

--- a/dist/gcc-compatible/configure
+++ b/dist/gcc-compatible/configure
@@ -207,6 +207,7 @@ show_help () {
   printf "                    * x86_64-apple-ios-simulator\n"
   printf "    --disable-bzero Do not use explicit_bzero (binary will work with an old GLIBC)\n"
   printf "    --disable-ocaml Disable OCAML bindings\n"
+  printf "    --enable-power9 Enable Power ISA v3.0 instruction set for PowerPC architecture\n"
   printf "\n"
 }
 
@@ -218,6 +219,7 @@ echo -n > config.h
 # Default arguments
 disable_ocaml=0
 disable_bzero=0
+enable_power9=0
 cross_build=0
 
 # Parse command line arguments.
@@ -227,6 +229,7 @@ while [ $# -gt 0 ]; do
         -target) build_target="$2"; shift ;;
         --disable-ocaml) disable_ocaml=1 ;;
         --disable-bzero) disable_bzero=1 ;;
+        --enable-power9) enable_power9=1 ;;
         --help) show_help; exit 0 ;;
         *) show_help; exit 2 ;;
     esac
@@ -428,7 +431,12 @@ if detect_powerpc; then
   echo "TARGET_ARCHITECTURE = PowerPC64" >> Makefile.config
   echo "#define TARGET_ARCHITECTURE TARGET_ARCHITECTURE_ID_POWERPC64" >> config.h
   compile_vec128=true
-  echo "CFLAGS_128 = -mpowerpc64 -mcpu=native -mtune=native -mabi=altivec" >> Makefile.config
+  if [[ "$enable_power9" == "1" ]]; then
+    echo "... enable Power ISA v3.0 instruction set"
+    echo "CFLAGS_128 = -mpowerpc64 -mabi=altivec -mpower9-vector" >> Makefile.config
+  else
+    echo "CFLAGS_128 = -mpowerpc64 -mabi=altivec" >> Makefile.config
+  fi
 fi
 
 if $compile_intrinsics; then


### PR DESCRIPTION
Tuning build configuration for native architecture isn't recommended because if the build machine has newer CPU than the target machine the output binaries will crash with illegal instructions signal when run on older CPU. This patch sets AltiVec and PPC64 as the minimum targeted architecture and set Power9 instruction set as optional. Explicitly using -mpower9-vector flag has performance increase 6% over native CPU tuning on POWER9 processor.