### PR TITLE
Enhance flag usage for PowerPC build configuration

### DIFF
--- a/dist/configure
+++ b/dist/configure
@@ -433,9 +433,7 @@ if detect_powerpc; then
   compile_vec128=true
   if [[ "$enable_power9" == "1" ]]; then
     echo "... enable Power ISA v3.0 instruction set"
-    echo "CFLAGS_128 = -mpowerpc64 -mabi=altivec -mpower9-vector" >> Makefile.config
-  else
-    echo "CFLAGS_128 = -mpowerpc64 -mabi=altivec" >> Makefile.config
+    echo "CFLAGS_128 = -mcpu=power9" >> Makefile.config
   fi
 fi
 

--- a/dist/gcc-compatible/configure
+++ b/dist/gcc-compatible/configure
@@ -433,9 +433,7 @@ if detect_powerpc; then
   compile_vec128=true
   if [[ "$enable_power9" == "1" ]]; then
     echo "... enable Power ISA v3.0 instruction set"
-    echo "CFLAGS_128 = -mpowerpc64 -mabi=altivec -mpower9-vector" >> Makefile.config
-  else
-    echo "CFLAGS_128 = -mpowerpc64 -mabi=altivec" >> Makefile.config
+    echo "CFLAGS_128 = -mcpu=power9" >> Makefile.config
   fi
 fi
 


### PR DESCRIPTION
This patch removes -mpowerpc64 -mabi=altivec flags and use -mcpu=power9 instead of -mpower9-vector flag for PowerPC build configuration according to recommendations in this https://github.com/project-everest/hacl-star/pull/455#issuecomment-867948609
Both paths (Default options and Power9 instruction set) has been tested successfully on PPC64LE.