### PR TITLE
More rlimit + ifuel

### DIFF
--- a/code/hpke/Hacl.Impl.HPKE.fst
+++ b/code/hpke/Hacl.Impl.HPKE.fst
@@ -665,7 +665,7 @@ val encap:
      )
 
 #restart-solver
-#push-options "--z3rlimit 500 --z3refresh"
+#push-options "--z3rlimit 600 --z3refresh --ifuel 1"
 
 [@ Meta.Attribute.inline_]
 let encap #cs o_shared o_enc skE pkR =


### PR DESCRIPTION
Similar to #570. The fact that these bumps in ifuel are needed for Meta only are quite surprising.
@msprotz had a hypothesis that proofs might succeed in Hacl.Impl.HPKE without the bump might be due to hint files helping with the proof. I managed to verify the entirety of Hacl.Impl.HPKE locally without hints, which seems to suggest the reason is to be found elsewhere...