### PR TITLE
Allow hacl-star opam package install on FreeBSD

### DIFF
--- a/dist/gcc-compatible/hacl-star-raw.opam
+++ b/dist/gcc-compatible/hacl-star-raw.opam
@@ -26,7 +26,7 @@ x-ci-accept-failures: [
   "oraclelinux-7" # Default C compiler is too old
 ]
 available: [
-  os-family != "bsd"
+  os = "freebsd" | os-family != "bsd"
 ]
 build: [
   ["./configure"]

--- a/dist/hacl-star-raw.opam
+++ b/dist/hacl-star-raw.opam
@@ -26,7 +26,7 @@ x-ci-accept-failures: [
   "oraclelinux-7" # Default C compiler is too old
 ]
 available: [
-  os-family != "bsd"
+  os = "freebsd" | os-family != "bsd"
 ]
 build: [
   ["./configure"]


### PR DESCRIPTION
With the work that @protz did on #463 we now have the ability to install hacl-star on FreeBSD.

@victor-dumitrescu and @protz for review, please.