### PR TITLE
Fix fragile proof in Hacl.Streaming.Functor

### DIFF
--- a/hints/Hacl.Streaming.Functor.fst.hints
+++ b/hints/Hacl.Streaming.Functor.fst.hints
@@ -1,5 +1,5 @@
 [
-  "9@›©rfèn{áaÓ\r§¨®",
+  "©ñ\u0010ö´F­È!Ï9J-ð$¼",
   [
     [
       "Hacl.Streaming.Functor.optional_freeable",
@@ -25,7 +25,7 @@
         "typing_FStar.Monotonic.HyperStack.get_tip"
       ],
       0,
-      "bf33c2f9c8f6ef1eefe6daae5bf47c01"
+      "8a1c2f1a3398258dc87bb447014b5122"
     ],
     [
       "Hacl.Streaming.Functor.optional_invariant",
@@ -51,7 +51,7 @@
         "typing_FStar.Monotonic.HyperStack.get_tip"
       ],
       0,
-      "fb36a1cba1c74f67893c0f473c9f90e9"
+      "f361be12cd5c2a23043b6811bb71d4b6"
     ],
     [
       "Hacl.Streaming.Functor.optional_footprint",
@@ -77,7 +77,7 @@
         "typing_FStar.Monotonic.HyperStack.get_tip"
       ],
       0,
-      "b980b5ee785fe4f099086afb34763717"
+      "7ce02b153dd4182c359a73bab1a4753e"
     ],
     [
       "Hacl.Streaming.Functor.optional_reveal",
@@ -97,7 +97,7 @@
         "inversion-interp"
       ],
       0,
-      "1939ae925a41bfc9003e95748c86d1a9"
+      "dbfbf3a2be31c8741dc23e46a1589cdb"
     ],
     [
       "Hacl.Streaming.Functor.optional_hide",
@@ -127,7 +127,7 @@
         "typing_FStar.Ghost.hide"
       ],
       0,
-      "5893d44d63710aabe1976aa00a95ed7a"
+      "e9b63dc291d24cc203e97b8f791ce5b9"
     ],
     [
       "Hacl.Streaming.Functor.stateful_frame_preserves_freeable",
@@ -136,7 +136,7 @@
       0,
       [ "@query" ],
       0,
-      "02fd095bb6a405c131d8fe52ab1cd801"
+      "92aae9fa207c3bb6406f97af98b84b3e"
     ],
     [
       "Hacl.Streaming.Functor.optional_frame",
@@ -161,7 +161,7 @@
         "inversion-interp", "true_interp"
       ],
       0,
-      "78f40ba9daa7abbc2c43eb723137f885"
+      "fd55d5b4c8510615e450b55a0975401e"
     ],
     [
       "Hacl.Streaming.Functor.loc_includes_union_l_footprint_s",
@@ -170,7 +170,7 @@
       0,
       [ "@query" ],
       0,
-      "8d1e70bd94d5fd39f1743c37d5396450"
+      "fbd59d3b63e98f219a4f66438b8244f5"
     ],
     [
       "Hacl.Streaming.Functor.invariant_s",
@@ -225,7 +225,7 @@
         "typing_LowStar.Monotonic.Buffer.len"
       ],
       0,
-      "f88bff24ebff095354fd750845d0c190"
+      "9d2758b988ec4bf0a0794f121201e98c"
     ],
     [
       "Hacl.Streaming.Functor.freeable",
@@ -241,7 +241,7 @@
         "refinement_interpretation_Tm_refine_573cfed777dae20cc82e8fef9622857e"
       ],
       0,
-      "9dcb482188cb1a75b78e9c99a475d6b5"
+      "b2772ed529fa985863775e0641403332"
     ],
     [
       "Hacl.Streaming.Functor.invariant",
@@ -257,7 +257,7 @@
         "refinement_interpretation_Tm_refine_573cfed777dae20cc82e8fef9622857e"
       ],
       0,
-      "2165ff9901e43e47157df72d32b745a5"
+      "6c56411ea02000aff923d8c54b292b67"
     ],
     [
       "Hacl.Streaming.Functor.invariant_loc_in_footprint",
@@ -329,7 +329,7 @@
         "typing_LowStar.Monotonic.Buffer.loc_union"
       ],
       0,
-      "866d0cb83e4f9e9ce7a42b6ed00d3374"
+      "e463a9f631b1545234e1bab6e4eb53fa"
     ],
     [
       "Hacl.Streaming.Functor.seen_bounded",
@@ -350,7 +350,7 @@
         "projection_inverse_BoxBool_proj_0"
       ],
       0,
-      "139d7e64ccf952966759c426494e66f5"
+      "75dfe3390a1008d7b17e85eb7611ac42"
     ],
     [
       "Hacl.Streaming.Functor.frame_invariant",
@@ -428,7 +428,7 @@
         "typing_tok_Hacl.Streaming.Interface.Erased@tok"
       ],
       0,
-      "b72bc191a4f259c0d66f8a1fb073ffb0"
+      "a0331599f30b7fe00ff8415f1ca26589"
     ],
     [
       "Hacl.Streaming.Functor.frame_seen",
@@ -477,7 +477,7 @@
         "typing_LowStar.Monotonic.Buffer.loc_buffer"
       ],
       0,
-      "66fa633404358e630197b72e98c92bef"
+      "854e35b7ce5a312cdb77a3f7bcecbcee"
     ],
     [
       "Hacl.Streaming.Functor.index_of_state",
@@ -490,7 +490,7 @@
         "refinement_interpretation_Tm_refine_eed61e872c76c9d08d9c5e037b1dc22d"
       ],
       0,
-      "74a9fde73c97117ea7902bd87fecc2b9"
+      "26a4644e2dd5ed805d2d63661a1fbf4f"
     ],
     [
       "Hacl.Streaming.Functor.index_of_state",
@@ -511,7 +511,7 @@
         "typing_FStar.Ghost.reveal"
       ],
       0,
-      "51828dc2c3b0fc8717cb6568d2521728"
+      "0e514c7e9681efd9ff596b1924e07fba"
     ],
     [
       "Hacl.Streaming.Functor.create_in_st",
@@ -524,7 +524,7 @@
         "refinement_interpretation_Tm_refine_a997f7fc0ee9057c4f6335ecd3b55d00"
       ],
       0,
-      "8c2ac9b6e5f2e8e493cdcda86093a0bb"
+      "29ef73647ce700678ad0b2c6c6a15b8a"
     ],
     [
       "Hacl.Streaming.Functor.create_in",
@@ -723,7 +723,7 @@
         "typing_tok_Lib.IntTypes.U8@tok"
       ],
       0,
-      "6dd7cb726c707fc5b01a1b66eaeeba62"
+      "7dad464cbf367a5b0614367831e7f126"
     ],
     [
       "Hacl.Streaming.Functor.alloca_st",
@@ -736,7 +736,7 @@
         "refinement_interpretation_Tm_refine_a997f7fc0ee9057c4f6335ecd3b55d00"
       ],
       0,
-      "07aeefbc101d7994fae1507a0dd292ed"
+      "78a67d78311b32ba24391e1dabe88113"
     ],
     [
       "Hacl.Streaming.Functor.alloca",
@@ -935,7 +935,7 @@
         "typing_tok_Lib.IntTypes.U8@tok"
       ],
       0,
-      "2a971fdf96ffe2555598b310a409cdbd"
+      "214c75633dd290933e0bdb7e092e8e92"
     ],
     [
       "Hacl.Streaming.Functor.init_st",
@@ -948,7 +948,7 @@
         "refinement_interpretation_Tm_refine_a997f7fc0ee9057c4f6335ecd3b55d00"
       ],
       0,
-      "14e16cd3aceb19afcd4b91fc440d6aeb"
+      "1beface6ece9626b56029349a60911c3"
     ],
     [
       "Hacl.Streaming.Functor.init",
@@ -1112,7 +1112,7 @@
         "typing_LowStar.Monotonic.Buffer.loc_union"
       ],
       0,
-      "261bb13e39ad536c41e7c0297b8bb982"
+      "e66352e1a09df9c380a691996a05b652"
     ],
     [
       "Hacl.Streaming.Functor.update_pre",
@@ -1121,7 +1121,7 @@
       0,
       [ "@query" ],
       0,
-      "4c0a097f0fccaf7604b560cce5224566"
+      "e774937efa8dc82b89d8b309df18b2be"
     ],
     [
       "Hacl.Streaming.Functor.update_st",
@@ -1134,7 +1134,7 @@
         "refinement_interpretation_Tm_refine_a997f7fc0ee9057c4f6335ecd3b55d00"
       ],
       0,
-      "0e54df52b131db976c65f5d91b2d9fe5"
+      "7e343949ff994e790532275cf3177365"
     ],
     [
       "Hacl.Streaming.Functor.rest",
@@ -1177,7 +1177,7 @@
         "typing_Hacl.Streaming.Spec.split_at_last_num_blocks"
       ],
       0,
-      "244204b66ae91c1a5d130765541cc760"
+      "fd7c038a3639a0f0054e463a1272fe99"
     ],
     [
       "Hacl.Streaming.Functor.nblocks",
@@ -1221,7 +1221,7 @@
         "typing_Lib.UpdateMulti.split_at_last_nb_rem"
       ],
       0,
-      "886868edd547cd23b38b3cb62a7f4010"
+      "807950b58701349c9f8898720506d6cc"
     ],
     [
       "Hacl.Streaming.Functor.rest_finish",
@@ -1269,7 +1269,7 @@
         "typing_Lib.UpdateMulti.split_at_last_nb_rem"
       ],
       0,
-      "57c7980703565bd9042d6089a50051e1"
+      "7f4f0a9311ef75db7a432de0f2780f95"
     ],
     [
       "Hacl.Streaming.Functor.add_len",
@@ -1298,7 +1298,7 @@
         "typing_Hacl.Streaming.Interface.__proj__Block__item__max_input_length"
       ],
       0,
-      "a208aec8d95a4f1d8dd4e4836174083d"
+      "11b32a5b9f6e035156c8f65aecaa01d9"
     ],
     [
       "Hacl.Streaming.Functor.add_len_small",
@@ -1374,7 +1374,7 @@
         "typing_Lib.UpdateMulti.split_at_last_nb_rem"
       ],
       0,
-      "f54a9db312ee47c14ae6403154fb33f2"
+      "e05cb7f3742dbe875503967df1011fbc"
     ],
     [
       "Hacl.Streaming.Functor.update_small",
@@ -1387,7 +1387,7 @@
         "refinement_interpretation_Tm_refine_eed61e872c76c9d08d9c5e037b1dc22d"
       ],
       0,
-      "7089667b1edc8aab3d25078ab0af0037"
+      "60a78a29d2b7bf9451498e477f9d28f3"
     ],
     [
       "Hacl.Streaming.Functor.split_at_last_rest_eq",
@@ -1426,7 +1426,7 @@
         "typing_Hacl.Streaming.Spec.split_at_last_num_blocks"
       ],
       0,
-      "b8fe23c5fdbedfe948fb072d45621281"
+      "6a56a05c825d5368a1b06adad9ba9f23"
     ],
     [
       "Hacl.Streaming.Functor.update_small",
@@ -1442,15 +1442,18 @@
         "LowStar.Buffer_interpretation_Tm_arrow_9b1c273e798ef422e9aacaac3436c4f3",
         "Prims_pretyping_ae567c2fb75be05905677af440075565", "b2t_def",
         "bool_inversion", "bool_typing",
+        "equation_FStar.HyperStack.ST.modifies_none",
         "equation_FStar.Int.Cast.uint32_to_uint64",
+        "equation_FStar.Monotonic.HyperHeap.hmap",
+        "equation_FStar.Monotonic.HyperHeap.modifies_just",
         "equation_FStar.Monotonic.HyperStack.live_region",
+        "equation_FStar.Monotonic.HyperStack.mem",
+        "equation_FStar.Monotonic.HyperStack.modifies",
         "equation_FStar.Pervasives.Native.fst",
-        "equation_FStar.Seq.Properties.split", "equation_FStar.UInt.eq",
-        "equation_FStar.UInt.fits", "equation_FStar.UInt.gt",
+        "equation_FStar.Seq.Properties.split", "equation_FStar.UInt.fits",
         "equation_FStar.UInt.max_int", "equation_FStar.UInt.min_int",
         "equation_FStar.UInt.mod", "equation_FStar.UInt.size",
-        "equation_FStar.UInt.uint_t", "equation_FStar.UInt64.eq",
-        "equation_FStar.UInt64.gt",
+        "equation_FStar.UInt.uint_t",
         "equation_Hacl.Streaming.Functor.add_len",
         "equation_Hacl.Streaming.Functor.bytes",
         "equation_Hacl.Streaming.Functor.footprint",
@@ -1484,6 +1487,7 @@
         "equation_LowStar.Monotonic.Buffer.length", "equation_Prims.eq2",
         "equation_Prims.eqtype", "equation_Prims.nat", "equation_Prims.pos",
         "fuel_guarded_inversion_Hacl.Streaming.Interface.block",
+        "function_token_typing_FStar.Monotonic.Heap.heap",
         "function_token_typing_Hacl.Streaming.Spec.bytes",
         "function_token_typing_Lib.IntTypes.uint8",
         "function_token_typing_LowStar.Buffer.trivial_preorder",
@@ -1495,6 +1499,13 @@
         "kinding_Hacl.Streaming.Functor.state_s@tok", "l_and-interp",
         "lemma_FStar.Ghost.hide_reveal", "lemma_FStar.Ghost.reveal_hide",
         "lemma_FStar.HyperStack.ST.lemma_equal_domains_trans",
+        "lemma_FStar.Map.lemma_ContainsDom",
+        "lemma_FStar.Map.lemma_InDomConcat",
+        "lemma_FStar.Map.lemma_InDomRestrict",
+        "lemma_FStar.Map.lemma_SelConcat1",
+        "lemma_FStar.Map.lemma_SelConcat2",
+        "lemma_FStar.Map.lemma_SelRestrict",
+        "lemma_FStar.Map.lemma_equal_intro",
         "lemma_FStar.Seq.Base.lemma_eq_elim",
         "lemma_FStar.Seq.Base.lemma_eq_intro",
         "lemma_FStar.Seq.Base.lemma_eq_refl",
@@ -1507,13 +1518,13 @@
         "lemma_FStar.Seq.Properties.slice_is_empty",
         "lemma_FStar.Seq.Properties.slice_length",
         "lemma_FStar.Seq.Properties.slice_slice",
-        "lemma_FStar.UInt32.vu_inv", "lemma_FStar.UInt64.uv_inv",
-        "lemma_FStar.UInt64.vu_inv",
+        "lemma_FStar.Set.mem_complement", "lemma_FStar.Set.mem_empty",
+        "lemma_FStar.Set.mem_subset", "lemma_FStar.UInt32.vu_inv",
+        "lemma_FStar.UInt64.uv_inv", "lemma_FStar.UInt64.vu_inv",
         "lemma_LowStar.Monotonic.Buffer.address_liveness_insensitive_buffer",
         "lemma_LowStar.Monotonic.Buffer.as_addr_gsub",
         "lemma_LowStar.Monotonic.Buffer.as_seq_gsub",
         "lemma_LowStar.Monotonic.Buffer.frameOf_gsub",
-        "lemma_LowStar.Monotonic.Buffer.lemma_live_equal_mem_domains",
         "lemma_LowStar.Monotonic.Buffer.len_gsub",
         "lemma_LowStar.Monotonic.Buffer.length_as_seq",
         "lemma_LowStar.Monotonic.Buffer.length_null_1",
@@ -1530,14 +1541,17 @@
         "lemma_LowStar.Monotonic.Buffer.loc_includes_trans_backwards",
         "lemma_LowStar.Monotonic.Buffer.loc_includes_union_l_",
         "lemma_LowStar.Monotonic.Buffer.loc_union_comm",
+        "lemma_LowStar.Monotonic.Buffer.loc_union_idem",
         "lemma_LowStar.Monotonic.Buffer.modifies_buffer_elim",
         "lemma_LowStar.Monotonic.Buffer.modifies_liveness_insensitive_buffer_weak",
         "lemma_LowStar.Monotonic.Buffer.modifies_loc_includes",
+        "lemma_LowStar.Monotonic.Buffer.modifies_refl",
         "lemma_LowStar.Monotonic.Buffer.modifies_trans_linear",
         "primitive_Prims.op_Addition", "primitive_Prims.op_AmpAmp",
-        "primitive_Prims.op_Equality", "primitive_Prims.op_GreaterThan",
+        "primitive_Prims.op_BarBar", "primitive_Prims.op_Equality",
         "primitive_Prims.op_LessThanOrEqual", "primitive_Prims.op_Modulus",
-        "primitive_Prims.op_Multiply", "primitive_Prims.op_Subtraction",
+        "primitive_Prims.op_Multiply", "primitive_Prims.op_Negation",
+        "primitive_Prims.op_Subtraction",
         "proj_equation_FStar.Pervasives.Native.Mktuple2__1",
         "proj_equation_Hacl.Streaming.Functor.State_block_state",
         "proj_equation_Hacl.Streaming.Functor.State_p_key",
@@ -1556,6 +1570,7 @@
         "projection_inverse_Hacl.Streaming.Functor.State_seen",
         "projection_inverse_Hacl.Streaming.Functor.State_total_len",
         "refinement_interpretation_Tm_refine_02951fd03552320d928a2182ed63fa53",
+        "refinement_interpretation_Tm_refine_05e15190c946858f68c69156f585f95a",
         "refinement_interpretation_Tm_refine_06f2bf4950bb76094f7b7f43daea2409",
         "refinement_interpretation_Tm_refine_0ea1fba779ad5718e28476faeef94d56",
         "refinement_interpretation_Tm_refine_18d7c8750c82f0db97a6c5369714adc4",
@@ -1586,6 +1601,7 @@
         "refinement_interpretation_Tm_refine_d3d07693cd71377864ef84dc97d10ec1",
         "refinement_interpretation_Tm_refine_d83f8da8ef6c1cb9f71d1465c1bb1c55",
         "refinement_interpretation_Tm_refine_eb435d983f25b2ac1b6f98caeb4b3f9b",
+        "refinement_interpretation_Tm_refine_ee39f9357cbd63bb5cf348fb8515eff7",
         "refinement_interpretation_Tm_refine_eed61e872c76c9d08d9c5e037b1dc22d",
         "refinement_interpretation_Tm_refine_f13070840248fced9d9d60d77bdae3ec",
         "refinement_kinding_Tm_refine_542f9d4f129664613f2483a6c88bc7c2",
@@ -1593,14 +1609,18 @@
         "token_correspondence_Hacl.Streaming.Interface.__proj__Block__item__max_input_length",
         "token_correspondence_Hacl.Streaming.Interface.__proj__Stateful__item__footprint",
         "true_interp", "typing_FStar.Ghost.reveal",
-        "typing_FStar.Int.Cast.uint32_to_uint64",
+        "typing_FStar.Int.Cast.uint32_to_uint64", "typing_FStar.Map.concat",
+        "typing_FStar.Map.contains", "typing_FStar.Map.domain",
+        "typing_FStar.Map.restrict", "typing_FStar.Monotonic.HyperHeap.rid",
+        "typing_FStar.Monotonic.HyperStack.get_hmap",
         "typing_FStar.Monotonic.HyperStack.live_region",
         "typing_FStar.Seq.Base.append", "typing_FStar.Seq.Base.create",
         "typing_FStar.Seq.Base.empty", "typing_FStar.Seq.Base.length",
-        "typing_FStar.Seq.Base.slice", "typing_FStar.Set.singleton",
+        "typing_FStar.Seq.Base.slice", "typing_FStar.Set.complement",
+        "typing_FStar.Set.empty", "typing_FStar.Set.singleton",
         "typing_FStar.UInt32.add", "typing_FStar.UInt32.uint_to_t",
         "typing_FStar.UInt32.v", "typing_FStar.UInt64.rem",
-        "typing_Hacl.Streaming.Functor.add_len",
+        "typing_FStar.UInt64.v", "typing_Hacl.Streaming.Functor.add_len",
         "typing_Hacl.Streaming.Functor.footprint",
         "typing_Hacl.Streaming.Functor.optional_footprint",
         "typing_Hacl.Streaming.Functor.rest",
@@ -1614,6 +1634,7 @@
         "typing_Hacl.Streaming.Spec.split_at_last",
         "typing_Hacl.Streaming.Spec.split_at_last_num_blocks",
         "typing_Lib.UpdateMulti.split_at_last_lazy",
+        "typing_Lib.UpdateMulti.split_at_last_lazy_nb_rem",
         "typing_Lib.UpdateMulti.split_at_last_nb_rem",
         "typing_LowStar.Buffer.trivial_preorder",
         "typing_LowStar.Monotonic.Buffer.as_addr",
@@ -1626,7 +1647,7 @@
         "typing_LowStar.Monotonic.Buffer.loc_union"
       ],
       0,
-      "7a2df71a08b30711edbb583388db89db"
+      "b4c07ccc849e2d98e81a55684dd5e1ca"
     ],
     [
       "Hacl.Streaming.Functor.update_empty_or_full_buf",
@@ -1664,7 +1685,7 @@
         "typing_FStar.UInt32.t"
       ],
       0,
-      "beb4abda0c5c6006b35b926ccf1b6cf0"
+      "722fea4800ece7a17ebd053415da5211"
     ],
     [
       "Hacl.Streaming.Functor.update_empty_or_full_buf",
@@ -1880,7 +1901,7 @@
         "typing_LowStar.Monotonic.Buffer.loc_union"
       ],
       0,
-      "5f942ffcf1cefe0ce8151c6dff8632d1"
+      "8888edff387aac3a52eac9f986ca3ae3"
     ],
     [
       "Hacl.Streaming.Functor.update_round",
@@ -1897,7 +1918,7 @@
         "refinement_interpretation_Tm_refine_eed61e872c76c9d08d9c5e037b1dc22d"
       ],
       0,
-      "3af445d26748b33dca8025c703780b2e"
+      "8568bc26b8bd406dbc595d201d7c36e1"
     ],
     [
       "Hacl.Streaming.Functor.update_round",
@@ -2012,7 +2033,7 @@
         "typing_LowStar.Monotonic.Buffer.length"
       ],
       0,
-      "93bbf00482edbfb0f1fd8025371146d1"
+      "db93809000369a9dd1df0a248f5fa05e"
     ],
     [
       "Hacl.Streaming.Functor.update",
@@ -2141,7 +2162,7 @@
         "unit_typing"
       ],
       0,
-      "709a9f72204758c1ba29cac09ce0ba81"
+      "e148beb9bf40bb52f49dc31178fb5381"
     ],
     [
       "Hacl.Streaming.Functor.finish_st",
@@ -2158,7 +2179,7 @@
         "refinement_interpretation_Tm_refine_a997f7fc0ee9057c4f6335ecd3b55d00"
       ],
       0,
-      "2d3188d76c2e00d66d543347988c9abc"
+      "a1c1c14a4277b73feea831285be3741b"
     ],
     [
       "Hacl.Streaming.Functor.mk_finish",
@@ -2438,7 +2459,7 @@
         "typing_tok_Hacl.Streaming.Interface.Erased@tok"
       ],
       0,
-      "4e59bd9fac95d0f651d8066ed5e926a1"
+      "7de91ac0fe4b7cff6c166331e53fce29"
     ],
     [
       "Hacl.Streaming.Functor.free_st",
@@ -2451,7 +2472,7 @@
         "refinement_interpretation_Tm_refine_a997f7fc0ee9057c4f6335ecd3b55d00"
       ],
       0,
-      "eb62f62b84d436d6519b633339803aed"
+      "bc285358a7315e3f4760c6f8898618b1"
     ],
     [
       "Hacl.Streaming.Functor.free",
@@ -2552,7 +2573,7 @@
         "typing_LowStar.Monotonic.Buffer.loc_union"
       ],
       0,
-      "e7036bfd08309002927c3f27d6535f70"
+      "bf2ecb5cc0c7fa99b55f2fab516ebd3b"
     ]
   ]
 ]


### PR DESCRIPTION
- Switch assertions over sequence equality (bad, unreliable, never works)
  to explicit calls to `Seq.lemma_eq_intro` (good, works better,
  somewhat more reliable).
- A couple manual calls to `B.modifies_trans` to guide the reasoning and
  rule out excessive modifies-clause reasoning.