### PR TITLE
Simple Makefile rule to build and install OCaml bindings

### DIFF
--- a/dist/Makefile.tmpl
+++ b/dist/Makefile.tmpl
@@ -213,5 +213,9 @@ install-hacl-star-raw: dllocamlevercrypt.$(SO)
          libevercrypt.a libevercrypt.$(SO) ocamlevercrypt.cma ocamlevercrypt.cmxa ocamlevercrypt.a \
          libocamlevercrypt.a dllocamlevercrypt.$(SO) config.h
 
+.PHONY: install-ocaml
+install-ocaml: install-hacl-star-raw
+	cd ../../bindings/ocaml && dune build && dune install
+
 endif
 endif

--- a/dist/c89-compatible/Makefile
+++ b/dist/c89-compatible/Makefile
@@ -213,5 +213,9 @@ install-hacl-star-raw: dllocamlevercrypt.$(SO)
          libevercrypt.a libevercrypt.$(SO) ocamlevercrypt.cma ocamlevercrypt.cmxa ocamlevercrypt.a \
          libocamlevercrypt.a dllocamlevercrypt.$(SO) config.h
 
+.PHONY: install-ocaml
+install-ocaml: install-hacl-star-raw
+	cd ../../bindings/ocaml && dune build && dune install
+
 endif
 endif

--- a/dist/ccf/Makefile
+++ b/dist/ccf/Makefile
@@ -213,5 +213,9 @@ install-hacl-star-raw: dllocamlevercrypt.$(SO)
          libevercrypt.a libevercrypt.$(SO) ocamlevercrypt.cma ocamlevercrypt.cmxa ocamlevercrypt.a \
          libocamlevercrypt.a dllocamlevercrypt.$(SO) config.h
 
+.PHONY: install-ocaml
+install-ocaml: install-hacl-star-raw
+	cd ../../bindings/ocaml && dune build && dune install
+
 endif
 endif

--- a/dist/election-guard/Makefile
+++ b/dist/election-guard/Makefile
@@ -213,5 +213,9 @@ install-hacl-star-raw: dllocamlevercrypt.$(SO)
          libevercrypt.a libevercrypt.$(SO) ocamlevercrypt.cma ocamlevercrypt.cmxa ocamlevercrypt.a \
          libocamlevercrypt.a dllocamlevercrypt.$(SO) config.h
 
+.PHONY: install-ocaml
+install-ocaml: install-hacl-star-raw
+	cd ../../bindings/ocaml && dune build && dune install
+
 endif
 endif

--- a/dist/evercrypt-external-headers/Makefile
+++ b/dist/evercrypt-external-headers/Makefile
@@ -213,5 +213,9 @@ install-hacl-star-raw: dllocamlevercrypt.$(SO)
          libevercrypt.a libevercrypt.$(SO) ocamlevercrypt.cma ocamlevercrypt.cmxa ocamlevercrypt.a \
          libocamlevercrypt.a dllocamlevercrypt.$(SO) config.h
 
+.PHONY: install-ocaml
+install-ocaml: install-hacl-star-raw
+	cd ../../bindings/ocaml && dune build && dune install
+
 endif
 endif

--- a/dist/gcc-compatible/Makefile
+++ b/dist/gcc-compatible/Makefile
@@ -213,5 +213,9 @@ install-hacl-star-raw: dllocamlevercrypt.$(SO)
          libevercrypt.a libevercrypt.$(SO) ocamlevercrypt.cma ocamlevercrypt.cmxa ocamlevercrypt.a \
          libocamlevercrypt.a dllocamlevercrypt.$(SO) config.h
 
+.PHONY: install-ocaml
+install-ocaml: install-hacl-star-raw
+	cd ../../bindings/ocaml && dune build && dune install
+
 endif
 endif

--- a/dist/gcc64-only/Makefile
+++ b/dist/gcc64-only/Makefile
@@ -213,5 +213,9 @@ install-hacl-star-raw: dllocamlevercrypt.$(SO)
          libevercrypt.a libevercrypt.$(SO) ocamlevercrypt.cma ocamlevercrypt.cmxa ocamlevercrypt.a \
          libocamlevercrypt.a dllocamlevercrypt.$(SO) config.h
 
+.PHONY: install-ocaml
+install-ocaml: install-hacl-star-raw
+	cd ../../bindings/ocaml && dune build && dune install
+
 endif
 endif

--- a/dist/mitls/Makefile
+++ b/dist/mitls/Makefile
@@ -213,5 +213,9 @@ install-hacl-star-raw: dllocamlevercrypt.$(SO)
          libevercrypt.a libevercrypt.$(SO) ocamlevercrypt.cma ocamlevercrypt.cmxa ocamlevercrypt.a \
          libocamlevercrypt.a dllocamlevercrypt.$(SO) config.h
 
+.PHONY: install-ocaml
+install-ocaml: install-hacl-star-raw
+	cd ../../bindings/ocaml && dune build && dune install
+
 endif
 endif

--- a/dist/mozilla/Makefile
+++ b/dist/mozilla/Makefile
@@ -213,5 +213,9 @@ install-hacl-star-raw: dllocamlevercrypt.$(SO)
          libevercrypt.a libevercrypt.$(SO) ocamlevercrypt.cma ocamlevercrypt.cmxa ocamlevercrypt.a \
          libocamlevercrypt.a dllocamlevercrypt.$(SO) config.h
 
+.PHONY: install-ocaml
+install-ocaml: install-hacl-star-raw
+	cd ../../bindings/ocaml && dune build && dune install
+
 endif
 endif

--- a/dist/msvc-compatible/Makefile
+++ b/dist/msvc-compatible/Makefile
@@ -213,5 +213,9 @@ install-hacl-star-raw: dllocamlevercrypt.$(SO)
          libevercrypt.a libevercrypt.$(SO) ocamlevercrypt.cma ocamlevercrypt.cmxa ocamlevercrypt.a \
          libocamlevercrypt.a dllocamlevercrypt.$(SO) config.h
 
+.PHONY: install-ocaml
+install-ocaml: install-hacl-star-raw
+	cd ../../bindings/ocaml && dune build && dune install
+
 endif
 endif

--- a/dist/portable-gcc-compatible/Makefile
+++ b/dist/portable-gcc-compatible/Makefile
@@ -213,5 +213,9 @@ install-hacl-star-raw: dllocamlevercrypt.$(SO)
          libevercrypt.a libevercrypt.$(SO) ocamlevercrypt.cma ocamlevercrypt.cmxa ocamlevercrypt.a \
          libocamlevercrypt.a dllocamlevercrypt.$(SO) config.h
 
+.PHONY: install-ocaml
+install-ocaml: install-hacl-star-raw
+	cd ../../bindings/ocaml && dune build && dune install
+
 endif
 endif


### PR DESCRIPTION
So far, one can either directly install the OCaml bindings for HACL*, i.e. the OCaml `hacl-star` package, via opam, or fully compile HACL* with `./everest hacl-star make`.

Is a middle ground possible, i.e. can we consider having a simple Makefile rule to recompile and install `hacl-star-raw` and `hacl-star` from `dist` without the need for reverifying everything?

We know the sequence of commands to do so, but it would not be palatable to tell users in a documentation to type those commands (see Context below.)

So, @msprotz suggested to introduce a `install-ocaml` rule to each Makefile in `dist/` (instead of a rule in the root HACL* Makefile), so that every distribution will enjoy that possibility.

This PR is a concrete implementation of Jonathan's proposal. With that, users can now run:
```
make -C dist/<their distribution> install-ocaml
```

to compile and install OCaml bindings for HACL* (packages hacl-star-raw and hacl-star) using the distribution of their choice.

Thank you Jonathan for your proposal!

## Context
I am currently writing detailed documentation to build EverParse from its sources for people not necessarily familiar with the Everest workflow but who want to contribute to the EverParse code. EverParse uses the hacl-star OCaml bindings.  I would like to add a simple instruction to manually build hacl-star-raw and hacl-star. Please let me insist on "simple", because the whole documentation to install dependencies and build EverParse already takes a dozen of steps. 