### PR TITLE
Fix options for Meta.HPKE proof

### DIFF
--- a/code/hpke/Hacl.Impl.HPKE.fst
+++ b/code/hpke/Hacl.Impl.HPKE.fst
@@ -990,7 +990,7 @@ let setupBaseS #cs o_pkE o_ctx skE pkR infolen info =
 
 #pop-options
 
-#push-options "--z3rlimit 400 --z3refresh"
+#push-options "--z3rlimit 600 --z3refresh --ifuel 1"
 
 [@ Meta.Attribute.specialize]
 let setupBaseR #cs o_ctx enc skR infolen info =


### PR DESCRIPTION
CI has been recently broken on Hacl.Meta.HPKE. For some reason, this functions needs an increased ifuel (and hence rlimit) after rewriting through Meta.Interface while the generic implementation doesn't