### PR TITLE
Further fix for configure script

### DIFF
--- a/dist/configure
+++ b/dist/configure
@@ -12,19 +12,24 @@ if [[ $CC == "" ]]; then
   CC=cc
 fi
 
-my_mktemp () {
+my_mktemp_dir () {
   local name=$1
-  local ext=$2
-  # Note: --suffix is not POSIX, doesn't work on OSX
-  local f=$(mktemp /tmp/$name.XXXXXXX)
-  if [[ $f == "" ]]; then
-    local f=$(mktemp -p . $name.XXXXXXX)
+  # Note: --suffix is not POSIX, doesn't work on OSX.
+  # Also on OSX, the XXXXXXX pattern cannot be followed by anything else.
+  local dir=$(mktemp -d /tmp/$name-XXXXXXX)
+  if [[ $dir == "" ]]; then
+    # Note: -p doesn't work on OSX, all tests will fail in case there is no
+    # permission to write to /tmp
+    local dir=$(mktemp -d -p . $name-XXXXXXX)
   fi
-  echo $f.ext
+  echo $dir
 }
 
 my_mktemp_c () {
-  my_mktemp $1 .c
+  local name=$1
+  local dir=$(my_mktemp_dir $name)
+  local file=$dir/$name.c
+  echo $file
 }
 
 # Helpers to help do feature or bug detection
@@ -68,8 +73,9 @@ check_no_bug81300 () {
   # but mozilla. If lib_intrinsics.h is not present, assume there is no bug and
   # return success.
   if [ -f lib_intrinsics.h ]; then
-  local out=$(my_mktemp testbug81300)
-  local file=$out.c
+  local dir=$(my_mktemp_dir testbug81300)
+  local file=$dir/testbug81300.c
+  local out=$dir/testbug81300.out
   cat > $file <<EOF
 #include <inttypes.h>
 #include <stdio.h>

--- a/dist/gcc-compatible/configure
+++ b/dist/gcc-compatible/configure
@@ -12,19 +12,24 @@ if [[ $CC == "" ]]; then
   CC=cc
 fi
 
-my_mktemp () {
+my_mktemp_dir () {
   local name=$1
-  local ext=$2
-  # Note: --suffix is not POSIX, doesn't work on OSX
-  local f=$(mktemp /tmp/$name.XXXXXXX)
-  if [[ $f == "" ]]; then
-    local f=$(mktemp -p . $name.XXXXXXX)
+  # Note: --suffix is not POSIX, doesn't work on OSX.
+  # Also on OSX, the XXXXXXX pattern cannot be followed by anything else.
+  local dir=$(mktemp -d /tmp/$name-XXXXXXX)
+  if [[ $dir == "" ]]; then
+    # Note: -p doesn't work on OSX, all tests will fail in case there is no
+    # permission to write to /tmp
+    local dir=$(mktemp -d -p . $name-XXXXXXX)
   fi
-  echo $f.ext
+  echo $dir
 }
 
 my_mktemp_c () {
-  my_mktemp $1 .c
+  local name=$1
+  local dir=$(my_mktemp_dir $name)
+  local file=$dir/$name.c
+  echo $file
 }
 
 # Helpers to help do feature or bug detection
@@ -68,8 +73,9 @@ check_no_bug81300 () {
   # but mozilla. If lib_intrinsics.h is not present, assume there is no bug and
   # return success.
   if [ -f lib_intrinsics.h ]; then
-  local out=$(my_mktemp testbug81300)
-  local file=$out.c
+  local dir=$(my_mktemp_dir testbug81300)
+  local file=$dir/testbug81300.c
+  local out=$dir/testbug81300.out
   cat > $file <<EOF
 #include <inttypes.h>
 #include <stdio.h>


### PR DESCRIPTION
This MR contains another fix for the configure script, which makes `my_mktemp_c` fully work cross-platform.

There is one small remaining compilation issue, to do with older `gcc` versions that don't support `__has_include`, which is currently present here:

```
gcc-compatible/Lib_Memzero0.c:#if __has_include("config.h")
gcc-compatible/evercrypt_targetconfig.h:#if __has_include("config.h")
gcc-compatible/libintvector.h:#if __has_include("config.h")
gcc-compatible/libintvector.h:#if __has_include("libintvector_debug.h")
gcc-compatible/lib_intrinsics.h:#if __has_include("config.h")
```

See an example of how this errors out [here](https://opam.ci.ocaml.org/github/ocaml/opam-repository/commit/089888a9d60c4e7b280102ed927421d22b6ab2b1/variant/opam-2.0,distributions,centos-7,hacl-star-raw.0.4.2).

In the opam snapshot, we can always assume that `config.h` is present and that `libintvector_debug.h` is not, so if we want to support these older `gcc` versions we could modify these files accordingly as part of the release preparation steps in `tools/Makefile.opam`. Thoughts?