### PR TITLE
Nix flake

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,4 @@ dist/wasm/*.wast
 doc/_build
 config.h
 *.smt2
+flake.lock

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,21 @@
+{
+  inputs = {
+    fstar-src.url     = github:fstarlang/fstar?ref=master;
+    fstar-src.flake   = false;
+    karamel-src.url   = github:fstarlang/karamel?ref=master;
+    karamel-src.flake = false;
+    
+    everest = {
+      url = github:project-everest/everest-nix?dir=projects;
+      inputs.fstar-src.follows    = "fstar-src";
+      inputs.karamel-src.follows  = "karamel-src";
+      # `/` means `self` (see NixOS/nix#4931)
+      inputs.hacl-src.follows     = "/";
+    };
+
+    flake-utils.url = "flake-utils";
+    nixpkgs.url = "nixpkgs";
+  };
+
+  outputs = {everest, ...}: everest;
+}


### PR DESCRIPTION
Hi,
This PR adds support for building Everest with Nix (on which we've been working with @pnmadelaine), via a Nix expression that lives in https://github.com/project-everest/everest-nix. This is useful for the (upcoming) CI.

Note that dependencies to specific branches of F* or KaRaMeL can be specified by replacing `master` by any other git reference in the field `fstar-src.url` and `karamel-src.url`.