### PR TITLE
Remove usage of __has_include

### DIFF
--- a/dist/c89-compatible/Lib_Memzero0.c
+++ b/dist/c89-compatible/Lib_Memzero0.c
@@ -1,8 +1,4 @@
-#if defined(__has_include)
-#if __has_include("config.h")
 #include "config.h"
-#endif
-#endif
 
 #ifdef _WIN32
 #include <windows.h>

--- a/dist/c89-compatible/evercrypt_targetconfig.h
+++ b/dist/c89-compatible/evercrypt_targetconfig.h
@@ -18,13 +18,7 @@
 #define TARGET_ARCHITECTURE_ID_SYSTEMZ 5
 #define TARGET_ARCHITECTURE_ID_POWERPC64 6
 
-#if defined(__has_include)
-#if __has_include("config.h")
 #include "config.h"
-#else
-#define TARGET_ARCHITECTURE TARGET_ARCHITECTURE_ID_UNKNOWN
-#endif
-#endif
 
 // Those functions are called on non-x64 platforms for which the feature detection
 // is not covered by vale's CPUID support; therefore, we hand-write in C ourselves.

--- a/dist/c89-compatible/lib_intrinsics.h
+++ b/dist/c89-compatible/lib_intrinsics.h
@@ -2,11 +2,7 @@
 
 #include <sys/types.h>
 
-#if defined(__has_include)
-#if __has_include("config.h")
 #include "config.h"
-#endif
-#endif
 
 #if defined(HACL_CAN_COMPILE_INTRINSICS)
 #if defined(_MSC_VER)

--- a/dist/c89-compatible/libintvector.h
+++ b/dist/c89-compatible/libintvector.h
@@ -6,11 +6,7 @@
 /* We include config.h here to ensure that the various feature-flags are
  * properly brought into scope. Users can either run the configure script, or
  * write a config.h themselves and put it under version control. */
-#if defined(__has_include)
-#if __has_include("config.h")
 #include "config.h"
-#endif
-#endif
 
 /* # DEBUGGING:
  * ============

--- a/dist/ccf/Lib_Memzero0.c
+++ b/dist/ccf/Lib_Memzero0.c
@@ -1,8 +1,4 @@
-#if defined(__has_include)
-#if __has_include("config.h")
 #include "config.h"
-#endif
-#endif
 
 #ifdef _WIN32
 #include <windows.h>

--- a/dist/ccf/evercrypt_targetconfig.h
+++ b/dist/ccf/evercrypt_targetconfig.h
@@ -18,13 +18,7 @@
 #define TARGET_ARCHITECTURE_ID_SYSTEMZ 5
 #define TARGET_ARCHITECTURE_ID_POWERPC64 6
 
-#if defined(__has_include)
-#if __has_include("config.h")
 #include "config.h"
-#else
-#define TARGET_ARCHITECTURE TARGET_ARCHITECTURE_ID_UNKNOWN
-#endif
-#endif
 
 // Those functions are called on non-x64 platforms for which the feature detection
 // is not covered by vale's CPUID support; therefore, we hand-write in C ourselves.

--- a/dist/election-guard/Lib_Memzero0.c
+++ b/dist/election-guard/Lib_Memzero0.c
@@ -1,8 +1,4 @@
-#if defined(__has_include)
-#if __has_include("config.h")
 #include "config.h"
-#endif
-#endif
 
 #ifdef _WIN32
 #include <windows.h>

--- a/dist/election-guard/evercrypt_targetconfig.h
+++ b/dist/election-guard/evercrypt_targetconfig.h
@@ -18,13 +18,7 @@
 #define TARGET_ARCHITECTURE_ID_SYSTEMZ 5
 #define TARGET_ARCHITECTURE_ID_POWERPC64 6
 
-#if defined(__has_include)
-#if __has_include("config.h")
 #include "config.h"
-#else
-#define TARGET_ARCHITECTURE TARGET_ARCHITECTURE_ID_UNKNOWN
-#endif
-#endif
 
 // Those functions are called on non-x64 platforms for which the feature detection
 // is not covered by vale's CPUID support; therefore, we hand-write in C ourselves.

--- a/dist/election-guard/lib_intrinsics.h
+++ b/dist/election-guard/lib_intrinsics.h
@@ -2,11 +2,7 @@
 
 #include <sys/types.h>
 
-#if defined(__has_include)
-#if __has_include("config.h")
 #include "config.h"
-#endif
-#endif
 
 #if defined(HACL_CAN_COMPILE_INTRINSICS)
 #if defined(_MSC_VER)

--- a/dist/election-guard/libintvector.h
+++ b/dist/election-guard/libintvector.h
@@ -6,11 +6,7 @@
 /* We include config.h here to ensure that the various feature-flags are
  * properly brought into scope. Users can either run the configure script, or
  * write a config.h themselves and put it under version control. */
-#if defined(__has_include)
-#if __has_include("config.h")
 #include "config.h"
-#endif
-#endif
 
 /* # DEBUGGING:
  * ============

--- a/dist/gcc-compatible/Lib_Memzero0.c
+++ b/dist/gcc-compatible/Lib_Memzero0.c
@@ -1,8 +1,4 @@
-#if defined(__has_include)
-#if __has_include("config.h")
 #include "config.h"
-#endif
-#endif
 
 #ifdef _WIN32
 #include <windows.h>

--- a/dist/gcc-compatible/evercrypt_targetconfig.h
+++ b/dist/gcc-compatible/evercrypt_targetconfig.h
@@ -18,13 +18,7 @@
 #define TARGET_ARCHITECTURE_ID_SYSTEMZ 5
 #define TARGET_ARCHITECTURE_ID_POWERPC64 6
 
-#if defined(__has_include)
-#if __has_include("config.h")
 #include "config.h"
-#else
-#define TARGET_ARCHITECTURE TARGET_ARCHITECTURE_ID_UNKNOWN
-#endif
-#endif
 
 // Those functions are called on non-x64 platforms for which the feature detection
 // is not covered by vale's CPUID support; therefore, we hand-write in C ourselves.

--- a/dist/gcc-compatible/lib_intrinsics.h
+++ b/dist/gcc-compatible/lib_intrinsics.h
@@ -2,11 +2,7 @@
 
 #include <sys/types.h>
 
-#if defined(__has_include)
-#if __has_include("config.h")
 #include "config.h"
-#endif
-#endif
 
 #if defined(HACL_CAN_COMPILE_INTRINSICS)
 #if defined(_MSC_VER)

--- a/dist/gcc-compatible/libintvector.h
+++ b/dist/gcc-compatible/libintvector.h
@@ -6,11 +6,7 @@
 /* We include config.h here to ensure that the various feature-flags are
  * properly brought into scope. Users can either run the configure script, or
  * write a config.h themselves and put it under version control. */
-#if defined(__has_include)
-#if __has_include("config.h")
 #include "config.h"
-#endif
-#endif
 
 /* # DEBUGGING:
  * ============

--- a/dist/gcc64-only/Lib_Memzero0.c
+++ b/dist/gcc64-only/Lib_Memzero0.c
@@ -1,8 +1,4 @@
-#if defined(__has_include)
-#if __has_include("config.h")
 #include "config.h"
-#endif
-#endif
 
 #ifdef _WIN32
 #include <windows.h>

--- a/dist/gcc64-only/evercrypt_targetconfig.h
+++ b/dist/gcc64-only/evercrypt_targetconfig.h
@@ -18,13 +18,7 @@
 #define TARGET_ARCHITECTURE_ID_SYSTEMZ 5
 #define TARGET_ARCHITECTURE_ID_POWERPC64 6
 
-#if defined(__has_include)
-#if __has_include("config.h")
 #include "config.h"
-#else
-#define TARGET_ARCHITECTURE TARGET_ARCHITECTURE_ID_UNKNOWN
-#endif
-#endif
 
 // Those functions are called on non-x64 platforms for which the feature detection
 // is not covered by vale's CPUID support; therefore, we hand-write in C ourselves.

--- a/dist/gcc64-only/lib_intrinsics.h
+++ b/dist/gcc64-only/lib_intrinsics.h
@@ -2,11 +2,7 @@
 
 #include <sys/types.h>
 
-#if defined(__has_include)
-#if __has_include("config.h")
 #include "config.h"
-#endif
-#endif
 
 #if defined(HACL_CAN_COMPILE_INTRINSICS)
 #if defined(_MSC_VER)

--- a/dist/gcc64-only/libintvector.h
+++ b/dist/gcc64-only/libintvector.h
@@ -6,11 +6,7 @@
 /* We include config.h here to ensure that the various feature-flags are
  * properly brought into scope. Users can either run the configure script, or
  * write a config.h themselves and put it under version control. */
-#if defined(__has_include)
-#if __has_include("config.h")
 #include "config.h"
-#endif
-#endif
 
 /* # DEBUGGING:
  * ============

--- a/dist/linux/Lib_Memzero0.c
+++ b/dist/linux/Lib_Memzero0.c
@@ -1,8 +1,4 @@
-#if defined(__has_include)
-#if __has_include("config.h")
 #include "config.h"
-#endif
-#endif
 
 #ifdef _WIN32
 #include <windows.h>

--- a/dist/linux/lib_intrinsics.h
+++ b/dist/linux/lib_intrinsics.h
@@ -2,11 +2,7 @@
 
 #include <sys/types.h>
 
-#if defined(__has_include)
-#if __has_include("config.h")
 #include "config.h"
-#endif
-#endif
 
 #if defined(HACL_CAN_COMPILE_INTRINSICS)
 #if defined(_MSC_VER)

--- a/dist/linux/libintvector.h
+++ b/dist/linux/libintvector.h
@@ -6,11 +6,7 @@
 /* We include config.h here to ensure that the various feature-flags are
  * properly brought into scope. Users can either run the configure script, or
  * write a config.h themselves and put it under version control. */
-#if defined(__has_include)
-#if __has_include("config.h")
 #include "config.h"
-#endif
-#endif
 
 /* # DEBUGGING:
  * ============

--- a/dist/mitls/Lib_Memzero0.c
+++ b/dist/mitls/Lib_Memzero0.c
@@ -1,8 +1,4 @@
-#if defined(__has_include)
-#if __has_include("config.h")
 #include "config.h"
-#endif
-#endif
 
 #ifdef _WIN32
 #include <windows.h>

--- a/dist/mitls/evercrypt_targetconfig.h
+++ b/dist/mitls/evercrypt_targetconfig.h
@@ -18,13 +18,7 @@
 #define TARGET_ARCHITECTURE_ID_SYSTEMZ 5
 #define TARGET_ARCHITECTURE_ID_POWERPC64 6
 
-#if defined(__has_include)
-#if __has_include("config.h")
 #include "config.h"
-#else
-#define TARGET_ARCHITECTURE TARGET_ARCHITECTURE_ID_UNKNOWN
-#endif
-#endif
 
 // Those functions are called on non-x64 platforms for which the feature detection
 // is not covered by vale's CPUID support; therefore, we hand-write in C ourselves.

--- a/dist/mitls/lib_intrinsics.h
+++ b/dist/mitls/lib_intrinsics.h
@@ -2,11 +2,7 @@
 
 #include <sys/types.h>
 
-#if defined(__has_include)
-#if __has_include("config.h")
 #include "config.h"
-#endif
-#endif
 
 #if defined(HACL_CAN_COMPILE_INTRINSICS)
 #if defined(_MSC_VER)

--- a/dist/mitls/libintvector.h
+++ b/dist/mitls/libintvector.h
@@ -6,11 +6,7 @@
 /* We include config.h here to ensure that the various feature-flags are
  * properly brought into scope. Users can either run the configure script, or
  * write a config.h themselves and put it under version control. */
-#if defined(__has_include)
-#if __has_include("config.h")
 #include "config.h"
-#endif
-#endif
 
 /* # DEBUGGING:
  * ============

--- a/dist/mozilla/libintvector.h
+++ b/dist/mozilla/libintvector.h
@@ -6,11 +6,7 @@
 /* We include config.h here to ensure that the various feature-flags are
  * properly brought into scope. Users can either run the configure script, or
  * write a config.h themselves and put it under version control. */
-#if defined(__has_include)
-#if __has_include("config.h")
 #include "config.h"
-#endif
-#endif
 
 /* # DEBUGGING:
  * ============

--- a/dist/msvc-compatible/Lib_Memzero0.c
+++ b/dist/msvc-compatible/Lib_Memzero0.c
@@ -1,8 +1,4 @@
-#if defined(__has_include)
-#if __has_include("config.h")
 #include "config.h"
-#endif
-#endif
 
 #ifdef _WIN32
 #include <windows.h>

--- a/dist/msvc-compatible/evercrypt_targetconfig.h
+++ b/dist/msvc-compatible/evercrypt_targetconfig.h
@@ -18,13 +18,7 @@
 #define TARGET_ARCHITECTURE_ID_SYSTEMZ 5
 #define TARGET_ARCHITECTURE_ID_POWERPC64 6
 
-#if defined(__has_include)
-#if __has_include("config.h")
 #include "config.h"
-#else
-#define TARGET_ARCHITECTURE TARGET_ARCHITECTURE_ID_UNKNOWN
-#endif
-#endif
 
 // Those functions are called on non-x64 platforms for which the feature detection
 // is not covered by vale's CPUID support; therefore, we hand-write in C ourselves.

--- a/dist/msvc-compatible/lib_intrinsics.h
+++ b/dist/msvc-compatible/lib_intrinsics.h
@@ -2,11 +2,7 @@
 
 #include <sys/types.h>
 
-#if defined(__has_include)
-#if __has_include("config.h")
 #include "config.h"
-#endif
-#endif
 
 #if defined(HACL_CAN_COMPILE_INTRINSICS)
 #if defined(_MSC_VER)

--- a/dist/msvc-compatible/libintvector.h
+++ b/dist/msvc-compatible/libintvector.h
@@ -6,11 +6,7 @@
 /* We include config.h here to ensure that the various feature-flags are
  * properly brought into scope. Users can either run the configure script, or
  * write a config.h themselves and put it under version control. */
-#if defined(__has_include)
-#if __has_include("config.h")
 #include "config.h"
-#endif
-#endif
 
 /* # DEBUGGING:
  * ============

--- a/dist/portable-gcc-compatible/Lib_Memzero0.c
+++ b/dist/portable-gcc-compatible/Lib_Memzero0.c
@@ -1,8 +1,4 @@
-#if defined(__has_include)
-#if __has_include("config.h")
 #include "config.h"
-#endif
-#endif
 
 #ifdef _WIN32
 #include <windows.h>

--- a/dist/portable-gcc-compatible/evercrypt_targetconfig.h
+++ b/dist/portable-gcc-compatible/evercrypt_targetconfig.h
@@ -18,13 +18,7 @@
 #define TARGET_ARCHITECTURE_ID_SYSTEMZ 5
 #define TARGET_ARCHITECTURE_ID_POWERPC64 6
 
-#if defined(__has_include)
-#if __has_include("config.h")
 #include "config.h"
-#else
-#define TARGET_ARCHITECTURE TARGET_ARCHITECTURE_ID_UNKNOWN
-#endif
-#endif
 
 // Those functions are called on non-x64 platforms for which the feature detection
 // is not covered by vale's CPUID support; therefore, we hand-write in C ourselves.

--- a/dist/portable-gcc-compatible/lib_intrinsics.h
+++ b/dist/portable-gcc-compatible/lib_intrinsics.h
@@ -2,11 +2,7 @@
 
 #include <sys/types.h>
 
-#if defined(__has_include)
-#if __has_include("config.h")
 #include "config.h"
-#endif
-#endif
 
 #if defined(HACL_CAN_COMPILE_INTRINSICS)
 #if defined(_MSC_VER)

--- a/dist/portable-gcc-compatible/libintvector.h
+++ b/dist/portable-gcc-compatible/libintvector.h
@@ -6,11 +6,7 @@
 /* We include config.h here to ensure that the various feature-flags are
  * properly brought into scope. Users can either run the configure script, or
  * write a config.h themselves and put it under version control. */
-#if defined(__has_include)
-#if __has_include("config.h")
 #include "config.h"
-#endif
-#endif
 
 /* # DEBUGGING:
  * ============

--- a/lib/c/Lib_Memzero0.c
+++ b/lib/c/Lib_Memzero0.c
@@ -1,8 +1,4 @@
-#if defined(__has_include)
-#if __has_include("config.h")
 #include "config.h"
-#endif
-#endif
 
 #ifdef _WIN32
 #include <windows.h>

--- a/lib/c/evercrypt_targetconfig.h
+++ b/lib/c/evercrypt_targetconfig.h
@@ -18,13 +18,7 @@
 #define TARGET_ARCHITECTURE_ID_SYSTEMZ 5
 #define TARGET_ARCHITECTURE_ID_POWERPC64 6
 
-#if defined(__has_include)
-#if __has_include("config.h")
 #include "config.h"
-#else
-#define TARGET_ARCHITECTURE TARGET_ARCHITECTURE_ID_UNKNOWN
-#endif
-#endif
 
 // Those functions are called on non-x64 platforms for which the feature detection
 // is not covered by vale's CPUID support; therefore, we hand-write in C ourselves.

--- a/lib/c/lib_intrinsics.h
+++ b/lib/c/lib_intrinsics.h
@@ -2,11 +2,7 @@
 
 #include <sys/types.h>
 
-#if defined(__has_include)
-#if __has_include("config.h")
 #include "config.h"
-#endif
-#endif
 
 #if defined(HACL_CAN_COMPILE_INTRINSICS)
 #if defined(_MSC_VER)

--- a/lib/c/libintvector.h
+++ b/lib/c/libintvector.h
@@ -6,11 +6,7 @@
 /* We include config.h here to ensure that the various feature-flags are
  * properly brought into scope. Users can either run the configure script, or
  * write a config.h themselves and put it under version control. */
-#if defined(__has_include)
-#if __has_include("config.h")
 #include "config.h"
-#endif
-#endif
 
 /* # DEBUGGING:
  * ============


### PR DESCRIPTION
@franziskuskiefer reported that our usage of `__has_include` was yet one more oddity that made support across compiler versions difficult.

I believe this *used* to be a an issue but with a recent change from Natalia, there is now a preprocessor guard that doesn't trigger __has_include unless we know we have it.

But simplifying this logic is good, and so I would like to remove our usage of __has_include. (There is one left for debugging purposes in libintvector.h that I believe is innocuous.)

There would need to be further changes, for instance:
- fixing the local Makefiles to copy a dummy development config.h to enable all the features
- making sure no dist relies on the absence of config.h (I know Mozilla has one now, but maybe election guard needs one...?)

Therefore, I'm leaving this as a draft PR for further discussion.