### PR TITLE
github action to update hints and dist

### DIFF
--- a/.github/workflows/buildproducts.yml
+++ b/.github/workflows/buildproducts.yml
@@ -5,7 +5,7 @@ on:
     - cron: '0 2 * * *'
 
 jobs:
-  update:
+  hints-and-dist:
     runs-on: ubuntu-latest
     steps:
       - name: checkout

--- a/.github/workflows/buildproducts.yml
+++ b/.github/workflows/buildproducts.yml
@@ -1,0 +1,26 @@
+name: update hints and dist
+
+on:
+  schedule:
+    - cron: '0 2 * * *'
+  workflow_dispatch:
+
+jobs:
+  update:
+    runs-on: ubuntu-latest
+    steps:
+      - name: checkout
+        uses: actions/checkout@v3
+      - name: download new files
+        run: |
+          git rm -r hints dist/*/*
+          export url=https://everest-ci.paris.inria.fr/job/everest/branch-master/hacl-build-products.x86_64-linux/latest/download
+          diff <(curl -L ${url}/3) <(git rev-parse HEAD)
+          curl -L ${url}/1 | tar -xv
+          curl -L ${url}/2 | tar -xv
+      - name: commit changes
+        uses: EndBug/add-and-commit@v9
+        with:
+          author_name: Project Everest
+          author_email: project@everest
+          message: "[CI] update hints and dist"

--- a/.github/workflows/buildproducts.yml
+++ b/.github/workflows/buildproducts.yml
@@ -18,8 +18,8 @@ jobs:
           baseUrl="https://everest-ci.paris.inria.fr"
           latestFinishedEval=$(curl -sLH 'Content-Type: application/json' "$baseUrl/jobset/hacl-star/branch-master/latest-eval")
 
-          rev=$(echo "$latestFinishedEval" | jq '.flake | split("/") | last')
-          id=$(echo "$latestFinishedEval" | jq '.id')
+          rev=$(echo "$latestFinishedEval" | jq -r '.flake | split("/") | last')
+          id=$(echo "$latestFinishedEval" | jq -r '.id')
 
           [[ "$rev" == "$(git rev-parse HEAD)" ]] || {
               echo "The latest evaluation on the CI doesn't correspond to the latest commit."
@@ -30,7 +30,7 @@ jobs:
           buildInfo=$(curl -sLH 'Content-Type: application/json' "$buildUrl")
 
           # Check wether the build was built correctly
-          [[ "$(echo "$buildInfo" | jq '.buildstatus')" == "$STATUS_SUCCEEDED" ]] || {
+          [[ "$(echo "$buildInfo" | jq -r '.buildstatus')" == "$STATUS_SUCCEEDED" ]] || {
               echo "The latest evaluation wasn't successful. Aborting."
               exit 2
           }

--- a/.github/workflows/buildproducts.yml
+++ b/.github/workflows/buildproducts.yml
@@ -3,7 +3,6 @@ name: update hints and dist
 on:
   schedule:
     - cron: '0 2 * * *'
-  workflow_dispatch:
 
 jobs:
   update:

--- a/.github/workflows/buildproducts.yml
+++ b/.github/workflows/buildproducts.yml
@@ -44,6 +44,6 @@ jobs:
       - name: commit changes
         uses: EndBug/add-and-commit@v9
         with:
-          author_name: Project Everest
-          author_email: project@everest
+          author_name: "Dzomo, the Everest Yak"
+          author_email: "everbld@microsoft.com"
           message: "[CI] update hints and dist"

--- a/.github/workflows/buildproducts.yml
+++ b/.github/workflows/buildproducts.yml
@@ -14,7 +14,7 @@ jobs:
         run: |
           git rm -r hints dist/*/*
           url=https://everest-ci.paris.inria.fr/job/everest/branch-master/hacl-build-products.x86_64-linux/latest/download
-          diff <(curl -L ${url}/3) <(git rev-parse HEAD)
+          diff <(curl -L ${url}/3) <(git rev-parse HEAD) # fails if the tarballs are stale
           curl -L ${url}/1 | tar -xv
           curl -L ${url}/2 | tar -xv
       - name: commit changes

--- a/.github/workflows/buildproducts.yml
+++ b/.github/workflows/buildproducts.yml
@@ -13,7 +13,7 @@ jobs:
       - name: download new files
         run: |
           git rm -r hints dist/*/*
-          export url=https://everest-ci.paris.inria.fr/job/everest/branch-master/hacl-build-products.x86_64-linux/latest/download
+          url=https://everest-ci.paris.inria.fr/job/everest/branch-master/hacl-build-products.x86_64-linux/latest/download
           diff <(curl -L ${url}/3) <(git rev-parse HEAD)
           curl -L ${url}/1 | tar -xv
           curl -L ${url}/2 | tar -xv

--- a/.github/workflows/buildproducts.yml
+++ b/.github/workflows/buildproducts.yml
@@ -10,13 +10,37 @@ jobs:
     steps:
       - name: checkout
         uses: actions/checkout@v3
+      - name: delete old files
+        run: git rm -r hints dist/*/*
       - name: download new files
         run: |
-          git rm -r hints dist/*/*
-          url=https://everest-ci.paris.inria.fr/job/everest/branch-master/hacl-build-products.x86_64-linux/latest/download
-          diff <(curl -L ${url}/3) <(git rev-parse HEAD) # fails if the tarballs are stale
-          curl -L ${url}/1 | tar -xv
-          curl -L ${url}/2 | tar -xv
+          STATUS_SUCCEEDED=0 # from https://github.com/NixOS/hydra/blob/cf9f38e43fd81f9298e3f2ff50c8a6ee0acc3af0/hydra-api.yaml#L927-L941
+          baseUrl="https://everest-ci.paris.inria.fr"
+          latestFinishedEval=$(curl -sLH 'Content-Type: application/json' "$baseUrl/jobset/hacl-star/branch-master/latest-eval")
+
+          rev=$(echo "$latestFinishedEval" | jq '.flake | split("/") | last')
+          id=$(echo "$latestFinishedEval" | jq '.id')
+
+          [[ "$rev" == "$(git rev-parse HEAD)" ]] || {
+              echo "The latest evaluation on the CI doesn't correspond to the latest commit."
+              exit 1
+          }
+
+          buildUrl="$baseUrl/eval/$id/job/hacl-build-products.x86_64-linux"
+          buildInfo=$(curl -sLH 'Content-Type: application/json' "$buildUrl")
+
+          # Check wether the build was built correctly
+          [[ "$(echo "$buildInfo" | jq '.buildstatus')" == "$STATUS_SUCCEEDED" ]] || {
+              echo "The latest evaluation wasn't successful. Aborting."
+              exit 2
+          }
+
+          installTar () {
+              curl -sL "$buildUrl/download-by-type/file/$1" | tar -xv
+          }
+
+          installTar "hints"
+          installTar "dist"
       - name: commit changes
         uses: EndBug/add-and-commit@v9
         with:


### PR DESCRIPTION
This PR adds a nightly github action to retrieve binary files generated by the [Hydra CI](https://everest-ci.paris.inria.fr).
This github action doesn't trigger a new build, it simply downloads build products from the latest succesful build on Hydra.