### PR TITLE
CI hint refresh: do not commit if no changes

### DIFF
--- a/.docker/build/build.sh
+++ b/.docker/build/build.sh
@@ -226,7 +226,16 @@ function refresh_hints_dist() {
 
     clean_build_dist || return 1
 
-    git commit --allow-empty -m "[CI] $msg"
+    # If no changes were staged, then exit.
+    # From: https://stackoverflow.com/a/2659808
+    if git diff-index --quiet --cached HEAD -- ; then
+        return 0
+    fi
+
+    # Commit. This will fail if the commit is empty,
+    # but that scenario should be ruled out by the test above
+    git commit -m "[CI] $msg"
+
     # Memorize that commit
     commit=$(git rev-parse HEAD)
     # Drop any other files that were modified as part of the build (e.g.


### PR DESCRIPTION
CI performs nightly hint refresh, and when no changes are necessary, empty commits are still pushed, most recently 371e471, ef89bb8, 49c3dc5. This puts an unnecessary overhead strain on our CI systems, including useless Everest upgrades, which take ~ 2 hours each.

I replicated project-everest/mitls-fstar@310eab0dd50babd4600c508e9cf8103616555793  so that no such empty commits are pushed if no changes are necessary.