### PR TITLE
Disable known offender

### DIFF
--- a/code/streaming/Hacl.Streaming.Functor.fst
+++ b/code/streaming/Hacl.Streaming.Functor.fst
@@ -712,7 +712,7 @@ let split_at_last_rest_eq (#index : Type0) (c: block index)
 // goes through fast, but a high rlimit is a security against regression failures.
 #restart-solver
 #push-options "--z3rlimit 300 --z3cliopt smt.arith.nl=false \
-  --using_facts_from '*,-LowStar.Monotonic.Buffer.unused_in_not_unused_in_disjoint_2'"
+  --using_facts_from '*,-LowStar.Monotonic.Buffer.unused_in_not_unused_in_disjoint_2,-FStar.Seq.Properties.slice_slice'"
 let update_small #index c i t t' p data len =
   [@inline_let] let _ = c.state.invariant_loc_in_footprint #i in
   [@inline_let] let _ = c.key.invariant_loc_in_footprint #i in

--- a/code/streaming/Hacl.Streaming.Functor.fst
+++ b/code/streaming/Hacl.Streaming.Functor.fst
@@ -711,7 +711,8 @@ let split_at_last_rest_eq (#index : Type0) (c: block index)
 // This rlimit is a bit crazy, but this proof is not stable. It usually
 // goes through fast, but a high rlimit is a security against regression failures.
 #restart-solver
-#push-options "--z3rlimit 300 --z3cliopt smt.arith.nl=false"
+#push-options "--z3rlimit 300 --z3cliopt smt.arith.nl=false \
+  --using_facts_from '*,-LowStar.Monotonic.Buffer.unused_in_not_unused_in_disjoint_2'"
 let update_small #index c i t t' p data len =
   [@inline_let] let _ = c.state.invariant_loc_in_footprint #i in
   [@inline_let] let _ = c.key.invariant_loc_in_footprint #i in

--- a/hints/Hacl.Streaming.Functor.fst.hints
+++ b/hints/Hacl.Streaming.Functor.fst.hints
@@ -1,5 +1,5 @@
 [
-  "©ñ\u0010ö´F­È!Ï9J-ð$¼",
+  "-/3+}xtÌh#‚\n»*ø\u0017",
   [
     [
       "Hacl.Streaming.Functor.optional_freeable",
@@ -25,7 +25,7 @@
         "typing_FStar.Monotonic.HyperStack.get_tip"
       ],
       0,
-      "d3806531af09427fd122eb0f5f27a557"
+      "80235c14208fa79b59a3944d82a3a478"
     ],
     [
       "Hacl.Streaming.Functor.optional_invariant",
@@ -51,7 +51,7 @@
         "typing_FStar.Monotonic.HyperStack.get_tip"
       ],
       0,
-      "80bcfe117502726a429cf5475a749f1b"
+      "a970a272a1f5daa79e836a3e08e259fd"
     ],
     [
       "Hacl.Streaming.Functor.optional_footprint",
@@ -77,7 +77,7 @@
         "typing_FStar.Monotonic.HyperStack.get_tip"
       ],
       0,
-      "d0588ab839bf18559f4343021c61d3fe"
+      "958527aef31323e9216a86e7d380a0ba"
     ],
     [
       "Hacl.Streaming.Functor.optional_reveal",
@@ -97,7 +97,7 @@
         "inversion-interp"
       ],
       0,
-      "97ab66f752bc6d6a72721a568db4249f"
+      "d36a42dfa3ac8bc54f2135ffc125f43d"
     ],
     [
       "Hacl.Streaming.Functor.optional_hide",
@@ -127,7 +127,7 @@
         "typing_FStar.Ghost.hide"
       ],
       0,
-      "71299c4a204c1a92318542dba35dc3a7"
+      "5f19c210380b790464c95a64f39b2c64"
     ],
     [
       "Hacl.Streaming.Functor.stateful_frame_preserves_freeable",
@@ -136,7 +136,7 @@
       0,
       [ "@query" ],
       0,
-      "45709460bebb5b7f1099298f4e8448bd"
+      "57cd68ca56978dc02180d8313e97d18c"
     ],
     [
       "Hacl.Streaming.Functor.optional_frame",
@@ -161,7 +161,7 @@
         "inversion-interp", "true_interp"
       ],
       0,
-      "94af5cf06761778b1a40a697847d0b0c"
+      "7683678173f846506c3b4a3d877bf676"
     ],
     [
       "Hacl.Streaming.Functor.loc_includes_union_l_footprint_s",
@@ -170,7 +170,7 @@
       0,
       [ "@query" ],
       0,
-      "19726bc26545f6dd5ef902b7d672dd02"
+      "bc1a6a4c75abef4da50d017aafb5348e"
     ],
     [
       "Hacl.Streaming.Functor.invariant_s",
@@ -225,7 +225,7 @@
         "typing_LowStar.Monotonic.Buffer.len"
       ],
       0,
-      "725d40b2bfdf6dd139e5c5479902f004"
+      "a74ec55de455af1c25e63a744d05564d"
     ],
     [
       "Hacl.Streaming.Functor.freeable",
@@ -241,7 +241,7 @@
         "refinement_interpretation_Tm_refine_573cfed777dae20cc82e8fef9622857e"
       ],
       0,
-      "bfb22c77df9a4d9116f623898e770e02"
+      "4d2abd4248c6f2c1c933a9d8d59acc42"
     ],
     [
       "Hacl.Streaming.Functor.invariant",
@@ -257,7 +257,7 @@
         "refinement_interpretation_Tm_refine_573cfed777dae20cc82e8fef9622857e"
       ],
       0,
-      "5984f28a990c201192aa1ff07e968745"
+      "20f1827dfe02247c9d0f7543f8b49a7e"
     ],
     [
       "Hacl.Streaming.Functor.invariant_loc_in_footprint",
@@ -329,7 +329,7 @@
         "typing_LowStar.Monotonic.Buffer.loc_union"
       ],
       0,
-      "3adb37f0f0dbf0258c07d0603a7b2125"
+      "74c27b07cdf3020812f8337a8384cfa6"
     ],
     [
       "Hacl.Streaming.Functor.seen_bounded",
@@ -350,7 +350,7 @@
         "projection_inverse_BoxBool_proj_0"
       ],
       0,
-      "90f02617446f7428837b570f2a24f99a"
+      "1fdeabf00a82e54de2c5222bb16b9f39"
     ],
     [
       "Hacl.Streaming.Functor.frame_invariant",
@@ -428,7 +428,7 @@
         "typing_tok_Hacl.Streaming.Interface.Erased@tok"
       ],
       0,
-      "9073b1652c2a5f7fbf19bb78e2e19a33"
+      "cede5c260fc720014a7854b30d31a945"
     ],
     [
       "Hacl.Streaming.Functor.frame_seen",
@@ -477,7 +477,7 @@
         "typing_LowStar.Monotonic.Buffer.loc_buffer"
       ],
       0,
-      "65f3287dd576cf5605b491fbbd73f79e"
+      "9ea61f930cb50cc4525064992da46d60"
     ],
     [
       "Hacl.Streaming.Functor.index_of_state",
@@ -490,7 +490,7 @@
         "refinement_interpretation_Tm_refine_eed61e872c76c9d08d9c5e037b1dc22d"
       ],
       0,
-      "5f8989845a676834b47df08c7ea50b04"
+      "84acd8a5655518c6b2154affbe1b49ad"
     ],
     [
       "Hacl.Streaming.Functor.index_of_state",
@@ -511,7 +511,7 @@
         "typing_FStar.Ghost.reveal"
       ],
       0,
-      "7ccd8cd296ff854ac757e198cb0a63cd"
+      "3668e611ee2bcc80b946b12d567017e0"
     ],
     [
       "Hacl.Streaming.Functor.create_in_st",
@@ -524,7 +524,7 @@
         "refinement_interpretation_Tm_refine_a997f7fc0ee9057c4f6335ecd3b55d00"
       ],
       0,
-      "722c987d8f542d424e25178afbc4ec82"
+      "06923b8338ff4c3634092016ace58658"
     ],
     [
       "Hacl.Streaming.Functor.create_in",
@@ -723,7 +723,7 @@
         "typing_tok_Lib.IntTypes.U8@tok"
       ],
       0,
-      "1f4f68614dc1c29f9bec13972cf11425"
+      "84361ff9d2151a9c4f3cd1d7eb202151"
     ],
     [
       "Hacl.Streaming.Functor.alloca_st",
@@ -736,7 +736,7 @@
         "refinement_interpretation_Tm_refine_a997f7fc0ee9057c4f6335ecd3b55d00"
       ],
       0,
-      "4d10d507fdc16e5766cd06460040b758"
+      "58b8096db2ff36f0b0d74badb4cd65b1"
     ],
     [
       "Hacl.Streaming.Functor.alloca",
@@ -935,7 +935,7 @@
         "typing_tok_Lib.IntTypes.U8@tok"
       ],
       0,
-      "dc6113384600a8bb85a68be028a99cea"
+      "6521cbb555a37d604654c8d440551da2"
     ],
     [
       "Hacl.Streaming.Functor.init_st",
@@ -948,7 +948,7 @@
         "refinement_interpretation_Tm_refine_a997f7fc0ee9057c4f6335ecd3b55d00"
       ],
       0,
-      "a2bb3f3dc6a5b866e816a5a72f764303"
+      "e809c4a3ef83e092d9549319aecae5fc"
     ],
     [
       "Hacl.Streaming.Functor.init",
@@ -1112,7 +1112,7 @@
         "typing_LowStar.Monotonic.Buffer.loc_union"
       ],
       0,
-      "c71d0fc18a71150e4d4579d86f67bb18"
+      "8b55bcb84cd9244cc650f37d6a15d1d7"
     ],
     [
       "Hacl.Streaming.Functor.update_pre",
@@ -1121,7 +1121,7 @@
       0,
       [ "@query" ],
       0,
-      "e305a3987f71046b4bc79df7538ce2c7"
+      "2dec195b614f138e7ad792c963db1ae3"
     ],
     [
       "Hacl.Streaming.Functor.update_st",
@@ -1134,7 +1134,7 @@
         "refinement_interpretation_Tm_refine_a997f7fc0ee9057c4f6335ecd3b55d00"
       ],
       0,
-      "7eece2397432d539076e1109cc547f12"
+      "e92c94ccb6de51734918d8b11035643f"
     ],
     [
       "Hacl.Streaming.Functor.rest",
@@ -1177,7 +1177,7 @@
         "typing_Hacl.Streaming.Spec.split_at_last_num_blocks"
       ],
       0,
-      "1a85cb05a2511caa71c4eb3f3ab9f675"
+      "a50caa4df7f734a2b8ab3c92ebcc5f1c"
     ],
     [
       "Hacl.Streaming.Functor.nblocks",
@@ -1221,7 +1221,7 @@
         "typing_Lib.UpdateMulti.split_at_last_nb_rem"
       ],
       0,
-      "0814e3fa4830af64fecc0117c2fa304d"
+      "6be5730abe85303fc01ff5a508f3634c"
     ],
     [
       "Hacl.Streaming.Functor.rest_finish",
@@ -1269,7 +1269,7 @@
         "typing_Lib.UpdateMulti.split_at_last_nb_rem"
       ],
       0,
-      "dfbecbebb71553f7ba36e303362a99e2"
+      "5b4065c31d3164b280905ce13b16d0a3"
     ],
     [
       "Hacl.Streaming.Functor.add_len",
@@ -1298,7 +1298,7 @@
         "typing_Hacl.Streaming.Interface.__proj__Block__item__max_input_length"
       ],
       0,
-      "453193fdbe23f5a7aaf6251f30fae05c"
+      "afbc817b7bdaee7714efaa31303cccba"
     ],
     [
       "Hacl.Streaming.Functor.add_len_small",
@@ -1374,7 +1374,7 @@
         "typing_Lib.UpdateMulti.split_at_last_nb_rem"
       ],
       0,
-      "c67267930713945cc2e84823d0c380b9"
+      "79f8c393677e9987a6fa40277cc28da4"
     ],
     [
       "Hacl.Streaming.Functor.update_small",
@@ -1387,7 +1387,7 @@
         "refinement_interpretation_Tm_refine_eed61e872c76c9d08d9c5e037b1dc22d"
       ],
       0,
-      "70203a5c2cfb9dda6297c6ff6b253931"
+      "bfbae8064d85923da859f27992d01733"
     ],
     [
       "Hacl.Streaming.Functor.split_at_last_rest_eq",
@@ -1426,7 +1426,7 @@
         "typing_Hacl.Streaming.Spec.split_at_last_num_blocks"
       ],
       0,
-      "313a164cc4f149d35dea118da2bf8c16"
+      "7633fc0cbb2d2ac4cad2e0e836528283"
     ],
     [
       "Hacl.Streaming.Functor.update_small",
@@ -1647,7 +1647,7 @@
         "typing_LowStar.Monotonic.Buffer.loc_union"
       ],
       0,
-      "689f094c34360aface0c86c2fb80e2ff"
+      "75dea835083e88a37be36d3a25e4a343"
     ],
     [
       "Hacl.Streaming.Functor.update_empty_or_full_buf",
@@ -1685,7 +1685,7 @@
         "typing_FStar.UInt32.t"
       ],
       0,
-      "0c67125401b75e95f2a919ef41dc2aed"
+      "a909cb6979ce91566f76d629a04585e3"
     ],
     [
       "Hacl.Streaming.Functor.update_empty_or_full_buf",
@@ -1901,7 +1901,7 @@
         "typing_LowStar.Monotonic.Buffer.loc_union"
       ],
       0,
-      "e28e49c57d39ea80aa303bce26894dc7"
+      "670ad605dc48b81c88c5d2199745bce8"
     ],
     [
       "Hacl.Streaming.Functor.update_round",
@@ -1918,7 +1918,7 @@
         "refinement_interpretation_Tm_refine_eed61e872c76c9d08d9c5e037b1dc22d"
       ],
       0,
-      "ee2876e083d07b45c44cbf71e56d81aa"
+      "75f7bb2d9bac02ddc54a696b8e88ec2a"
     ],
     [
       "Hacl.Streaming.Functor.update_round",
@@ -2033,7 +2033,7 @@
         "typing_LowStar.Monotonic.Buffer.length"
       ],
       0,
-      "230591831bfa15def3db49012a5bb793"
+      "ee6e9740a0f82806cd407f05db201da1"
     ],
     [
       "Hacl.Streaming.Functor.update",
@@ -2162,7 +2162,7 @@
         "unit_typing"
       ],
       0,
-      "209715b9b1349c2efd7bff4bfa5d712d"
+      "6048377896123bc04dc5c2b31bd311bc"
     ],
     [
       "Hacl.Streaming.Functor.finish_st",
@@ -2179,7 +2179,7 @@
         "refinement_interpretation_Tm_refine_a997f7fc0ee9057c4f6335ecd3b55d00"
       ],
       0,
-      "da62597c9d7e36f00ec30ffe44501a2d"
+      "d65fab8a2bc385ff6986d8c123813845"
     ],
     [
       "Hacl.Streaming.Functor.mk_finish",
@@ -2459,7 +2459,7 @@
         "typing_tok_Hacl.Streaming.Interface.Erased@tok"
       ],
       0,
-      "82eaaed69444c5020d79be0d08b209ab"
+      "aed68e1e7117dcf1282fd72ae04e4b3e"
     ],
     [
       "Hacl.Streaming.Functor.free_st",
@@ -2472,7 +2472,7 @@
         "refinement_interpretation_Tm_refine_a997f7fc0ee9057c4f6335ecd3b55d00"
       ],
       0,
-      "ac367ecc5adb7b89db53233a4ed00cbc"
+      "2e555a3232d467ee12959cc076207570"
     ],
     [
       "Hacl.Streaming.Functor.free",
@@ -2573,7 +2573,7 @@
         "typing_LowStar.Monotonic.Buffer.loc_union"
       ],
       0,
-      "78d4fb2c01fa2d3330583ef91a0a245e"
+      "02cb1f12c03f239783e3948d5eed8026"
     ]
   ]
 ]

--- a/hints/Hacl.Streaming.Functor.fst.hints
+++ b/hints/Hacl.Streaming.Functor.fst.hints
@@ -7,25 +7,17 @@
       0,
       0,
       [
-        "@MaxIFuel_assumption", "@query", "bool_inversion",
+        "@MaxIFuel_assumption", "@query",
+        "constructor_distinct_Hacl.Streaming.Interface.Runtime",
         "disc_equation_Hacl.Streaming.Interface.Erased",
         "disc_equation_Hacl.Streaming.Interface.Runtime",
-        "equation_FStar.Monotonic.HyperHeap.hmap",
-        "equation_FStar.Monotonic.HyperStack.is_tip",
-        "equation_FStar.Monotonic.HyperStack.is_wf_with_ctr_and_tip",
-        "equation_FStar.Monotonic.HyperStack.mem",
+        "equality_tok_Hacl.Streaming.Interface.Runtime@tok",
         "equation_Hacl.Streaming.Interface.optional_key",
         "fuel_guarded_inversion_Hacl.Streaming.Interface.key_management",
-        "function_token_typing_FStar.Monotonic.Heap.heap",
-        "inversion-interp", "lemma_FStar.Map.lemma_ContainsDom",
-        "projection_inverse_BoxBool_proj_0",
-        "refinement_interpretation_Tm_refine_05e15190c946858f68c69156f585f95a",
-        "typing_FStar.Map.contains", "typing_FStar.Monotonic.HyperHeap.rid",
-        "typing_FStar.Monotonic.HyperStack.get_hmap",
-        "typing_FStar.Monotonic.HyperStack.get_tip"
+        "inversion-interp", "projection_inverse_BoxBool_proj_0"
       ],
       0,
-      "80235c14208fa79b59a3944d82a3a478"
+      "3337d7f55288108fb66bff9ea90a2d54"
     ],
     [
       "Hacl.Streaming.Functor.optional_invariant",
@@ -33,25 +25,17 @@
       0,
       0,
       [
-        "@MaxIFuel_assumption", "@query", "bool_inversion",
+        "@MaxIFuel_assumption", "@query",
+        "constructor_distinct_Hacl.Streaming.Interface.Runtime",
         "disc_equation_Hacl.Streaming.Interface.Erased",
         "disc_equation_Hacl.Streaming.Interface.Runtime",
-        "equation_FStar.Monotonic.HyperHeap.hmap",
-        "equation_FStar.Monotonic.HyperStack.is_tip",
-        "equation_FStar.Monotonic.HyperStack.is_wf_with_ctr_and_tip",
-        "equation_FStar.Monotonic.HyperStack.mem",
+        "equality_tok_Hacl.Streaming.Interface.Runtime@tok",
         "equation_Hacl.Streaming.Interface.optional_key",
         "fuel_guarded_inversion_Hacl.Streaming.Interface.key_management",
-        "function_token_typing_FStar.Monotonic.Heap.heap",
-        "inversion-interp", "lemma_FStar.Map.lemma_ContainsDom",
-        "projection_inverse_BoxBool_proj_0",
-        "refinement_interpretation_Tm_refine_05e15190c946858f68c69156f585f95a",
-        "typing_FStar.Map.contains", "typing_FStar.Monotonic.HyperHeap.rid",
-        "typing_FStar.Monotonic.HyperStack.get_hmap",
-        "typing_FStar.Monotonic.HyperStack.get_tip"
+        "inversion-interp", "projection_inverse_BoxBool_proj_0"
       ],
       0,
-      "a970a272a1f5daa79e836a3e08e259fd"
+      "3cb899d75a90c699d4106597cf9bb21c"
     ],
     [
       "Hacl.Streaming.Functor.optional_footprint",
@@ -59,25 +43,17 @@
       0,
       0,
       [
-        "@MaxIFuel_assumption", "@query", "bool_inversion",
+        "@MaxIFuel_assumption", "@query",
+        "constructor_distinct_Hacl.Streaming.Interface.Runtime",
         "disc_equation_Hacl.Streaming.Interface.Erased",
         "disc_equation_Hacl.Streaming.Interface.Runtime",
-        "equation_FStar.Monotonic.HyperHeap.hmap",
-        "equation_FStar.Monotonic.HyperStack.is_tip",
-        "equation_FStar.Monotonic.HyperStack.is_wf_with_ctr_and_tip",
-        "equation_FStar.Monotonic.HyperStack.mem",
+        "equality_tok_Hacl.Streaming.Interface.Runtime@tok",
         "equation_Hacl.Streaming.Interface.optional_key",
         "fuel_guarded_inversion_Hacl.Streaming.Interface.key_management",
-        "function_token_typing_FStar.Monotonic.Heap.heap",
-        "inversion-interp", "lemma_FStar.Map.lemma_ContainsDom",
-        "projection_inverse_BoxBool_proj_0",
-        "refinement_interpretation_Tm_refine_05e15190c946858f68c69156f585f95a",
-        "typing_FStar.Map.contains", "typing_FStar.Monotonic.HyperHeap.rid",
-        "typing_FStar.Monotonic.HyperStack.get_hmap",
-        "typing_FStar.Monotonic.HyperStack.get_tip"
+        "inversion-interp", "projection_inverse_BoxBool_proj_0"
       ],
       0,
-      "958527aef31323e9216a86e7d380a0ba"
+      "23d8161c030a2ca655aebe0ad48a4000"
     ],
     [
       "Hacl.Streaming.Functor.optional_reveal",
@@ -94,10 +70,10 @@
         "equality_tok_Hacl.Streaming.Interface.Runtime@tok",
         "equation_Hacl.Streaming.Interface.optional_key",
         "fuel_guarded_inversion_Hacl.Streaming.Interface.key_management",
-        "inversion-interp"
+        "inversion-interp", "projection_inverse_BoxBool_proj_0"
       ],
       0,
-      "d36a42dfa3ac8bc54f2135ffc125f43d"
+      "d8f394c561220eceeaf20cbd0b735263"
     ],
     [
       "Hacl.Streaming.Functor.optional_hide",
@@ -121,13 +97,13 @@
         "fuel_guarded_inversion_Hacl.Streaming.Interface.stateful",
         "function_token_typing_Hacl.Streaming.Interface.__proj__Stateful__item__t",
         "function_token_typing_Hacl.Streaming.Interface.__proj__Stateful__item__v",
-        "inversion-interp",
+        "inversion-interp", "projection_inverse_BoxBool_proj_0",
         "token_correspondence_Hacl.Streaming.Interface.__proj__Stateful__item__t",
         "token_correspondence_Hacl.Streaming.Interface.__proj__Stateful__item__v",
         "typing_FStar.Ghost.hide"
       ],
       0,
-      "5f19c210380b790464c95a64f39b2c64"
+      "f55c73acaf2561de13ff017eab701252"
     ],
     [
       "Hacl.Streaming.Functor.stateful_frame_preserves_freeable",
@@ -136,7 +112,7 @@
       0,
       [ "@query" ],
       0,
-      "57cd68ca56978dc02180d8313e97d18c"
+      "0b1e1daf269c2eae9e890ae016caf2ca"
     ],
     [
       "Hacl.Streaming.Functor.optional_frame",
@@ -158,10 +134,11 @@
         "equation_Hacl.Streaming.Interface.optional_key",
         "fuel_guarded_inversion_Hacl.Streaming.Interface.key_management",
         "fuel_guarded_inversion_Hacl.Streaming.Interface.stateful",
-        "inversion-interp", "true_interp"
+        "inversion-interp", "projection_inverse_BoxBool_proj_0",
+        "true_interp"
       ],
       0,
-      "7683678173f846506c3b4a3d877bf676"
+      "a21abe58c29844a87b0a86121b2e9ec0"
     ],
     [
       "Hacl.Streaming.Functor.loc_includes_union_l_footprint_s",
@@ -170,7 +147,7 @@
       0,
       [ "@query" ],
       0,
-      "bc1a6a4c75abef4da50d017aafb5348e"
+      "5e4bd3c70a26a91b02733ce8ff8d2f15"
     ],
     [
       "Hacl.Streaming.Functor.invariant_s",
@@ -225,7 +202,7 @@
         "typing_LowStar.Monotonic.Buffer.len"
       ],
       0,
-      "a74ec55de455af1c25e63a744d05564d"
+      "539a42d5e861bee20ec3095d68a22682"
     ],
     [
       "Hacl.Streaming.Functor.freeable",
@@ -241,7 +218,7 @@
         "refinement_interpretation_Tm_refine_573cfed777dae20cc82e8fef9622857e"
       ],
       0,
-      "4d2abd4248c6f2c1c933a9d8d59acc42"
+      "39819d37a1f6a1944c9fad3c4206ae4b"
     ],
     [
       "Hacl.Streaming.Functor.invariant",
@@ -257,7 +234,7 @@
         "refinement_interpretation_Tm_refine_573cfed777dae20cc82e8fef9622857e"
       ],
       0,
-      "20f1827dfe02247c9d0f7543f8b49a7e"
+      "fd30eacaa11d3b94f10bea6615703e47"
     ],
     [
       "Hacl.Streaming.Functor.invariant_loc_in_footprint",
@@ -329,7 +306,7 @@
         "typing_LowStar.Monotonic.Buffer.loc_union"
       ],
       0,
-      "74c27b07cdf3020812f8337a8384cfa6"
+      "d66b8d5961115517dbababe2e8b693e6"
     ],
     [
       "Hacl.Streaming.Functor.seen_bounded",
@@ -350,7 +327,7 @@
         "projection_inverse_BoxBool_proj_0"
       ],
       0,
-      "1fdeabf00a82e54de2c5222bb16b9f39"
+      "119b451174ef34ef6a311d13608dc7db"
     ],
     [
       "Hacl.Streaming.Functor.frame_invariant",
@@ -428,7 +405,7 @@
         "typing_tok_Hacl.Streaming.Interface.Erased@tok"
       ],
       0,
-      "cede5c260fc720014a7854b30d31a945"
+      "680ece07477b575faee615244aa6b642"
     ],
     [
       "Hacl.Streaming.Functor.frame_seen",
@@ -477,7 +454,7 @@
         "typing_LowStar.Monotonic.Buffer.loc_buffer"
       ],
       0,
-      "9ea61f930cb50cc4525064992da46d60"
+      "ced4c66f22ac59a87bafc7f448221f8c"
     ],
     [
       "Hacl.Streaming.Functor.index_of_state",
@@ -490,7 +467,7 @@
         "refinement_interpretation_Tm_refine_eed61e872c76c9d08d9c5e037b1dc22d"
       ],
       0,
-      "84acd8a5655518c6b2154affbe1b49ad"
+      "c88e34da36fd9005d8e2b7076178cc0e"
     ],
     [
       "Hacl.Streaming.Functor.index_of_state",
@@ -511,7 +488,7 @@
         "typing_FStar.Ghost.reveal"
       ],
       0,
-      "3668e611ee2bcc80b946b12d567017e0"
+      "2604a74b263c1516d2485d757d64a221"
     ],
     [
       "Hacl.Streaming.Functor.create_in_st",
@@ -524,7 +501,7 @@
         "refinement_interpretation_Tm_refine_a997f7fc0ee9057c4f6335ecd3b55d00"
       ],
       0,
-      "06923b8338ff4c3634092016ace58658"
+      "50203ea3282e9eb38304ed3195400bdc"
     ],
     [
       "Hacl.Streaming.Functor.create_in",
@@ -723,7 +700,7 @@
         "typing_tok_Lib.IntTypes.U8@tok"
       ],
       0,
-      "84361ff9d2151a9c4f3cd1d7eb202151"
+      "7557774153042f13f8ec79df00013e47"
     ],
     [
       "Hacl.Streaming.Functor.alloca_st",
@@ -736,7 +713,7 @@
         "refinement_interpretation_Tm_refine_a997f7fc0ee9057c4f6335ecd3b55d00"
       ],
       0,
-      "58b8096db2ff36f0b0d74badb4cd65b1"
+      "8f5728efad5ac230d33882085e3caf88"
     ],
     [
       "Hacl.Streaming.Functor.alloca",
@@ -792,6 +769,7 @@
         "equation_Hacl.Streaming.Interface.optional_key",
         "equation_Hacl.Streaming.Interface.uint8",
         "equation_Hacl.Streaming.Spec.bytes",
+        "equation_Hacl.Streaming.Spec.split_at_last",
         "equation_Hacl.Streaming.Spec.uint8", "equation_Lib.IntTypes.bits",
         "equation_Lib.IntTypes.maxint", "equation_Lib.IntTypes.minint",
         "equation_Lib.IntTypes.range", "equation_Lib.IntTypes.uint8",
@@ -890,6 +868,7 @@
         "refinement_interpretation_Tm_refine_a997f7fc0ee9057c4f6335ecd3b55d00",
         "refinement_interpretation_Tm_refine_b361ba8089a6e963921008d537e799a1",
         "refinement_interpretation_Tm_refine_b913a3f691ca99086652e0a655e72f17",
+        "refinement_interpretation_Tm_refine_be2ca09695fecdeeca4426be0859f2b6",
         "refinement_interpretation_Tm_refine_c1424615841f28cac7fc34e92b7ff33c",
         "refinement_interpretation_Tm_refine_ee39f9357cbd63bb5cf348fb8515eff7",
         "refinement_interpretation_Tm_refine_f13070840248fced9d9d60d77bdae3ec",
@@ -935,7 +914,7 @@
         "typing_tok_Lib.IntTypes.U8@tok"
       ],
       0,
-      "6521cbb555a37d604654c8d440551da2"
+      "ae213897c63e6b19adc31efdaecef12b"
     ],
     [
       "Hacl.Streaming.Functor.init_st",
@@ -948,7 +927,7 @@
         "refinement_interpretation_Tm_refine_a997f7fc0ee9057c4f6335ecd3b55d00"
       ],
       0,
-      "e809c4a3ef83e092d9549319aecae5fc"
+      "2656694fbd8111ae06cf310ce89e95b2"
     ],
     [
       "Hacl.Streaming.Functor.init",
@@ -1024,8 +1003,7 @@
         "int_typing",
         "interpretation_Tm_abs_612136ee4143d24977831c80e4f470a1",
         "inversion-interp", "kinding_Hacl.Streaming.Functor.state_s@tok",
-        "l_and-interp", "lemma_FStar.Ghost.hide_reveal",
-        "lemma_FStar.Ghost.reveal_hide",
+        "l_and-interp", "lemma_FStar.Ghost.reveal_hide",
         "lemma_FStar.HyperStack.ST.lemma_equal_domains_trans",
         "lemma_FStar.Seq.Base.lemma_index_upd1",
         "lemma_FStar.Seq.Properties.slice_is_empty",
@@ -1043,6 +1021,7 @@
         "lemma_LowStar.Monotonic.Buffer.loc_includes_trans_backwards",
         "lemma_LowStar.Monotonic.Buffer.loc_includes_union_l_",
         "lemma_LowStar.Monotonic.Buffer.loc_union_comm",
+        "lemma_LowStar.Monotonic.Buffer.loc_union_loc_none_r",
         "lemma_LowStar.Monotonic.Buffer.modifies_buffer_elim",
         "lemma_LowStar.Monotonic.Buffer.modifies_liveness_insensitive_buffer_weak",
         "lemma_LowStar.Monotonic.Buffer.modifies_loc_includes",
@@ -1112,7 +1091,7 @@
         "typing_LowStar.Monotonic.Buffer.loc_union"
       ],
       0,
-      "8b55bcb84cd9244cc650f37d6a15d1d7"
+      "4af10220ab4acbadab22d5b659b7497a"
     ],
     [
       "Hacl.Streaming.Functor.update_pre",
@@ -1121,7 +1100,7 @@
       0,
       [ "@query" ],
       0,
-      "2dec195b614f138e7ad792c963db1ae3"
+      "b9d689b3d94419d53976277a8bb00397"
     ],
     [
       "Hacl.Streaming.Functor.update_st",
@@ -1134,7 +1113,7 @@
         "refinement_interpretation_Tm_refine_a997f7fc0ee9057c4f6335ecd3b55d00"
       ],
       0,
-      "e92c94ccb6de51734918d8b11035643f"
+      "6ff7911cc587c246513a601fb751a4ef"
     ],
     [
       "Hacl.Streaming.Functor.rest",
@@ -1153,31 +1132,34 @@
         "equation_FStar.UInt.uint_t", "equation_FStar.UInt64.eq",
         "equation_FStar.UInt64.gt",
         "equation_Hacl.Streaming.Spec.split_at_last_num_blocks",
-        "equation_Prims.nat",
+        "equation_Lib.UpdateMulti.split_at_last_nb_rem",
+        "equation_Prims.nat", "equation_Prims.pos",
         "fuel_guarded_inversion_Hacl.Streaming.Interface.block",
         "function_token_typing_Hacl.Streaming.Interface.__proj__Block__item__blocks_state_len",
-        "int_inversion", "int_typing", "lemma_FStar.Ghost.reveal_hide",
-        "lemma_FStar.UInt64.vu_inv", "primitive_Prims.op_Addition",
-        "primitive_Prims.op_AmpAmp", "primitive_Prims.op_Equality",
-        "primitive_Prims.op_GreaterThan",
+        "int_inversion", "int_typing", "lemma_FStar.UInt64.vu_inv",
+        "primitive_Prims.op_Addition", "primitive_Prims.op_AmpAmp",
+        "primitive_Prims.op_Equality", "primitive_Prims.op_GreaterThan",
         "primitive_Prims.op_LessThanOrEqual", "primitive_Prims.op_Modulus",
-        "primitive_Prims.op_Subtraction",
+        "primitive_Prims.op_Multiply", "primitive_Prims.op_Subtraction",
         "projection_inverse_BoxBool_proj_0",
         "projection_inverse_BoxInt_proj_0",
+        "projection_inverse_FStar.Pervasives.Native.Mktuple2__1",
+        "refinement_interpretation_Tm_refine_362e2dfd5fc10941f1049c892a15d4e9",
         "refinement_interpretation_Tm_refine_441ef698a21a62d85e9329d3de04db00",
         "refinement_interpretation_Tm_refine_505e38c43a22cb1838b480b2d5f14cdb",
         "refinement_interpretation_Tm_refine_542f9d4f129664613f2483a6c88bc7c2",
+        "refinement_interpretation_Tm_refine_774ba3f728d91ead8ef40be66c9802e5",
         "refinement_interpretation_Tm_refine_9239da84efb2ef57317a8ef1dd12bd83",
         "refinement_interpretation_Tm_refine_b1b24842341f4a9e0a645751b0d9b99a",
         "refinement_interpretation_Tm_refine_f13070840248fced9d9d60d77bdae3ec",
-        "refinement_kinding_Tm_refine_542f9d4f129664613f2483a6c88bc7c2",
         "token_correspondence_Hacl.Streaming.Interface.__proj__Block__item__blocks_state_len",
         "typing_FStar.UInt.fits", "typing_FStar.UInt32.v",
         "typing_FStar.UInt64.v",
-        "typing_Hacl.Streaming.Spec.split_at_last_num_blocks"
+        "typing_Hacl.Streaming.Spec.split_at_last_num_blocks",
+        "typing_Lib.UpdateMulti.split_at_last_nb_rem"
       ],
       0,
-      "a50caa4df7f734a2b8ab3c92ebcc5f1c"
+      "c2cd8bc36bc739fb9393f8056eea76a0"
     ],
     [
       "Hacl.Streaming.Functor.nblocks",
@@ -1188,40 +1170,50 @@
         "@MaxIFuel_assumption", "@query",
         "Hacl.Streaming.Interface_interpretation_Tm_arrow_011e939061623ee15fa4a0d456ecdd81",
         "Hacl.Streaming.Interface_interpretation_Tm_arrow_7b1dc8185f03eadbcc027104ec62ed38",
-        "b2t_def", "equation_FStar.Int.Cast.uint32_to_uint64",
-        "equation_FStar.UInt.fits", "equation_FStar.UInt.max_int",
-        "equation_FStar.UInt.min_int", "equation_FStar.UInt.size",
-        "equation_FStar.UInt.uint_t",
+        "Prims_pretyping_ae567c2fb75be05905677af440075565", "b2t_def",
+        "bool_inversion", "bool_typing",
+        "equation_FStar.Int.Cast.uint32_to_uint64", "equation_FStar.UInt.eq",
+        "equation_FStar.UInt.fits", "equation_FStar.UInt.gt",
+        "equation_FStar.UInt.max_int", "equation_FStar.UInt.min_int",
+        "equation_FStar.UInt.mod", "equation_FStar.UInt.size",
+        "equation_FStar.UInt.uint_t", "equation_FStar.UInt64.eq",
+        "equation_FStar.UInt64.gt",
         "equation_Hacl.Streaming.Spec.split_at_last_num_blocks",
         "equation_Lib.UpdateMulti.split_at_last_nb_rem",
         "equation_Prims.nat", "equation_Prims.pos",
         "fuel_guarded_inversion_Hacl.Streaming.Interface.block",
         "function_token_typing_Hacl.Streaming.Interface.__proj__Block__item__block_len",
-        "int_inversion", "int_typing", "lemma_FStar.Ghost.reveal_hide",
+        "function_token_typing_Prims.__cache_version_number__",
+        "int_inversion", "int_typing", "lemma_FStar.UInt64.vu_inv",
         "primitive_Prims.op_Addition", "primitive_Prims.op_AmpAmp",
-        "primitive_Prims.op_Division", "primitive_Prims.op_LessThanOrEqual",
-        "primitive_Prims.op_Modulus", "primitive_Prims.op_Multiply",
-        "primitive_Prims.op_Subtraction",
+        "primitive_Prims.op_Division", "primitive_Prims.op_Equality",
+        "primitive_Prims.op_GreaterThan",
+        "primitive_Prims.op_LessThanOrEqual", "primitive_Prims.op_Modulus",
+        "primitive_Prims.op_Multiply", "primitive_Prims.op_Subtraction",
         "projection_inverse_BoxBool_proj_0",
         "projection_inverse_BoxInt_proj_0",
         "projection_inverse_FStar.Pervasives.Native.Mktuple2__1",
         "projection_inverse_FStar.Pervasives.Native.Mktuple2__2",
+        "refinement_interpretation_Tm_refine_06f2bf4950bb76094f7b7f43daea2409",
         "refinement_interpretation_Tm_refine_0c228824ac6e9762debc92bdf41bd064",
         "refinement_interpretation_Tm_refine_362e2dfd5fc10941f1049c892a15d4e9",
         "refinement_interpretation_Tm_refine_505e38c43a22cb1838b480b2d5f14cdb",
+        "refinement_interpretation_Tm_refine_542f9d4f129664613f2483a6c88bc7c2",
         "refinement_interpretation_Tm_refine_774ba3f728d91ead8ef40be66c9802e5",
         "refinement_interpretation_Tm_refine_9239da84efb2ef57317a8ef1dd12bd83",
+        "refinement_interpretation_Tm_refine_94d25b6e0041d543efd58300424ecc37",
         "refinement_interpretation_Tm_refine_9e7f68c38e43484e77069094f4fd88d3",
         "refinement_interpretation_Tm_refine_d15a9766d4c1ec94d1574f05b54a618b",
         "refinement_interpretation_Tm_refine_f13070840248fced9d9d60d77bdae3ec",
-        "refinement_kinding_Tm_refine_542f9d4f129664613f2483a6c88bc7c2",
         "token_correspondence_Hacl.Streaming.Interface.__proj__Block__item__block_len",
-        "typing_FStar.Int.Cast.uint32_to_uint64", "typing_FStar.UInt32.v",
+        "typing_FStar.Int.Cast.uint32_to_uint64", "typing_FStar.UInt.fits",
+        "typing_FStar.UInt32.v", "typing_FStar.UInt64.rem",
+        "typing_FStar.UInt64.v",
         "typing_Hacl.Streaming.Spec.split_at_last_num_blocks",
         "typing_Lib.UpdateMulti.split_at_last_nb_rem"
       ],
       0,
-      "6be5730abe85303fc01ff5a508f3634c"
+      "855e6d9b01b53b50fb21ef52e2493840"
     ],
     [
       "Hacl.Streaming.Functor.rest_finish",
@@ -1269,7 +1261,7 @@
         "typing_Lib.UpdateMulti.split_at_last_nb_rem"
       ],
       0,
-      "5b4065c31d3164b280905ce13b16d0a3"
+      "220e889e2785ead24ee67db5bdf4c9ce"
     ],
     [
       "Hacl.Streaming.Functor.add_len",
@@ -1298,7 +1290,7 @@
         "typing_Hacl.Streaming.Interface.__proj__Block__item__max_input_length"
       ],
       0,
-      "afbc817b7bdaee7714efaa31303cccba"
+      "c9684871ebc01d205dcbff9a9a6d8335"
     ],
     [
       "Hacl.Streaming.Functor.add_len_small",
@@ -1306,22 +1298,20 @@
       0,
       0,
       [
-        "@MaxFuel_assumption", "@MaxIFuel_assumption",
-        "@fuel_correspondence_Prims.pow2.fuel_instrumented", "@query",
+        "@MaxIFuel_assumption", "@query",
         "Hacl.Streaming.Interface_interpretation_Tm_arrow_5daade47d6db9948d24a098f692af064",
-        "Hacl.Streaming.Interface_interpretation_Tm_arrow_b21442048f6750654f0f5992659ef521",
         "Hacl.Streaming.Interface_interpretation_Tm_arrow_d11159514572a3537a8cf4204e785738",
-        "Hacl.Streaming.Interface_interpretation_Tm_arrow_e83b1ab9b9efe974fec250f7a2122e5a",
         "b2t_def", "bool_inversion", "bool_typing",
         "constructor_distinct_FStar.Integers.Signed",
         "constructor_distinct_FStar.Integers.Winfinite",
         "equality_tok_FStar.Integers.Winfinite@tok",
         "equation_FStar.Int.Cast.uint32_to_uint64",
         "equation_FStar.Integers.int_t",
-        "equation_FStar.Pervasives.Native.fst", "equation_FStar.UInt.fits",
-        "equation_FStar.UInt.gt", "equation_FStar.UInt.max_int",
-        "equation_FStar.UInt.min_int", "equation_FStar.UInt.mod",
-        "equation_FStar.UInt.size", "equation_FStar.UInt.uint_t",
+        "equation_FStar.Pervasives.Native.fst", "equation_FStar.UInt.eq",
+        "equation_FStar.UInt.fits", "equation_FStar.UInt.gt",
+        "equation_FStar.UInt.max_int", "equation_FStar.UInt.min_int",
+        "equation_FStar.UInt.mod", "equation_FStar.UInt.size",
+        "equation_FStar.UInt.uint_t", "equation_FStar.UInt64.eq",
         "equation_FStar.UInt64.gt",
         "equation_Hacl.Streaming.Functor.add_len",
         "equation_Hacl.Streaming.Functor.rest",
@@ -1331,10 +1321,8 @@
         "equation_Prims.nat", "equation_Prims.pos", "equation_Prims.squash",
         "fuel_guarded_inversion_Hacl.Streaming.Interface.block",
         "function_token_typing_Hacl.Streaming.Interface.__proj__Block__item__blocks_state_len",
-        "function_token_typing_Hacl.Streaming.Interface.__proj__Block__item__max_input_length",
         "int_inversion", "int_typing", "l_and-interp",
-        "lemma_FStar.UInt.pow2_values", "lemma_FStar.UInt32.uv_inv",
-        "lemma_FStar.UInt64.uv_inv", "lemma_FStar.UInt64.vu_inv",
+        "lemma_FStar.UInt32.uv_inv", "lemma_FStar.UInt64.uv_inv",
         "primitive_Prims.op_Addition", "primitive_Prims.op_AmpAmp",
         "primitive_Prims.op_Division", "primitive_Prims.op_Equality",
         "primitive_Prims.op_GreaterThan",
@@ -1349,24 +1337,21 @@
         "refinement_interpretation_Tm_refine_06f2bf4950bb76094f7b7f43daea2409",
         "refinement_interpretation_Tm_refine_2de20c066034c13bf76e9c0b94f4806c",
         "refinement_interpretation_Tm_refine_362e2dfd5fc10941f1049c892a15d4e9",
-        "refinement_interpretation_Tm_refine_48c1b5b4c02ad49f0760911a9d4b1fb4",
         "refinement_interpretation_Tm_refine_505e38c43a22cb1838b480b2d5f14cdb",
         "refinement_interpretation_Tm_refine_542f9d4f129664613f2483a6c88bc7c2",
         "refinement_interpretation_Tm_refine_709aff84c75b0fff77dcbf3b529649dd",
         "refinement_interpretation_Tm_refine_774ba3f728d91ead8ef40be66c9802e5",
-        "refinement_interpretation_Tm_refine_88fb557a2abe191d24589fc827f0535c",
         "refinement_interpretation_Tm_refine_9239da84efb2ef57317a8ef1dd12bd83",
         "refinement_interpretation_Tm_refine_94d25b6e0041d543efd58300424ecc37",
-        "refinement_interpretation_Tm_refine_a3e91433acc705e2c7f5ab6f610b2493",
+        "refinement_interpretation_Tm_refine_bc552b2c624e2add758b3ac761c0c563",
         "refinement_interpretation_Tm_refine_bf67d3e28cde358513c77973f30f2bd9",
         "refinement_interpretation_Tm_refine_d15a9766d4c1ec94d1574f05b54a618b",
         "refinement_interpretation_Tm_refine_eb435d983f25b2ac1b6f98caeb4b3f9b",
         "refinement_interpretation_Tm_refine_ee39f9357cbd63bb5cf348fb8515eff7",
         "refinement_interpretation_Tm_refine_f13070840248fced9d9d60d77bdae3ec",
-        "typing_FStar.Int.Cast.uint32_to_uint64",
-        "typing_FStar.Int.Cast.uint64_to_uint32", "typing_FStar.UInt.fits",
+        "typing_FStar.Int.Cast.uint32_to_uint64", "typing_FStar.UInt.fits",
         "typing_FStar.UInt32.add", "typing_FStar.UInt32.v",
-        "typing_FStar.UInt64.rem", "typing_FStar.UInt64.uint_to_t",
+        "typing_FStar.UInt64.add", "typing_FStar.UInt64.rem",
         "typing_FStar.UInt64.v", "typing_Hacl.Streaming.Functor.add_len",
         "typing_Hacl.Streaming.Functor.rest",
         "typing_Hacl.Streaming.Spec.split_at_last_num_blocks",
@@ -1374,7 +1359,7 @@
         "typing_Lib.UpdateMulti.split_at_last_nb_rem"
       ],
       0,
-      "79f8c393677e9987a6fa40277cc28da4"
+      "b6afd19675c73d7dcf3cebb8a33c413c"
     ],
     [
       "Hacl.Streaming.Functor.update_small",
@@ -1387,7 +1372,7 @@
         "refinement_interpretation_Tm_refine_eed61e872c76c9d08d9c5e037b1dc22d"
       ],
       0,
-      "bfbae8064d85923da859f27992d01733"
+      "b680aaecda86fea193c652dfd0e20b36"
     ],
     [
       "Hacl.Streaming.Functor.split_at_last_rest_eq",
@@ -1426,7 +1411,7 @@
         "typing_Hacl.Streaming.Spec.split_at_last_num_blocks"
       ],
       0,
-      "7633fc0cbb2d2ac4cad2e0e836528283"
+      "71c4f0efe94bc6ee66012eaf27b4b985"
     ],
     [
       "Hacl.Streaming.Functor.update_small",
@@ -1450,10 +1435,12 @@
         "equation_FStar.Monotonic.HyperStack.mem",
         "equation_FStar.Monotonic.HyperStack.modifies",
         "equation_FStar.Pervasives.Native.fst",
-        "equation_FStar.Seq.Properties.split", "equation_FStar.UInt.fits",
+        "equation_FStar.Seq.Properties.split", "equation_FStar.UInt.eq",
+        "equation_FStar.UInt.fits", "equation_FStar.UInt.gt",
         "equation_FStar.UInt.max_int", "equation_FStar.UInt.min_int",
         "equation_FStar.UInt.mod", "equation_FStar.UInt.size",
-        "equation_FStar.UInt.uint_t",
+        "equation_FStar.UInt.uint_t", "equation_FStar.UInt64.eq",
+        "equation_FStar.UInt64.gt",
         "equation_Hacl.Streaming.Functor.add_len",
         "equation_Hacl.Streaming.Functor.bytes",
         "equation_Hacl.Streaming.Functor.footprint",
@@ -1519,12 +1506,14 @@
         "lemma_FStar.Seq.Properties.slice_length",
         "lemma_FStar.Seq.Properties.slice_slice",
         "lemma_FStar.Set.mem_complement", "lemma_FStar.Set.mem_empty",
-        "lemma_FStar.Set.mem_subset", "lemma_FStar.UInt32.vu_inv",
-        "lemma_FStar.UInt64.uv_inv", "lemma_FStar.UInt64.vu_inv",
+        "lemma_FStar.Set.mem_subset", "lemma_FStar.UInt32.uv_inv",
+        "lemma_FStar.UInt32.vu_inv", "lemma_FStar.UInt64.uv_inv",
+        "lemma_FStar.UInt64.vu_inv",
         "lemma_LowStar.Monotonic.Buffer.address_liveness_insensitive_buffer",
         "lemma_LowStar.Monotonic.Buffer.as_addr_gsub",
         "lemma_LowStar.Monotonic.Buffer.as_seq_gsub",
         "lemma_LowStar.Monotonic.Buffer.frameOf_gsub",
+        "lemma_LowStar.Monotonic.Buffer.lemma_live_equal_mem_domains",
         "lemma_LowStar.Monotonic.Buffer.len_gsub",
         "lemma_LowStar.Monotonic.Buffer.length_as_seq",
         "lemma_LowStar.Monotonic.Buffer.length_null_1",
@@ -1541,7 +1530,6 @@
         "lemma_LowStar.Monotonic.Buffer.loc_includes_trans_backwards",
         "lemma_LowStar.Monotonic.Buffer.loc_includes_union_l_",
         "lemma_LowStar.Monotonic.Buffer.loc_union_comm",
-        "lemma_LowStar.Monotonic.Buffer.loc_union_idem",
         "lemma_LowStar.Monotonic.Buffer.modifies_buffer_elim",
         "lemma_LowStar.Monotonic.Buffer.modifies_liveness_insensitive_buffer_weak",
         "lemma_LowStar.Monotonic.Buffer.modifies_loc_includes",
@@ -1549,6 +1537,7 @@
         "lemma_LowStar.Monotonic.Buffer.modifies_trans_linear",
         "primitive_Prims.op_Addition", "primitive_Prims.op_AmpAmp",
         "primitive_Prims.op_BarBar", "primitive_Prims.op_Equality",
+        "primitive_Prims.op_GreaterThan",
         "primitive_Prims.op_LessThanOrEqual", "primitive_Prims.op_Modulus",
         "primitive_Prims.op_Multiply", "primitive_Prims.op_Negation",
         "primitive_Prims.op_Subtraction",
@@ -1601,7 +1590,6 @@
         "refinement_interpretation_Tm_refine_d3d07693cd71377864ef84dc97d10ec1",
         "refinement_interpretation_Tm_refine_d83f8da8ef6c1cb9f71d1465c1bb1c55",
         "refinement_interpretation_Tm_refine_eb435d983f25b2ac1b6f98caeb4b3f9b",
-        "refinement_interpretation_Tm_refine_ee39f9357cbd63bb5cf348fb8515eff7",
         "refinement_interpretation_Tm_refine_eed61e872c76c9d08d9c5e037b1dc22d",
         "refinement_interpretation_Tm_refine_f13070840248fced9d9d60d77bdae3ec",
         "refinement_kinding_Tm_refine_542f9d4f129664613f2483a6c88bc7c2",
@@ -1634,7 +1622,6 @@
         "typing_Hacl.Streaming.Spec.split_at_last",
         "typing_Hacl.Streaming.Spec.split_at_last_num_blocks",
         "typing_Lib.UpdateMulti.split_at_last_lazy",
-        "typing_Lib.UpdateMulti.split_at_last_lazy_nb_rem",
         "typing_Lib.UpdateMulti.split_at_last_nb_rem",
         "typing_LowStar.Buffer.trivial_preorder",
         "typing_LowStar.Monotonic.Buffer.as_addr",
@@ -1647,7 +1634,7 @@
         "typing_LowStar.Monotonic.Buffer.loc_union"
       ],
       0,
-      "75dea835083e88a37be36d3a25e4a343"
+      "172a66bb0e06d6773e75152c7733fb67"
     ],
     [
       "Hacl.Streaming.Functor.update_empty_or_full_buf",
@@ -1685,7 +1672,7 @@
         "typing_FStar.UInt32.t"
       ],
       0,
-      "a909cb6979ce91566f76d629a04585e3"
+      "2a3209516dd258b204a10f87fb0f63a9"
     ],
     [
       "Hacl.Streaming.Functor.update_empty_or_full_buf",
@@ -1693,17 +1680,13 @@
       0,
       0,
       [
-        "@MaxIFuel_assumption",
-        "@fuel_correspondence_Prims.pow2.fuel_instrumented", "@query",
-        "FStar.UInt32_pretyping_2ab3c8ba2d08b0172817fc70b5994868",
+        "@MaxIFuel_assumption", "@query",
         "Hacl.Streaming.Interface_interpretation_Tm_arrow_011e939061623ee15fa4a0d456ecdd81",
         "Hacl.Streaming.Interface_interpretation_Tm_arrow_5daade47d6db9948d24a098f692af064",
         "Hacl.Streaming.Interface_interpretation_Tm_arrow_7b1dc8185f03eadbcc027104ec62ed38",
-        "Hacl.Streaming.Interface_interpretation_Tm_arrow_a11ec6dec41dedfeb9e6586c8b3c1c34",
         "Hacl.Streaming.Interface_interpretation_Tm_arrow_d11159514572a3537a8cf4204e785738",
         "Hacl.Streaming.Interface_interpretation_Tm_arrow_e83b1ab9b9efe974fec250f7a2122e5a",
         "Hacl.Streaming.Interface_interpretation_Tm_ghost_arrow_ad10d34bc7178b69bbaeb4c1e041c6da",
-        "Prims_interpretation_Tm_arrow_2eaa01e78f73e9bab5d0955fc1a662da",
         "Prims_pretyping_ae567c2fb75be05905677af440075565", "b2t_def",
         "bool_inversion", "bool_typing",
         "constructor_distinct_FStar.Integers.Signed",
@@ -1732,7 +1715,6 @@
         "equation_Hacl.Streaming.Functor.optional_footprint",
         "equation_Hacl.Streaming.Functor.optional_freeable",
         "equation_Hacl.Streaming.Functor.optional_invariant",
-        "equation_Hacl.Streaming.Functor.optional_reveal",
         "equation_Hacl.Streaming.Functor.preserves_freeable",
         "equation_Hacl.Streaming.Functor.rest",
         "equation_Hacl.Streaming.Functor.seen",
@@ -1767,7 +1749,7 @@
         "int_typing",
         "interpretation_Tm_abs_612136ee4143d24977831c80e4f470a1",
         "kinding_Hacl.Streaming.Functor.state_s@tok", "l_and-interp",
-        "lemma_FStar.Ghost.hide_reveal", "lemma_FStar.Ghost.reveal_hide",
+        "lemma_FStar.Ghost.reveal_hide",
         "lemma_FStar.HyperStack.ST.lemma_equal_domains_trans",
         "lemma_FStar.Seq.Base.lemma_eq_elim",
         "lemma_FStar.Seq.Base.lemma_index_create",
@@ -1829,7 +1811,6 @@
         "refinement_interpretation_Tm_refine_0ea1fba779ad5718e28476faeef94d56",
         "refinement_interpretation_Tm_refine_18d7c8750c82f0db97a6c5369714adc4",
         "refinement_interpretation_Tm_refine_1ba8fd8bb363097813064c67740b2de5",
-        "refinement_interpretation_Tm_refine_1ccfb21903aa30ace8832f7a4d067d9b",
         "refinement_interpretation_Tm_refine_282b371e484f60711d2ac598c6e009a2",
         "refinement_interpretation_Tm_refine_2d7a69447bcff867a8adb2610ca1ad43",
         "refinement_interpretation_Tm_refine_2dad1c55090cb3266e67d003d40344d3",
@@ -1847,7 +1828,6 @@
         "refinement_interpretation_Tm_refine_94d25b6e0041d543efd58300424ecc37",
         "refinement_interpretation_Tm_refine_9e7f68c38e43484e77069094f4fd88d3",
         "refinement_interpretation_Tm_refine_a997f7fc0ee9057c4f6335ecd3b55d00",
-        "refinement_interpretation_Tm_refine_aa4b3d268075d84252df525db1f85524",
         "refinement_interpretation_Tm_refine_c1424615841f28cac7fc34e92b7ff33c",
         "refinement_interpretation_Tm_refine_c79377e4df5a6931d57c833f9aaaa3cc",
         "refinement_interpretation_Tm_refine_cc936e5a549dcdc2e3f9713145143490",
@@ -1858,33 +1838,27 @@
         "refinement_interpretation_Tm_refine_eed61e872c76c9d08d9c5e037b1dc22d",
         "refinement_interpretation_Tm_refine_f13070840248fced9d9d60d77bdae3ec",
         "refinement_kinding_Tm_refine_542f9d4f129664613f2483a6c88bc7c2",
-        "token_correspondence_Hacl.Streaming.Interface.__proj__Block__item__init_s",
         "token_correspondence_Hacl.Streaming.Interface.__proj__Block__item__max_input_length",
         "token_correspondence_Hacl.Streaming.Interface.__proj__Stateful__item__footprint",
         "token_correspondence_Hacl.Streaming.Interface.__proj__Stateful__item__s",
-        "token_correspondence_Hacl.Streaming.Interface.__proj__Stateful__item__t",
         "true_interp", "typing_FStar.Ghost.reveal",
         "typing_FStar.Int.Cast.uint32_to_uint64",
         "typing_FStar.Monotonic.HyperStack.live_region",
         "typing_FStar.Seq.Base.append", "typing_FStar.Seq.Base.create",
         "typing_FStar.Seq.Base.length", "typing_FStar.Seq.Base.slice",
         "typing_FStar.Set.singleton", "typing_FStar.UInt.fits",
-        "typing_FStar.UInt32.mul", "typing_FStar.UInt32.sub",
-        "typing_FStar.UInt32.t", "typing_FStar.UInt32.uint_to_t",
-        "typing_FStar.UInt32.v", "typing_FStar.UInt64.rem",
-        "typing_FStar.UInt64.v", "typing_Hacl.Streaming.Functor.footprint",
+        "typing_FStar.UInt32.uint_to_t", "typing_FStar.UInt32.v",
+        "typing_FStar.UInt64.rem", "typing_FStar.UInt64.v",
+        "typing_Hacl.Streaming.Functor.footprint",
         "typing_Hacl.Streaming.Functor.nblocks",
         "typing_Hacl.Streaming.Functor.optional_footprint",
-        "typing_Hacl.Streaming.Functor.optional_reveal",
         "typing_Hacl.Streaming.Functor.rest",
         "typing_Hacl.Streaming.Functor.seen",
-        "typing_Hacl.Streaming.Interface.__proj__Block__item__init_s",
         "typing_Hacl.Streaming.Interface.__proj__Block__item__key",
         "typing_Hacl.Streaming.Interface.__proj__Block__item__km",
         "typing_Hacl.Streaming.Interface.__proj__Block__item__max_input_length",
         "typing_Hacl.Streaming.Interface.__proj__Block__item__state",
         "typing_Hacl.Streaming.Interface.__proj__Stateful__item__footprint",
-        "typing_Hacl.Streaming.Interface.__proj__Stateful__item__t",
         "typing_Hacl.Streaming.Interface.optional_key",
         "typing_Hacl.Streaming.Spec.split_at_last",
         "typing_Hacl.Streaming.Spec.split_at_last_num_blocks",
@@ -1901,7 +1875,7 @@
         "typing_LowStar.Monotonic.Buffer.loc_union"
       ],
       0,
-      "670ad605dc48b81c88c5d2199745bce8"
+      "af0f6a2063735cf55777b58bfc562544"
     ],
     [
       "Hacl.Streaming.Functor.update_round",
@@ -1918,7 +1892,7 @@
         "refinement_interpretation_Tm_refine_eed61e872c76c9d08d9c5e037b1dc22d"
       ],
       0,
-      "75f7bb2d9bac02ddc54a696b8e88ec2a"
+      "296f3673befc4a22c492ff3b87a85107"
     ],
     [
       "Hacl.Streaming.Functor.update_round",
@@ -1937,7 +1911,8 @@
         "equation_FStar.Int.Cast.uint32_to_uint64",
         "equation_FStar.Integers.int_t",
         "equation_FStar.Pervasives.Native.fst",
-        "equation_FStar.Seq.Properties.split", "equation_FStar.UInt.uint_t",
+        "equation_FStar.Seq.Properties.split", "equation_FStar.UInt.mod",
+        "equation_FStar.UInt.uint_t",
         "equation_Hacl.Streaming.Functor.bytes",
         "equation_Hacl.Streaming.Functor.invariant",
         "equation_Hacl.Streaming.Functor.invariant_s",
@@ -1976,8 +1951,7 @@
         "lemma_LowStar.Monotonic.Buffer.length_null_1",
         "lemma_LowStar.Monotonic.Buffer.length_null_2",
         "primitive_Prims.op_Addition", "primitive_Prims.op_AmpAmp",
-        "primitive_Prims.op_Division", "primitive_Prims.op_Equality",
-        "primitive_Prims.op_GreaterThan",
+        "primitive_Prims.op_Equality", "primitive_Prims.op_GreaterThan",
         "primitive_Prims.op_LessThanOrEqual", "primitive_Prims.op_Modulus",
         "primitive_Prims.op_Multiply", "primitive_Prims.op_Subtraction",
         "proj_equation_FStar.Pervasives.Native.Mktuple2__1",
@@ -1989,6 +1963,7 @@
         "projection_inverse_FStar.Pervasives.Native.Mktuple2__1",
         "projection_inverse_FStar.Pervasives.Native.Mktuple2__2",
         "refinement_interpretation_Tm_refine_02951fd03552320d928a2182ed63fa53",
+        "refinement_interpretation_Tm_refine_06f2bf4950bb76094f7b7f43daea2409",
         "refinement_interpretation_Tm_refine_1a3484a55eb64d985e34b4eae5150027",
         "refinement_interpretation_Tm_refine_282b371e484f60711d2ac598c6e009a2",
         "refinement_interpretation_Tm_refine_2dad1c55090cb3266e67d003d40344d3",
@@ -2002,6 +1977,7 @@
         "refinement_interpretation_Tm_refine_81407705a0828c2c1b1976675443f647",
         "refinement_interpretation_Tm_refine_90a1661541e4f009452ab107b47b5955",
         "refinement_interpretation_Tm_refine_9239da84efb2ef57317a8ef1dd12bd83",
+        "refinement_interpretation_Tm_refine_94d25b6e0041d543efd58300424ecc37",
         "refinement_interpretation_Tm_refine_9e7f68c38e43484e77069094f4fd88d3",
         "refinement_interpretation_Tm_refine_a997f7fc0ee9057c4f6335ecd3b55d00",
         "refinement_interpretation_Tm_refine_cc20949c516a329fa2165984ecd0ed6c",
@@ -2017,6 +1993,7 @@
         "typing_FStar.Int.Cast.uint32_to_uint64",
         "typing_FStar.Seq.Base.append", "typing_FStar.Seq.Base.length",
         "typing_FStar.Seq.Base.slice", "typing_FStar.UInt32.v",
+        "typing_FStar.UInt64.rem", "typing_FStar.UInt64.v",
         "typing_Hacl.Streaming.Functor.rest",
         "typing_Hacl.Streaming.Functor.seen",
         "typing_Hacl.Streaming.Functor.total_len_h",
@@ -2029,11 +2006,10 @@
         "typing_Lib.UpdateMulti.split_at_last_lazy",
         "typing_Lib.UpdateMulti.split_at_last_lazy_nb_rem",
         "typing_Lib.UpdateMulti.split_at_last_nb_rem",
-        "typing_LowStar.Buffer.trivial_preorder",
-        "typing_LowStar.Monotonic.Buffer.length"
+        "typing_LowStar.Buffer.trivial_preorder"
       ],
       0,
-      "ee6e9740a0f82806cd407f05db201da1"
+      "872087fa05131e7aba980dc3146af6fb"
     ],
     [
       "Hacl.Streaming.Functor.update",
@@ -2045,11 +2021,9 @@
         "FStar.UInt32_pretyping_2ab3c8ba2d08b0172817fc70b5994868",
         "Hacl.Streaming.Interface_interpretation_Tm_arrow_5daade47d6db9948d24a098f692af064",
         "Hacl.Streaming.Interface_interpretation_Tm_arrow_d11159514572a3537a8cf4204e785738",
-        "Prims_pretyping_ae567c2fb75be05905677af440075565", "b2t_def",
-        "bool_inversion", "bool_typing",
+        "b2t_def", "bool_inversion", "bool_typing",
         "equation_FStar.Int.Cast.uint32_to_uint64",
-        "equation_FStar.Pervasives.Native.fst",
-        "equation_FStar.Seq.Properties.split", "equation_FStar.UInt.fits",
+        "equation_FStar.Pervasives.Native.fst", "equation_FStar.UInt.fits",
         "equation_FStar.UInt.lte", "equation_FStar.UInt.max_int",
         "equation_FStar.UInt.min_int", "equation_FStar.UInt.size",
         "equation_FStar.UInt.uint_t", "equation_FStar.UInt32.lte",
@@ -2069,7 +2043,6 @@
         "equation_Hacl.Streaming.Spec.split_at_last",
         "equation_Hacl.Streaming.Spec.split_at_last_num_blocks",
         "equation_Hacl.Streaming.Spec.uint8", "equation_Lib.IntTypes.uint8",
-        "equation_Lib.UpdateMulti.split_at_last_lazy",
         "equation_Lib.UpdateMulti.split_at_last_lazy_nb_rem",
         "equation_Lib.UpdateMulti.split_at_last_nb_rem",
         "equation_Lib.UpdateMulti.uint8", "equation_LowStar.Buffer.buffer",
@@ -2083,7 +2056,6 @@
         "function_token_typing_Hacl.Streaming.Spec.bytes",
         "function_token_typing_Lib.IntTypes.uint8",
         "function_token_typing_LowStar.Buffer.trivial_preorder",
-        "function_token_typing_Prims.__cache_version_number__",
         "int_inversion", "int_typing",
         "interpretation_Tm_abs_612136ee4143d24977831c80e4f470a1",
         "l_and-interp", "lemma_FStar.Ghost.hide_reveal",
@@ -2108,9 +2080,9 @@
         "lemma_LowStar.Monotonic.Buffer.modifies_buffer_elim",
         "lemma_LowStar.Monotonic.Buffer.modifies_trans_linear",
         "primitive_Prims.op_Addition", "primitive_Prims.op_AmpAmp",
-        "primitive_Prims.op_Division", "primitive_Prims.op_Equality",
-        "primitive_Prims.op_LessThanOrEqual", "primitive_Prims.op_Modulus",
-        "primitive_Prims.op_Multiply", "primitive_Prims.op_Subtraction",
+        "primitive_Prims.op_Equality", "primitive_Prims.op_LessThanOrEqual",
+        "primitive_Prims.op_Modulus", "primitive_Prims.op_Multiply",
+        "primitive_Prims.op_Subtraction",
         "proj_equation_FStar.Pervasives.Native.Mktuple2__1",
         "proj_equation_Hacl.Streaming.Functor.State_seen",
         "proj_equation_Hacl.Streaming.Functor.State_total_len",
@@ -2162,7 +2134,7 @@
         "unit_typing"
       ],
       0,
-      "6048377896123bc04dc5c2b31bd311bc"
+      "71aa8f27802000fe41a6879dafb86c24"
     ],
     [
       "Hacl.Streaming.Functor.finish_st",
@@ -2179,7 +2151,7 @@
         "refinement_interpretation_Tm_refine_a997f7fc0ee9057c4f6335ecd3b55d00"
       ],
       0,
-      "d65fab8a2bc385ff6986d8c123813845"
+      "f5ce3e9da3f5bb878c411d553a79f14c"
     ],
     [
       "Hacl.Streaming.Functor.mk_finish",
@@ -2187,9 +2159,8 @@
       0,
       0,
       [
-        "@MaxFuel_assumption", "@MaxIFuel_assumption",
+        "@MaxIFuel_assumption",
         "@fuel_correspondence_Prims.pow2.fuel_instrumented", "@query",
-        "FStar.UInt32_pretyping_2ab3c8ba2d08b0172817fc70b5994868",
         "Hacl.Streaming.Interface_interpretation_Tm_arrow_011e939061623ee15fa4a0d456ecdd81",
         "Hacl.Streaming.Interface_interpretation_Tm_arrow_5daade47d6db9948d24a098f692af064",
         "Hacl.Streaming.Interface_interpretation_Tm_arrow_7b1dc8185f03eadbcc027104ec62ed38",
@@ -2268,13 +2239,14 @@
         "function_token_typing_Hacl.Streaming.Spec.bytes",
         "function_token_typing_Lib.IntTypes.uint8",
         "function_token_typing_LowStar.Buffer.trivial_preorder",
+        "function_token_typing_LowStar.Monotonic.Buffer.mgsub",
         "function_token_typing_Prims.__cache_version_number__",
         "function_token_typing_Prims.int",
         "haseqTm_refine_542f9d4f129664613f2483a6c88bc7c2", "int_inversion",
         "int_typing",
         "interpretation_Tm_abs_612136ee4143d24977831c80e4f470a1",
         "inversion-interp", "kinding_Hacl.Streaming.Functor.state_s@tok",
-        "l_and-interp", "lemma_FStar.Ghost.reveal_hide",
+        "l_and-interp",
         "lemma_FStar.HyperStack.ST.lemma_equal_domains_trans",
         "lemma_FStar.HyperStack.ST.lemma_same_refs_in_all_regions_elim",
         "lemma_FStar.HyperStack.ST.lemma_same_refs_in_all_regions_intro",
@@ -2301,15 +2273,12 @@
         "lemma_FStar.Set.lemma_equal_intro",
         "lemma_FStar.Set.mem_complement", "lemma_FStar.Set.mem_intersect",
         "lemma_FStar.Set.mem_singleton", "lemma_FStar.Set.mem_subset",
-        "lemma_FStar.Set.mem_union", "lemma_FStar.UInt.pow2_values",
-        "lemma_FStar.UInt32.uv_inv", "lemma_FStar.UInt32.vu_inv",
-        "lemma_FStar.UInt64.uv_inv",
+        "lemma_FStar.Set.mem_union", "lemma_FStar.UInt32.uv_inv",
+        "lemma_FStar.UInt32.vu_inv", "lemma_FStar.UInt64.uv_inv",
         "lemma_Hacl.Streaming.Functor.frame_invariant",
         "lemma_Hacl.Streaming.Functor.invariant_loc_in_footprint",
         "lemma_LowStar.Monotonic.Buffer.address_liveness_insensitive_buffer",
-        "lemma_LowStar.Monotonic.Buffer.as_addr_gsub",
         "lemma_LowStar.Monotonic.Buffer.as_seq_gsub",
-        "lemma_LowStar.Monotonic.Buffer.frameOf_gsub",
         "lemma_LowStar.Monotonic.Buffer.fresh_frame_loc_not_unused_in_disjoint",
         "lemma_LowStar.Monotonic.Buffer.fresh_frame_modifies",
         "lemma_LowStar.Monotonic.Buffer.gsub_gsub",
@@ -2366,12 +2335,14 @@
         "projection_inverse_Hacl.Streaming.Functor.State_total_len",
         "refinement_interpretation_Tm_refine_02951fd03552320d928a2182ed63fa53",
         "refinement_interpretation_Tm_refine_05e15190c946858f68c69156f585f95a",
+        "refinement_interpretation_Tm_refine_06f2bf4950bb76094f7b7f43daea2409",
         "refinement_interpretation_Tm_refine_0859070c7f6625cbbba72f82b97fb4e2",
         "refinement_interpretation_Tm_refine_0900fdafd6f988fc582c6dc5286385c7",
         "refinement_interpretation_Tm_refine_0941c9ff95557f2d53bc8f8179ab793e",
         "refinement_interpretation_Tm_refine_0ea1fba779ad5718e28476faeef94d56",
         "refinement_interpretation_Tm_refine_19ac6a052799e5086e9c3eb3a21d54a5",
         "refinement_interpretation_Tm_refine_1ba8fd8bb363097813064c67740b2de5",
+        "refinement_interpretation_Tm_refine_2a3c8348dea0f60c78266e1db4f49210",
         "refinement_interpretation_Tm_refine_2dad1c55090cb3266e67d003d40344d3",
         "refinement_interpretation_Tm_refine_2de20c066034c13bf76e9c0b94f4806c",
         "refinement_interpretation_Tm_refine_35a0739c434508f48d0bb1d5cd5df9e8",
@@ -2385,11 +2356,11 @@
         "refinement_interpretation_Tm_refine_66ffa57fc47893a5c0e06969206a8610",
         "refinement_interpretation_Tm_refine_709aff84c75b0fff77dcbf3b529649dd",
         "refinement_interpretation_Tm_refine_774ba3f728d91ead8ef40be66c9802e5",
-        "refinement_interpretation_Tm_refine_7fcf0b553d1122f1436b22dd0d3044fe",
         "refinement_interpretation_Tm_refine_81407705a0828c2c1b1976675443f647",
         "refinement_interpretation_Tm_refine_88fb557a2abe191d24589fc827f0535c",
         "refinement_interpretation_Tm_refine_90a1661541e4f009452ab107b47b5955",
         "refinement_interpretation_Tm_refine_9239da84efb2ef57317a8ef1dd12bd83",
+        "refinement_interpretation_Tm_refine_94d25b6e0041d543efd58300424ecc37",
         "refinement_interpretation_Tm_refine_967d9abf7da1030baab9f914327b8ccf",
         "refinement_interpretation_Tm_refine_9e7f68c38e43484e77069094f4fd88d3",
         "refinement_interpretation_Tm_refine_a1b19d4eb558917d602bf2d63ffec24f",
@@ -2430,7 +2401,8 @@
         "typing_FStar.Set.union", "typing_FStar.UInt.fits",
         "typing_FStar.UInt32.add", "typing_FStar.UInt32.rem",
         "typing_FStar.UInt32.t", "typing_FStar.UInt32.uint_to_t",
-        "typing_FStar.UInt32.v", "typing_Hacl.Streaming.Functor.footprint",
+        "typing_FStar.UInt32.v", "typing_FStar.UInt64.rem",
+        "typing_Hacl.Streaming.Functor.footprint",
         "typing_Hacl.Streaming.Functor.optional_footprint",
         "typing_Hacl.Streaming.Interface.__proj__Block__item__key",
         "typing_Hacl.Streaming.Interface.__proj__Block__item__km",
@@ -2459,7 +2431,7 @@
         "typing_tok_Hacl.Streaming.Interface.Erased@tok"
       ],
       0,
-      "aed68e1e7117dcf1282fd72ae04e4b3e"
+      "f1367ebc482d72e87caa69d332354415"
     ],
     [
       "Hacl.Streaming.Functor.free_st",
@@ -2472,7 +2444,7 @@
         "refinement_interpretation_Tm_refine_a997f7fc0ee9057c4f6335ecd3b55d00"
       ],
       0,
-      "2e555a3232d467ee12959cc076207570"
+      "816e0468116053a411d71020f9d937ea"
     ],
     [
       "Hacl.Streaming.Functor.free",
@@ -2573,7 +2545,7 @@
         "typing_LowStar.Monotonic.Buffer.loc_union"
       ],
       0,
-      "02cb1f12c03f239783e3948d5eed8026"
+      "acee4e9c6dc4f39ee767d01d076fd715"
     ]
   ]
 ]

--- a/hints/Hacl.Streaming.Functor.fst.hints
+++ b/hints/Hacl.Streaming.Functor.fst.hints
@@ -1,5 +1,5 @@
 [
-  "-/3+}xtÌh#‚\n»*ø\u0017",
+  "(Fr™p’6\u007fJ–ƒ=uctp",
   [
     [
       "Hacl.Streaming.Functor.optional_freeable",
@@ -1504,7 +1504,6 @@
         "lemma_FStar.Seq.Base.lemma_len_slice",
         "lemma_FStar.Seq.Properties.slice_is_empty",
         "lemma_FStar.Seq.Properties.slice_length",
-        "lemma_FStar.Seq.Properties.slice_slice",
         "lemma_FStar.Set.mem_complement", "lemma_FStar.Set.mem_empty",
         "lemma_FStar.Set.mem_subset", "lemma_FStar.UInt32.uv_inv",
         "lemma_FStar.UInt32.vu_inv", "lemma_FStar.UInt64.uv_inv",
@@ -1563,7 +1562,6 @@
         "refinement_interpretation_Tm_refine_06f2bf4950bb76094f7b7f43daea2409",
         "refinement_interpretation_Tm_refine_0ea1fba779ad5718e28476faeef94d56",
         "refinement_interpretation_Tm_refine_18d7c8750c82f0db97a6c5369714adc4",
-        "refinement_interpretation_Tm_refine_1ba8fd8bb363097813064c67740b2de5",
         "refinement_interpretation_Tm_refine_282b371e484f60711d2ac598c6e009a2",
         "refinement_interpretation_Tm_refine_2dad1c55090cb3266e67d003d40344d3",
         "refinement_interpretation_Tm_refine_35a0739c434508f48d0bb1d5cd5df9e8",
@@ -1634,7 +1632,7 @@
         "typing_LowStar.Monotonic.Buffer.loc_union"
       ],
       0,
-      "172a66bb0e06d6773e75152c7733fb67"
+      "2d294cea34797a657acb2cfa418a7417"
     ],
     [
       "Hacl.Streaming.Functor.update_empty_or_full_buf",


### PR DESCRIPTION
CI is currently failing on two proofs: one in streaming, one in Karatsuba. This should fix the streaming one.

The remaining one is then:

```
[STDERR]/home/everest/everest/hacl-star/code/bignum/Hacl.Spec.Karatsuba.Lemmas.fst(78,2-103,4): (Error 16) Unknown assertion failed
[STDERR]        SMT solver says:
[STDERR]        unknown because canceled (fuel=0; ifuel=0);
[STDERR]        unknown because canceled (fuel=0; ifuel=0; with hint);
[STDERR]        Note: 'canceled' or 'resource limits reached' means the SMT query timed out, so you might want to increase the rlimit;
[STDERR]        'incomplete quantifiers' means Z3 could not prove the query, so try to spell your proof out in greater detail, increase fuel or ifuel
[STDERR]        'unknown' means Z3 provided no further reason for the proof failing
```

@polubelova once you're back from holiday time off, if you have time to look at this failure that'd be really great. Feel free to push on top of this PR to confirm we get a green. Thanks!