### PR TITLE
Add AESGCM encrypt/decrypt functions with no dynamic checks

### DIFF
--- a/providers/evercrypt/EverCrypt.AEAD.fsti
+++ b/providers/evercrypt/EverCrypt.AEAD.fsti
@@ -359,15 +359,24 @@ let encrypt_expand_st (does_runtime_check: bool) (a: supported_alg) =
           False)
 
 /// It's a little difficult to deal with AES-GCM cleanly because we're missing a
-/// fallback C implementation. The two functions below cannot appear in the code
-/// of EverCrypt, as they don't perform a runtime check and as such,
-/// unconditionally contain a link-time reference to the X64 AES-GCM code (which
-/// breaks the build on ARM. So, they're marked as inline_for_extraction,
-/// meaning clients can still call them, but then it's their problem to deal
-/// with dangling symbols on non-X64 targets.
-inline_for_extraction noextract
+/// fallback C implementation. The two functions below guard the reference to the
+/// X64 AES-GCM code behind a test of `EverCrypt.TargetConfig.hacl_can_compile_vale`,
+/// which gets extracted to a preprocessor test, so that we can always compile them.
+
+[@@ Comment "WARNING: this function doesn't perform any dynamic
+  hardware check. You MUST make sure your hardware supports the
+  implementation of AESGCM. Besides, this function was not designed
+  for cross-compilation: if you compile it on a system which doesn't
+  support AESGCM, it will compile it to a function which makes the
+  program exit."]
 val encrypt_expand_aes128_gcm_no_check: encrypt_expand_st false AES128_GCM
-inline_for_extraction noextract
+
+[@@ Comment "WARNING: this function doesn't perform any dynamic
+  hardware check. You MUST make sure your hardware supports the
+  implementation of AESGCM. Besides, this function was not designed
+  for cross-compilation: if you compile it on a system which doesn't
+  support AESGCM, it will compile it to a function which makes the
+  program exit."]
 val encrypt_expand_aes256_gcm_no_check: encrypt_expand_st false AES256_GCM
 
 /// Those functions take a key, expand it then perform encryption. They do not

--- a/providers/evercrypt/EverCrypt.AEAD.fsti
+++ b/providers/evercrypt/EverCrypt.AEAD.fsti
@@ -362,12 +362,14 @@ let encrypt_expand_st (does_runtime_check: bool) (a: supported_alg) =
 /// fallback C implementation. The two functions below guard the reference to the
 /// X64 AES-GCM code behind a test of `EverCrypt.TargetConfig.hacl_can_compile_vale`,
 /// which gets extracted to a preprocessor test, so that we can always compile them.
+/// In case the code is compiled on a system which doesn't support Vale, the functions
+/// are compiled in such a way that they make the program exit cleanly.
 
 [@@ Comment "WARNING: this function doesn't perform any dynamic
   hardware check. You MUST make sure your hardware supports the
   implementation of AESGCM. Besides, this function was not designed
   for cross-compilation: if you compile it on a system which doesn't
-  support AESGCM, it will compile it to a function which makes the
+  support Vale, it will compile it to a function which makes the
   program exit."]
 val encrypt_expand_aes128_gcm_no_check: encrypt_expand_st false AES128_GCM
 
@@ -375,7 +377,7 @@ val encrypt_expand_aes128_gcm_no_check: encrypt_expand_st false AES128_GCM
   hardware check. You MUST make sure your hardware supports the
   implementation of AESGCM. Besides, this function was not designed
   for cross-compilation: if you compile it on a system which doesn't
-  support AESGCM, it will compile it to a function which makes the
+  support Vale, it will compile it to a function which makes the
   program exit."]
 val encrypt_expand_aes256_gcm_no_check: encrypt_expand_st false AES256_GCM
 
@@ -504,7 +506,7 @@ let decrypt_expand_st (does_runtime_check: bool) (a: supported_alg) =
   hardware check. You MUST make sure your hardware supports the
   implementation of AESGCM. Besides, this function was not designed
   for cross-compilation: if you compile it on a system which doesn't
-  support AESGCM, it will compile it to a function which makes the
+  support Vale, it will compile it to a function which makes the
   program exit."]
 val decrypt_expand_aes128_gcm_no_check: decrypt_expand_st false AES128_GCM
 
@@ -512,7 +514,7 @@ val decrypt_expand_aes128_gcm_no_check: decrypt_expand_st false AES128_GCM
   hardware check. You MUST make sure your hardware supports the
   implementation of AESGCM. Besides, this function was not designed
   for cross-compilation: if you compile it on a system which doesn't
-  support AESGCM, it will compile it to a function which makes the
+  support Vale, it will compile it to a function which makes the
   program exit."]
 val decrypt_expand_aes256_gcm_no_check: decrypt_expand_st false AES256_GCM
 

--- a/providers/evercrypt/EverCrypt.AEAD.fsti
+++ b/providers/evercrypt/EverCrypt.AEAD.fsti
@@ -498,9 +498,22 @@ let decrypt_expand_st (does_runtime_check: bool) (a: supported_alg) =
       | _ -> False
       end)
 
-inline_for_extraction noextract
+/// See the comments for the encryption functions.
+
+[@@ Comment "WARNING: this function doesn't perform any dynamic
+  hardware check. You MUST make sure your hardware supports the
+  implementation of AESGCM. Besides, this function was not designed
+  for cross-compilation: if you compile it on a system which doesn't
+  support AESGCM, it will compile it to a function which makes the
+  program exit."]
 val decrypt_expand_aes128_gcm_no_check: decrypt_expand_st false AES128_GCM
-inline_for_extraction noextract
+
+[@@ Comment "WARNING: this function doesn't perform any dynamic
+  hardware check. You MUST make sure your hardware supports the
+  implementation of AESGCM. Besides, this function was not designed
+  for cross-compilation: if you compile it on a system which doesn't
+  support AESGCM, it will compile it to a function which makes the
+  program exit."]
 val decrypt_expand_aes256_gcm_no_check: decrypt_expand_st false AES256_GCM
 
 /// This function takes a key, expands it and performs decryption.

--- a/providers/evercrypt/fst/EverCrypt.AEAD.fst
+++ b/providers/evercrypt/fst/EverCrypt.AEAD.fst
@@ -364,25 +364,19 @@ let encrypt_expand_aes_gcm (i: vale_impl): encrypt_expand_st false (alg_of_vale_
   pop_frame ();
   Success
 
-(* Small trick: we write a partial match. Kremlin will extract it to a macro
-   if then else, where the else branch makes the program exit - this is safer
-   then always returning UnsupportedAlgorithm, because the user might not testg
-   the return value (which is always supposed to be Success *)
 let encrypt_expand_aes128_gcm_no_check : encrypt_expand_st false AES128_GCM =
   fun k iv iv_len ad ad_len plain plain_len cipher tag ->
-//  match EverCrypt.TargetConfig.hacl_can_compile_vale with
-//  | true -> encrypt_expand_aes_gcm Vale_AES128 k iv iv_len ad ad_len plain plain_len cipher tag
   if EverCrypt.TargetConfig.hacl_can_compile_vale then
     encrypt_expand_aes_gcm Vale_AES128 k iv iv_len ad ad_len plain plain_len cipher tag
-  else UnsupportedAlgorithm
+  else
+    LowStar.Failure.failwith "EverCrypt was compiled on a system which doesn't support Vale"
 
 let encrypt_expand_aes256_gcm_no_check : encrypt_expand_st false AES256_GCM =
   fun k iv iv_len ad ad_len plain plain_len cipher tag ->
-//  match EverCrypt.TargetConfig.hacl_can_compile_vale with
-//  | true -> encrypt_expand_aes_gcm Vale_AES256 k iv iv_len ad ad_len plain plain_len cipher tag
   if EverCrypt.TargetConfig.hacl_can_compile_vale then
     encrypt_expand_aes_gcm Vale_AES256 k iv iv_len ad ad_len plain plain_len cipher tag
-  else UnsupportedAlgorithm
+  else
+    LowStar.Failure.failwith "EverCrypt was compiled on a system which doesn't support Vale"
 
 let encrypt_expand_aes128_gcm : encrypt_expand_st true AES128_GCM =
   fun k iv iv_len ad ad_len plain plain_len cipher tag  ->
@@ -627,20 +621,18 @@ let decrypt_expand_aes_gcm (i: vale_impl): decrypt_expand_st false (alg_of_vale_
   r
 
 let decrypt_expand_aes128_gcm_no_check : decrypt_expand_st false AES128_GCM =
-  // TODO: make the implementation always fail in the else branch
   fun k iv iv_len ad ad_len cipher cipher_len tag dst ->
   if EverCrypt.TargetConfig.hacl_can_compile_vale then
     decrypt_expand_aes_gcm Vale_AES128 k iv iv_len ad ad_len cipher cipher_len tag dst
   else
-    UnsupportedAlgorithm
+    LowStar.Failure.failwith "EverCrypt was compiled on a system which doesn't support Vale"
 
 let decrypt_expand_aes256_gcm_no_check : decrypt_expand_st false AES256_GCM =
-  // TODO: make the implementation always fail in the else branch
   fun k iv iv_len ad ad_len cipher cipher_len tag dst ->
   if EverCrypt.TargetConfig.hacl_can_compile_vale then
     decrypt_expand_aes_gcm Vale_AES256 k iv iv_len ad ad_len cipher cipher_len tag dst
   else
-    UnsupportedAlgorithm
+    LowStar.Failure.failwith "EverCrypt was compiled on a system which doesn't support Vale"
 
 let decrypt_expand_aes128_gcm : decrypt_expand_st true AES128_GCM =
   fun k iv iv_len ad ad_len cipher cipher_len tag dst ->

--- a/providers/evercrypt/fst/EverCrypt.AEAD.fst
+++ b/providers/evercrypt/fst/EverCrypt.AEAD.fst
@@ -364,11 +364,19 @@ let encrypt_expand_aes_gcm (i: vale_impl): encrypt_expand_st false (alg_of_vale_
   pop_frame ();
   Success
 
+(* Small trick: we write a partial match. Kremlin will extract it to a macro
+   if then else, where the else branch makes the program exit - this is safer
+   then always returning UnsupportedAlgorithm, because the user might not testg
+   the return value (which is always supposed to be Success *)
 let encrypt_expand_aes128_gcm_no_check : encrypt_expand_st false AES128_GCM =
-  encrypt_expand_aes_gcm Vale_AES128
+  fun k iv iv_len ad ad_len plain plain_len cipher tag ->
+  match EverCrypt.TargetConfig.hacl_can_compile_vale with
+  | true -> encrypt_expand_aes_gcm Vale_AES128 k iv iv_len ad ad_len plain plain_len cipher tag
 
 let encrypt_expand_aes256_gcm_no_check : encrypt_expand_st false AES256_GCM =
-  encrypt_expand_aes_gcm Vale_AES256
+  fun k iv iv_len ad ad_len plain plain_len cipher tag ->
+  match EverCrypt.TargetConfig.hacl_can_compile_vale with
+  | true -> encrypt_expand_aes_gcm Vale_AES256 k iv iv_len ad ad_len plain plain_len cipher tag
 
 let encrypt_expand_aes128_gcm : encrypt_expand_st true AES128_GCM =
   fun k iv iv_len ad ad_len plain plain_len cipher tag  ->

--- a/providers/evercrypt/fst/EverCrypt.AEAD.fst
+++ b/providers/evercrypt/fst/EverCrypt.AEAD.fst
@@ -370,13 +370,19 @@ let encrypt_expand_aes_gcm (i: vale_impl): encrypt_expand_st false (alg_of_vale_
    the return value (which is always supposed to be Success *)
 let encrypt_expand_aes128_gcm_no_check : encrypt_expand_st false AES128_GCM =
   fun k iv iv_len ad ad_len plain plain_len cipher tag ->
-  match EverCrypt.TargetConfig.hacl_can_compile_vale with
-  | true -> encrypt_expand_aes_gcm Vale_AES128 k iv iv_len ad ad_len plain plain_len cipher tag
+//  match EverCrypt.TargetConfig.hacl_can_compile_vale with
+//  | true -> encrypt_expand_aes_gcm Vale_AES128 k iv iv_len ad ad_len plain plain_len cipher tag
+  if EverCrypt.TargetConfig.hacl_can_compile_vale then
+    encrypt_expand_aes_gcm Vale_AES128 k iv iv_len ad ad_len plain plain_len cipher tag
+  else UnsupportedAlgorithm
 
 let encrypt_expand_aes256_gcm_no_check : encrypt_expand_st false AES256_GCM =
   fun k iv iv_len ad ad_len plain plain_len cipher tag ->
-  match EverCrypt.TargetConfig.hacl_can_compile_vale with
-  | true -> encrypt_expand_aes_gcm Vale_AES256 k iv iv_len ad ad_len plain plain_len cipher tag
+//  match EverCrypt.TargetConfig.hacl_can_compile_vale with
+//  | true -> encrypt_expand_aes_gcm Vale_AES256 k iv iv_len ad ad_len plain plain_len cipher tag
+  if EverCrypt.TargetConfig.hacl_can_compile_vale then
+    encrypt_expand_aes_gcm Vale_AES256 k iv iv_len ad ad_len plain plain_len cipher tag
+  else UnsupportedAlgorithm
 
 let encrypt_expand_aes128_gcm : encrypt_expand_st true AES128_GCM =
   fun k iv iv_len ad ad_len plain plain_len cipher tag  ->
@@ -621,10 +627,20 @@ let decrypt_expand_aes_gcm (i: vale_impl): decrypt_expand_st false (alg_of_vale_
   r
 
 let decrypt_expand_aes128_gcm_no_check : decrypt_expand_st false AES128_GCM =
-  decrypt_expand_aes_gcm Vale_AES128
+  // TODO: make the implementation always fail in the else branch
+  fun k iv iv_len ad ad_len cipher cipher_len tag dst ->
+  if EverCrypt.TargetConfig.hacl_can_compile_vale then
+    decrypt_expand_aes_gcm Vale_AES128 k iv iv_len ad ad_len cipher cipher_len tag dst
+  else
+    UnsupportedAlgorithm
 
 let decrypt_expand_aes256_gcm_no_check : decrypt_expand_st false AES256_GCM =
-  decrypt_expand_aes_gcm Vale_AES256
+  // TODO: make the implementation always fail in the else branch
+  fun k iv iv_len ad ad_len cipher cipher_len tag dst ->
+  if EverCrypt.TargetConfig.hacl_can_compile_vale then
+    decrypt_expand_aes_gcm Vale_AES256 k iv iv_len ad ad_len cipher cipher_len tag dst
+  else
+    UnsupportedAlgorithm
 
 let decrypt_expand_aes128_gcm : decrypt_expand_st true AES128_GCM =
   fun k iv iv_len ad ad_len cipher cipher_len tag dst ->


### PR DESCRIPTION
There was previously no easy way of accessing the AESGCM functions outside the agile EverCrypt versions. Due to modularity issues, using those functions also forced people to work in the ST effect, and not the Stack effect. This PR fixes that.