### PR TITLE
Add support for Blake2b/Blake2s optimized versions in EverCrypt.Hash

### DIFF
--- a/code/hash/Hacl.Hash.Blake2.fst
+++ b/code/hash/Hacl.Hash.Blake2.fst
@@ -235,8 +235,14 @@ let mk_update_last_ a m update_multi blake2_update_last_block s ev prev_len inpu
 let update_multi_blake2s_32 =
   mk_update_multi Blake2S Core.M32 update_blake2s_32
 
+let update_multi_blake2s_128 =
+  mk_update_multi Blake2S Core.M128 update_blake2s_128
+
 let update_multi_blake2b_32 =
   mk_update_multi Blake2B Core.M32 update_blake2b_32
+
+let update_multi_blake2b_256 =
+  mk_update_multi Blake2B Core.M256 update_blake2b_256
 
 let mk_update_last a m update_multi =
   mk_update_last_ a m update_multi (mk_blake2_update_last_block a m)
@@ -245,9 +251,17 @@ let update_last_blake2s_32 =
   mk_update_last_ Blake2S Core.M32 update_multi_blake2s_32
                   (mk_blake2_update_last_block Blake2S Core.M32)
 
+let update_last_blake2s_128 =
+  mk_update_last_ Blake2S Core.M128 update_multi_blake2s_128
+                  (mk_blake2_update_last_block Blake2S Core.M128)
+
 let update_last_blake2b_32 =
   mk_update_last_ Blake2B Core.M32 update_multi_blake2b_32
                   (mk_blake2_update_last_block Blake2B Core.M32)
+
+let update_last_blake2b_256 =
+  mk_update_last_ Blake2B Core.M256 update_multi_blake2b_256
+                  (mk_blake2_update_last_block Blake2B Core.M256)
 
 let mk_hash a m blake2 = fun input input_len dst ->
   let h0 = ST.get() in
@@ -259,4 +273,6 @@ let mk_hash a m blake2 = fun input input_len dst ->
   lemma_blake2_hash_equivalence a (B.as_seq h0 input)
 
 let hash_blake2s_32: hash_st Blake2S = mk_hash Blake2S Core.M32 Hacl.Blake2s_32.blake2s
+let hash_blake2s_128: hash_st Blake2S = mk_hash Blake2S Core.M128 Hacl.Blake2s_128.blake2s
 let hash_blake2b_32: hash_st Blake2B = mk_hash Blake2B Core.M32 Hacl.Blake2b_32.blake2b
+let hash_blake2b_256: hash_st Blake2B = mk_hash Blake2B Core.M256 Hacl.Blake2b_256.blake2b

--- a/code/hash/Hacl.Hash.Blake2.fsti
+++ b/code/hash/Hacl.Hash.Blake2.fsti
@@ -26,7 +26,9 @@ val mk_update_multi:
   update_multi_st (|a, m|)
 
 val update_multi_blake2s_32: update_multi_st (|Blake2S, Blake2.M32|)
+val update_multi_blake2s_128: update_multi_st (|Blake2S, Blake2.M128|)
 val update_multi_blake2b_32: update_multi_st (|Blake2B, Blake2.M32|)
+val update_multi_blake2b_256: update_multi_st (|Blake2B, Blake2.M256|)
 
 noextract inline_for_extraction
 val mk_update_last:
@@ -36,7 +38,9 @@ val mk_update_last:
   update_last_st (|a, m|)
 
 val update_last_blake2s_32: update_last_st (|Blake2S, Blake2.M32|)
+val update_last_blake2s_128: update_last_st (|Blake2S, Blake2.M128|)
 val update_last_blake2b_32: update_last_st (|Blake2B, Blake2.M32|)
+val update_last_blake2b_256: update_last_st (|Blake2B, Blake2.M256|)
 
 noextract inline_for_extraction
 val mk_hash:
@@ -46,4 +50,6 @@ val mk_hash:
   hash_st a
 
 val hash_blake2s_32: hash_st Blake2S
+val hash_blake2s_128: hash_st Blake2S
 val hash_blake2b_32: hash_st Blake2B
+val hash_blake2b_256: hash_st Blake2B

--- a/code/hash/Hacl.Hash.Core.Blake2.fsti
+++ b/code/hash/Hacl.Hash.Core.Blake2.fsti
@@ -18,24 +18,36 @@ val mk_finish (a:hash_alg{is_blake a}) (m:m_spec a) : finish_st (|a, m|)
 
 noextract inline_for_extraction
 val init_blake2s_32: init_st (|Blake2S, Core.M32|)
+noextract inline_for_extraction
+val init_blake2s_128: init_st (|Blake2S, Core.M128|)
 
 noextract inline_for_extraction
 val alloca_blake2s_32: alloca_st (|Blake2S, Core.M32|)
+noextract inline_for_extraction
+val alloca_blake2s_128: alloca_st (|Blake2S, Core.M128|)
 
 val update_blake2s_32: update_st (|Blake2S, Core.M32|)
+val update_blake2s_128: update_st (|Blake2S, Core.M128|)
 val finish_blake2s_32: finish_st (|Blake2S, Core.M32|)
+val finish_blake2s_128: finish_st (|Blake2S, Core.M128|)
 
 noextract inline_for_extraction
 val pad_blake2s: pad_st Blake2S
 
 noextract inline_for_extraction
 val init_blake2b_32: init_st (|Blake2B, Core.M32|)
+noextract inline_for_extraction
+val init_blake2b_256: init_st (|Blake2B, Core.M256|)
 
 noextract inline_for_extraction
 val alloca_blake2b_32: alloca_st (|Blake2B, Core.M32|)
+noextract inline_for_extraction
+val alloca_blake2b_256: alloca_st (|Blake2B, Core.M256|)
 
 val update_blake2b_32: update_st (|Blake2B, Core.M32|)
+val update_blake2b_256: update_st (|Blake2B, Core.M256|)
 val finish_blake2b_32: finish_st (|Blake2B, Core.M32|)
+val finish_blake2b_256: finish_st (|Blake2B, Core.M256|)
 
 noextract inline_for_extraction
 val pad_blake2b: pad_st Blake2B

--- a/providers/evercrypt/fst/EverCrypt.Hash.fst
+++ b/providers/evercrypt/fst/EverCrypt.Hash.fst
@@ -37,20 +37,52 @@ let string_of_alg =
 let uint32_p = B.buffer uint_32
 let uint64_p = B.buffer uint_64
 
-inline_for_extraction noextract
-let blake2_spec = Hacl.Impl.Blake2.Core.M32
+let is_valid_impl (i: impl) =
+  let open Hacl.Impl.Blake2.Core in
+  match i with
+  | (| MD5, () |)
+  | (| SHA1, () |)
+  | (| SHA2_224, () |)
+  | (| SHA2_256, () |)
+  | (| SHA2_384, () |)
+  | (| SHA2_512, () |)
+  | (| Blake2S, M32 |)
+  | (| Blake2S, M128 |)
+  | (| Blake2B, M32 |)
+  | (| Blake2B, M256 |) -> true
+  | _ -> false
+
+let impl = i:impl { is_valid_impl i }
 
 inline_for_extraction noextract
-let impl_of_alg (a:alg) : impl =
-  match a with
-  | MD5 | SHA1 | SHA2_224 | SHA2_256 | SHA2_384 | SHA2_512 -> (|a, ()|)
-  | Blake2S | Blake2B -> (|a, blake2_spec|)
+let md5: impl = (| MD5, () |)
+inline_for_extraction noextract
+let sha1: impl = (| SHA1, () |)
+inline_for_extraction noextract
+let sha2_224: impl = (| SHA2_224, () |)
+inline_for_extraction noextract
+let sha2_256: impl = (| SHA2_256, () |)
+inline_for_extraction noextract
+let sha2_384: impl = (| SHA2_384, () |)
+inline_for_extraction noextract
+let sha2_512: impl = (| SHA2_512, () |)
+inline_for_extraction noextract
+let blake2s_32: impl = (| Blake2S, Hacl.Impl.Blake2.Core.M32 |)
+inline_for_extraction noextract
+let blake2s_128: impl = (| Blake2S, Hacl.Impl.Blake2.Core.M128 |)
+inline_for_extraction noextract
+let blake2b_32: impl = (| Blake2B, Hacl.Impl.Blake2.Core.M32 |)
+inline_for_extraction noextract
+let blake2b_256: impl = (| Blake2B, Hacl.Impl.Blake2.Core.M256 |)
 
+inline_for_extraction noextract
+let alg_of_impl (i: impl): alg = dfst i
 
-// JP: not sharing the 224/256 and 384/512 cases, even though the internal state
-//   is the same, to avoid the additional proof burden.
-// JP: also note that we are sharing state between implementations, since Vale
-//   kindly offers a wrapper that is compatible with the HACL* representation
+// JP: This is a slightly more complicated case than for AEAD... for AEAD,
+//   `state_s a = i & kv a & buffer uint8`
+// because no matter the /implementation/, the resulting C type for the key is
+// always a pointer to bytes. Here, that's no longer true because of Blake2, so
+// we need to be a little more verbose.
 noeq
 type state_s: alg -> Type0 =
 | MD5_s: p:Hacl.Hash.Definitions.state (|MD5, ()|) -> state_s MD5
@@ -59,8 +91,17 @@ type state_s: alg -> Type0 =
 | SHA2_256_s: p:Hacl.Hash.Definitions.state (|SHA2_256, ()|) -> state_s SHA2_256
 | SHA2_384_s: p:Hacl.Hash.Definitions.state (|SHA2_384, ()|) -> state_s SHA2_384
 | SHA2_512_s: p:Hacl.Hash.Definitions.state (|SHA2_512, ()|) -> state_s SHA2_512
-| Blake2S_s: p:Hacl.Hash.Definitions.state (|Blake2S, blake2_spec|) -> state_s Blake2S
-| Blake2B_s: p:Hacl.Hash.Definitions.state (|Blake2B, blake2_spec|) -> state_s Blake2B
+| Blake2S_s: p:Hacl.Hash.Definitions.state (|Blake2S, Hacl.Impl.Blake2.Core.M32|) -> state_s Blake2S
+| Blake2S_128_s:
+  _:squash (EverCrypt.TargetConfig.hacl_can_compile_vec128 /\
+    EverCrypt.AutoConfig2.vec128_enabled) ->
+  p:Hacl.Hash.Definitions.state (|Blake2S, Hacl.Impl.Blake2.Core.M128|) ->
+  state_s Blake2S
+| Blake2B_s: p:Hacl.Hash.Definitions.state (|Blake2B, Hacl.Impl.Blake2.Core.M32|) -> state_s Blake2B
+| Blake2B_256_s:
+  _:squash (EverCrypt.TargetConfig.hacl_can_compile_vec256 /\
+    EverCrypt.AutoConfig2.vec256_enabled) ->
+  p:Hacl.Hash.Definitions.state (|Blake2B, Hacl.Impl.Blake2.Core.M256|) -> state_s Blake2B
 
 let invert_state_s (a: alg): Lemma
   (requires True)
@@ -69,20 +110,28 @@ let invert_state_s (a: alg): Lemma
 =
   allow_inversion (state_s a)
 
-let mk_state_s (#a:alg) (p:Hacl.Hash.Definitions.state (impl_of_alg a)) :
-  GTot (state_s a) =
-  match a with
-  | MD5 -> MD5_s p
-  | SHA1 -> SHA1_s p
-  | SHA2_224 -> SHA2_224_s p
-  | SHA2_256 -> SHA2_256_s p
-  | SHA2_384 -> SHA2_384_s p
-  | SHA2_512 -> SHA2_512_s p
-  | Blake2S -> Blake2S_s p
-  | Blake2B -> Blake2B_s p
-
 inline_for_extraction
-let p #a (s: state_s a): Hacl.Hash.Definitions.state (impl_of_alg a) =
+let impl_of_state #a (s: state_s a): i:impl { alg_of_impl i == a } =
+  match s with
+  | MD5_s _ -> md5
+  | SHA1_s _ -> sha1
+  | SHA2_224_s _ -> sha2_224
+  | SHA2_256_s _ -> sha2_256
+  | SHA2_384_s _ -> sha2_384
+  | SHA2_512_s _ -> sha2_512
+  | Blake2S_s _ -> blake2s_32
+  | Blake2S_128_s _ _ -> blake2s_128
+  | Blake2B_s _ -> blake2b_32
+  | Blake2B_256_s _ _ -> blake2b_256
+
+// In state_s, the data type already captures what implementation we have... three
+// design choices here:
+// - turn state_s into a dependent pair of G.erased impl & (SHA2_s | SHA3_s |
+//   ...) so as not to repeat redundant information at run-time
+// - hope that we can get away with returning dependent pairs only when needed.
+// We're going for a third one in this module, which is more lightweight.
+inline_for_extraction
+let p #a (s: state_s a): Hacl.Hash.Definitions.state (impl_of_state s) =
   match s with
   | MD5_s p -> p
   | SHA1_s p -> p
@@ -91,7 +140,9 @@ let p #a (s: state_s a): Hacl.Hash.Definitions.state (impl_of_alg a) =
   | SHA2_384_s p -> p
   | SHA2_512_s p -> p
   | Blake2S_s p -> p
+  | Blake2S_128_s _ p -> p
   | Blake2B_s p -> p
+  | Blake2B_256_s _ p -> p
 
 let freeable_s #a s = B.freeable (p #a s)
 
@@ -115,7 +166,9 @@ let alg_of_state a s =
   | SHA2_384_s _ -> SHA2_384
   | SHA2_512_s _ -> SHA2_512
   | Blake2S_s _ -> Blake2S
+  | Blake2S_128_s _ _ -> Blake2S
   | Blake2B_s _ -> Blake2B
+  | Blake2B_256_s _ _ -> Blake2B
 
 let repr_eq (#a:alg) (r1 r2: Spec.Hash.Definitions.words_state' a) =
   Seq.equal r1 r2
@@ -138,8 +191,22 @@ let alloca a =
     | SHA2_256 -> SHA2_256_s (B.alloca 0ul 8ul)
     | SHA2_384 -> SHA2_384_s (B.alloca 0UL 8ul)
     | SHA2_512 -> SHA2_512_s (B.alloca 0UL 8ul)
-    | Blake2S -> Blake2S_s (B.alloca 0ul 16ul)
-    | Blake2B -> Blake2B_s (B.alloca 0uL 16ul)
+    | Blake2S ->
+        let vec128 = EverCrypt.AutoConfig2.has_vec128 () in
+        if EverCrypt.TargetConfig.hacl_can_compile_vec128 && vec128 then
+          let open Hacl.Impl.Blake2.Core in
+          [@inline_let] let i: impl = (| Blake2S , M128 |) in
+          Blake2S_128_s () (B.alloca (zero_element Spec.Blake2.Blake2S M128) (impl_state_len i))
+        else
+          Blake2S_s (B.alloca 0ul 16ul)
+    | Blake2B ->
+        let vec256 = EverCrypt.AutoConfig2.has_vec256 () in
+        if EverCrypt.TargetConfig.hacl_can_compile_vec256 && vec256 then
+          let open Hacl.Impl.Blake2.Core in
+          [@inline_let] let i: impl = (| Blake2B , M256 |) in
+          Blake2B_256_s () (B.alloca (zero_element Spec.Blake2.Blake2B M256) (impl_state_len i))
+        else
+          Blake2B_s (B.alloca 0uL 16ul)
   in
   B.alloca s 1ul
 
@@ -152,8 +219,22 @@ let create_in a r =
     | SHA2_256 -> SHA2_256_s (B.malloc r 0ul 8ul)
     | SHA2_384 -> SHA2_384_s (B.malloc r 0UL 8ul)
     | SHA2_512 -> SHA2_512_s (B.malloc r 0UL 8ul)
-    | Blake2S -> Blake2S_s (B.malloc r 0ul 16ul)
-    | Blake2B -> Blake2B_s (B.malloc r 0uL 16ul)
+    | Blake2S ->
+        let vec128 = EverCrypt.AutoConfig2.has_vec128 () in
+        if EverCrypt.TargetConfig.hacl_can_compile_vec128 && vec128 then
+          let open Hacl.Impl.Blake2.Core in
+          [@inline_let] let i: impl = (| Blake2S , M128 |) in
+          Blake2S_128_s () (B.malloc r (zero_element Spec.Blake2.Blake2S M128) (impl_state_len i))
+        else
+          Blake2S_s (B.malloc r 0ul 16ul)
+    | Blake2B ->
+        let vec256 = EverCrypt.AutoConfig2.has_vec256 () in
+        if EverCrypt.TargetConfig.hacl_can_compile_vec256 && vec256 then
+          let open Hacl.Impl.Blake2.Core in
+          [@inline_let] let i: impl = (| Blake2B , M256 |) in
+          Blake2B_256_s () (B.malloc r (zero_element Spec.Blake2.Blake2B M256) (impl_state_len i))
+        else
+          Blake2B_s (B.malloc r 0uL 16ul)
   in
   B.malloc r s 1ul
 
@@ -162,6 +243,9 @@ let create a =
 
 #push-options "--ifuel 1"
 
+// NOTE: HACL* does not require suitable preconditions so the squashed proofs
+// that we have the right CPU flags are useless. But it's good to demonstrate
+// how to do it for future reference and/or future other implementations.
 let init #a s =
   match !*s with
   | MD5_s p -> Hacl.Hash.MD5.legacy_init p
@@ -171,7 +255,9 @@ let init #a s =
   | SHA2_384_s p -> Hacl.Hash.SHA2.init_384 p
   | SHA2_512_s p -> Hacl.Hash.SHA2.init_512 p
   | Blake2S_s p -> let _ = Hacl.Hash.Blake2.init_blake2s_32 p in ()
+  | Blake2S_128_s _ p -> let _ = Hacl.Hash.Blake2.init_blake2s_128 p in ()
   | Blake2B_s p -> let _ = Hacl.Hash.Blake2.init_blake2b_32 p in ()
+  | Blake2B_256_s _ p -> let _ = Hacl.Hash.Blake2.init_blake2b_256 p in ()
 #pop-options
 
 friend Vale.SHA.SHA_helpers
@@ -183,6 +269,13 @@ let k224_256 =
 #push-options "--ifuel 1"
 
 // A new switch between HACL and Vale; can be used in place of Hacl.Hash.SHA2.update_256
+// NOTE: this is an old-style switch where the CPU check is done on every call
+// to update_multi... this is SUBOPTIMAL. I (JP) ported this module to use a
+// proper concept of /implementation/, and for the Blake2 optimized variants,
+// the state is now capable of keeping a squashed proof that the CPU supports
+// what is needed...
+// TODO: introduce SHA2_256_Vale in the state and test for CPU instructions only
+// once, at state-creation time!
 let update_multi_256 s ev blocks n =
   let has_shaext = AC.has_shaext () in
   let has_sse = AC.has_sse () in
@@ -218,9 +311,16 @@ let update2 #a s prevlen block =
   | Blake2S_s p ->
       let _ = Hacl.Hash.Blake2.update_blake2s_32 p prevlen block in
       ()
+  | Blake2S_128_s _ p ->
+      let _ = Hacl.Hash.Blake2.update_blake2s_128 p prevlen block in
+      ()
   | Blake2B_s p ->
       [@inline_let] let prevlen = Int.Cast.Full.uint64_to_uint128 prevlen in
       let _ = Hacl.Hash.Blake2.update_blake2b_32 p prevlen block in
+      ()
+  | Blake2B_256_s _ p ->
+      [@inline_let] let prevlen = Int.Cast.Full.uint64_to_uint128 prevlen in
+      let _ = Hacl.Hash.Blake2.update_blake2b_256 p prevlen block in
       ()
 #pop-options
 
@@ -254,10 +354,19 @@ let update_multi2 #a s prevlen blocks len =
       let n = len / block_len Blake2S in
       let _ = Hacl.Hash.Blake2.update_multi_blake2s_32 p prevlen blocks n in
       ()
+  | Blake2S_128_s _ p ->
+      let n = len / block_len Blake2S in
+      let _ = Hacl.Hash.Blake2.update_multi_blake2s_128 p prevlen blocks n in
+      ()
   | Blake2B_s p ->
       [@inline_let] let prevlen = Int.Cast.Full.uint64_to_uint128 prevlen in
       let n = len / block_len Blake2B in
       let _ = Hacl.Hash.Blake2.update_multi_blake2b_32 p prevlen blocks n in
+      ()
+  | Blake2B_256_s _ p ->
+      [@inline_let] let prevlen = Int.Cast.Full.uint64_to_uint128 prevlen in
+      let n = len / block_len Blake2B in
+      let _ = Hacl.Hash.Blake2.update_multi_blake2b_256 p prevlen blocks n in
       ()
 
 #pop-options
@@ -286,9 +395,10 @@ let update_last_224 s prev_len input input_len =
 // Splitting out these proof bits; the proof is highly unreliable when all six
 // cases are done together in a single match
 inline_for_extraction
-let update_last_st (#a:e_alg) =
-  let a = Ghost.reveal a in
-  p:Hacl.Hash.Definitions.state (impl_of_alg a) ->
+let update_last_st (#i:G.erased impl) =
+  let i = Ghost.reveal i in
+  let a = alg_of_impl i in
+  p:Hacl.Hash.Definitions.state i ->
   ev:extra_state a ->
   prev_len:uint64_t ->
   last:uint8_p { B.length last <= block_length a } ->
@@ -310,39 +420,44 @@ let update_last_st (#a:e_alg) =
                                         (v prev_len) (B.as_seq h0 last))
 
 inline_for_extraction
-val update_last_64 (a: e_alg{ G.reveal a <> SHA2_384 /\
-                              G.reveal a <> SHA2_512 /\
-                              G.reveal a <> Blake2B })
-  (update_last: Hacl.Hash.Definitions.update_last_st (impl_of_alg (G.reveal a))):
-  update_last_st #a
+val update_last_64 (i: G.erased impl{ G.reveal i <> sha2_384 /\
+                                      G.reveal i <> sha2_512 /\
+                                      G.reveal i <> blake2b_32 /\
+                                      G.reveal i <> blake2b_256 })
+  (update_last: Hacl.Hash.Definitions.update_last_st i):
+  update_last_st #i
 inline_for_extraction
-let update_last_64 a update_last p ev prev_len last last_len =
+let update_last_64 i update_last p ev prev_len last last_len =
   update_last p ev prev_len last last_len
 
 inline_for_extraction
-val update_last_128 (a: e_alg{ G.reveal a = SHA2_384 \/
-                               G.reveal a = SHA2_512 \/
-                               G.reveal a = Blake2B})
-  (update_last: Hacl.Hash.Definitions.update_last_st (impl_of_alg (G.reveal a))):
-  update_last_st #a
+val update_last_128 (i: G.erased impl{ G.reveal i = sha2_384 \/
+                                       G.reveal i = sha2_512 \/
+                                       G.reveal i = blake2b_32 \/
+                                       G.reveal i = blake2b_256})
+  (update_last: Hacl.Hash.Definitions.update_last_st i):
+  update_last_st #i
 inline_for_extraction
-let update_last_128 a update_last p ev prev_len last last_len =
+let update_last_128 i update_last p ev prev_len last last_len =
   [@inline_let] let prev_len : UInt128.t = Int.Cast.Full.uint64_to_uint128 prev_len in
   update_last p ev prev_len last last_len
 
-let state_s_to_words_state (#a:alg) (s:state_s a) (h:HS.mem) (counter:uint64_t) :
-  GTot (words_state a) =
+let state_s_to_words_state (#i:impl) (s:Hacl.Hash.Definitions.state i)
+  (h:HS.mem) (counter:uint64_t) :
+  GTot (words_state (alg_of_impl i)) =
+  let a = alg_of_impl i in
   if is_blake a then
     let ev : extra_state a = Lib.IntTypes.cast (extra_state_int_type a) Lib.IntTypes.SEC counter in
-    as_seq h (p s), ev
-  else (as_seq h (p s), ())
+    as_seq h s, ev
+  else (as_seq h s, ())
 
 /// Before defining ``update_last`` we introduce auxiliary functions for Blake2S
 /// and Blake2B, because trying to define it completely at once leads to a proof loop.
 /// Besides, even with this the Blake functions tend to loop.
 inline_for_extraction noextract
-let update_last_with_internal_st (a : alg) =
-  p:Hacl.Hash.Definitions.state (impl_of_alg a) ->
+let update_last_with_internal_st (i : impl) =
+  let a = alg_of_impl i in (
+  p:Hacl.Hash.Definitions.state i ->
   prev_len:uint64_t ->
   last:B.buffer Lib.IntTypes.uint8 { B.length last <= block_length a } ->
   last_len:uint32_t {
@@ -352,61 +467,83 @@ let update_last_with_internal_st (a : alg) =
     } ->
   Stack unit
   (requires fun h0 ->
-    let s = mk_state_s p in
-    invariant_s s h0 /\
+    B.live h0 p /\
     B.live h0 last /\
-    B.(loc_disjoint (footprint_s s) (loc_buffer last) /\
-    v prev_len + v last_len <= max_input_length a))
+    B.(loc_disjoint (B.loc_addr_of_buffer p) (loc_buffer last)))
   (ensures fun h0 _ h1 ->
-    let s = mk_state_s p in
-    invariant_s s h1 /\
+    B.live h1 p /\
     as_seq h1 p ==
-      fst (Spec.Hash.Incremental.update_last a (state_s_to_words_state s h0 prev_len) (v prev_len)
+      fst (Spec.Hash.Incremental.update_last a (state_s_to_words_state p h0 prev_len) (v prev_len)
                                              (B.as_seq h0 last)) /\
-    B.(modifies (footprint_s s) h0 h1) /\
-    footprint_s s == footprint_s s)
+    B.(modifies (B.loc_addr_of_buffer p) h0 h1)))
 
 
 inline_for_extraction noextract
-val update_last_blake2s : update_last_with_internal_st Blake2S
+val update_last_blake2s_32 : update_last_with_internal_st blake2s_32
 
 #push-options "--fuel 0 --ifuel 1"
-let update_last_blake2s p prev_len last last_len =
+let update_last_blake2s_32 p prev_len last last_len =
   [@inline_let] let ev = prev_len in
   let x:Lib.IntTypes.uint_t Lib.IntTypes.U64 Lib.IntTypes.SEC =
-    update_last_64 Blake2S Hacl.Hash.Blake2.update_last_blake2s_32 p ev
+    update_last_64 blake2s_32 Hacl.Hash.Blake2.update_last_blake2s_32 p ev
                    prev_len last last_len in
   ()
 #pop-options
 
 inline_for_extraction noextract
-val update_last_blake2b : update_last_with_internal_st Blake2B
+val update_last_blake2s_128 : update_last_with_internal_st blake2s_128
 
-let update_last_blake2b p prev_len last last_len =
+#push-options "--fuel 0 --ifuel 1"
+let update_last_blake2s_128 p prev_len last last_len =
+  [@inline_let] let ev = prev_len in
+  let x:Lib.IntTypes.uint_t Lib.IntTypes.U64 Lib.IntTypes.SEC =
+    update_last_64 blake2s_128 Hacl.Hash.Blake2.update_last_blake2s_128 p ev
+                   prev_len last last_len in
+  ()
+#pop-options
+
+inline_for_extraction noextract
+val update_last_blake2b_32 : update_last_with_internal_st blake2b_32
+
+let update_last_blake2b_32 p prev_len last last_len =
   [@inline_let] let ev = Int.Cast.Full.uint64_to_uint128 prev_len in
   let x:Lib.IntTypes.uint_t Lib.IntTypes.U128 Lib.IntTypes.SEC =
-    update_last_128 Blake2B Hacl.Hash.Blake2.update_last_blake2b_32 p ev
+    update_last_128 blake2b_32 Hacl.Hash.Blake2.update_last_blake2b_32 p ev
+                    prev_len last last_len in
+  ()
+
+inline_for_extraction noextract
+val update_last_blake2b_256 : update_last_with_internal_st blake2b_256
+
+let update_last_blake2b_256 p prev_len last last_len =
+  [@inline_let] let ev = Int.Cast.Full.uint64_to_uint128 prev_len in
+  let x:Lib.IntTypes.uint_t Lib.IntTypes.U128 Lib.IntTypes.SEC =
+    update_last_128 blake2b_256 Hacl.Hash.Blake2.update_last_blake2b_256 p ev
                     prev_len last last_len in
   ()
 
 let update_last2 #a s prev_len last last_len =
   match !*s with
   | MD5_s p ->
-      update_last_64 a Hacl.Hash.MD5.legacy_update_last p () prev_len last last_len
+      update_last_64 md5 Hacl.Hash.MD5.legacy_update_last p () prev_len last last_len
   | SHA1_s p ->
-      update_last_64 a Hacl.Hash.SHA1.legacy_update_last p () prev_len last last_len
+      update_last_64 sha1 Hacl.Hash.SHA1.legacy_update_last p () prev_len last last_len
   | SHA2_224_s p ->
-      update_last_64 a update_last_224 p () prev_len last last_len
+      update_last_64 sha2_224 update_last_224 p () prev_len last last_len
   | SHA2_256_s p ->
-      update_last_64 a update_last_256 p () prev_len last last_len
+      update_last_64 sha2_256 update_last_256 p () prev_len last last_len
   | SHA2_384_s p ->
-      update_last_128 a Hacl.Hash.SHA2.update_last_384 p () prev_len last last_len
+      update_last_128 sha2_384 Hacl.Hash.SHA2.update_last_384 p () prev_len last last_len
   | SHA2_512_s p ->
-      update_last_128 a Hacl.Hash.SHA2.update_last_512 p () prev_len last last_len
+      update_last_128 sha2_512 Hacl.Hash.SHA2.update_last_512 p () prev_len last last_len
   | Blake2S_s p ->
-      update_last_blake2s p prev_len last last_len
+      update_last_blake2s_32 p prev_len last last_len
+  | Blake2S_128_s _ p ->
+      update_last_blake2s_128 p prev_len last last_len
   | Blake2B_s p ->
-      update_last_blake2b p prev_len last last_len
+      update_last_blake2b_32 p prev_len last last_len
+  | Blake2B_256_s _ p ->
+      update_last_blake2b_256 p prev_len last last_len
 
 // TODO: move to FStar.Math.Lemmas
 val modulo_sub_lemma (a : int) (b : nat) (c : pos) :
@@ -496,8 +633,12 @@ let finish #a s dst =
   | SHA2_384_s p -> Hacl.Hash.SHA2.finish_384 p () dst
   | SHA2_512_s p -> Hacl.Hash.SHA2.finish_512 p () dst
   | Blake2S_s p -> Hacl.Hash.Blake2.finish_blake2s_32 p 0UL dst
+  | Blake2S_128_s _ p -> Hacl.Hash.Blake2.finish_blake2s_128 p 0UL dst
   | Blake2B_s p ->
     Hacl.Hash.Blake2.finish_blake2b_32 p (Int.Cast.Full.uint64_to_uint128
+                                             (UInt64.uint_to_t 0)) dst
+  | Blake2B_256_s _ p ->
+    Hacl.Hash.Blake2.finish_blake2b_256 p (Int.Cast.Full.uint64_to_uint128
                                              (UInt64.uint_to_t 0)) dst
 
 #pop-options
@@ -511,7 +652,9 @@ let free #ea s =
   | SHA2_384_s p -> B.free p
   | SHA2_512_s p -> B.free p
   | Blake2S_s p -> B.free p
+  | Blake2S_128_s _ p -> B.free p
   | Blake2B_s p -> B.free p
+  | Blake2B_256_s _ p -> B.free p
   end;
   B.free s
 
@@ -549,7 +692,7 @@ let copy #a s_src s_dst =
       let s_dst: state SHA2_512 = s_dst in
       let p_dst = SHA2_512_s?.p !*s_dst in
       B.blit p_src 0ul p_dst 0ul 8ul
-  | Blake2S_s p_src ->
+  (*| Blake2S_s p_src ->
       [@inline_let]
       let s_dst: state Blake2S = s_dst in
       let p_dst = Blake2S_s?.p !*s_dst in
@@ -558,7 +701,9 @@ let copy #a s_src s_dst =
       [@inline_let]
       let s_dst: state Blake2B = s_dst in
       let p_dst = Blake2B_s?.p !*s_dst in
-      B.blit p_src 0ul p_dst 0ul 16ul
+      B.blit p_src 0ul p_dst 0ul 16ul*)
+  | _ ->
+      LowStar.Failure.failwith "TODO"
 
 #pop-options
 
@@ -579,5 +724,15 @@ let hash a dst input len =
   | SHA2_256 -> hash_256 input len dst
   | SHA2_384 -> Hacl.Hash.SHA2.hash_384 input len dst
   | SHA2_512 -> Hacl.Hash.SHA2.hash_512 input len dst
-  | Blake2S -> Hacl.Hash.Blake2.hash_blake2s_32 input len dst
-  | Blake2B -> Hacl.Hash.Blake2.hash_blake2b_32 input len dst
+  | Blake2S ->
+      let vec128 = EverCrypt.AutoConfig2.has_vec128 () in
+      if EverCrypt.TargetConfig.hacl_can_compile_vec128 && vec128 then
+        Hacl.Hash.Blake2.hash_blake2s_128 input len dst
+      else
+        Hacl.Hash.Blake2.hash_blake2s_32 input len dst
+  | Blake2B ->
+      let vec256 = EverCrypt.AutoConfig2.has_vec256 () in
+      if EverCrypt.TargetConfig.hacl_can_compile_vec256 && vec256 then
+        Hacl.Hash.Blake2.hash_blake2b_256 input len dst
+      else
+        Hacl.Hash.Blake2.hash_blake2b_32 input len dst

--- a/providers/evercrypt/fst/EverCrypt.Poly1305.fst
+++ b/providers/evercrypt/fst/EverCrypt.Poly1305.fst
@@ -124,8 +124,6 @@ let poly1305_vale
   assert (B.as_seq h3 dst `S.equal` Spec.Poly1305.poly1305_mac (B.as_seq h0 src) (B.as_seq h0 key))
 let poly1305 dst src len key =
   let h0 = ST.get () in
-  let avx2 = EverCrypt.AutoConfig2.has_avx2 () in
-  let avx = EverCrypt.AutoConfig2.has_avx () in
   let vec256 = EverCrypt.AutoConfig2.has_vec256 () in
   let vec128 = EverCrypt.AutoConfig2.has_vec128 () in
   let vale = EverCrypt.AutoConfig2.wants_vale () in


### PR DESCRIPTION
There remains one item to be done, namely implement the copy function to fatally fail if someone started hashing with blake2 *then* called autoconfig only to discover that the vectorized version is enabled.