### PR TITLE
Replace =. with =

### DIFF
--- a/code/hmac/Hacl.HMAC.fst
+++ b/code/hmac/Hacl.HMAC.fst
@@ -168,7 +168,7 @@ let part2 a m init update_multi update_last finish s dst key data len =
   (**) let init_v : Ghost.erased (init_t a) = Spec.Agile.Hash.init a in
   (**) assert ((D.as_seq h1 s, ev) == Ghost.reveal init_v);
   let ev =
-    if len =. 0ul then
+    if len = 0ul then
       begin
       let ev = update_last s ev (zero_to_len a) key (D.block_len a) in
       (**) let h2 = ST.get () in

--- a/dist/gcc-compatible/EverCrypt_HMAC.c
+++ b/dist/gcc-compatible/EverCrypt_HMAC.c
@@ -99,15 +99,8 @@ EverCrypt_HMAC_compute_sha1(
   Hacl_Hash_Core_SHA1_legacy_finish(s, dst1);
   uint8_t *hash1 = ipad;
   Hacl_Hash_Core_SHA1_legacy_init(s);
-  if ((uint32_t)20U == (uint32_t)0U)
-  {
-    Hacl_Hash_SHA1_legacy_update_last(s, (uint64_t)0U, opad, (uint32_t)64U);
-  }
-  else
-  {
-    Hacl_Hash_SHA1_legacy_update_multi(s, opad, (uint32_t)1U);
-    Hacl_Hash_SHA1_legacy_update_last(s, (uint64_t)(uint32_t)64U, hash1, (uint32_t)20U);
-  }
+  Hacl_Hash_SHA1_legacy_update_multi(s, opad, (uint32_t)1U);
+  Hacl_Hash_SHA1_legacy_update_last(s, (uint64_t)(uint32_t)64U, hash1, (uint32_t)20U);
   Hacl_Hash_Core_SHA1_legacy_finish(s, dst);
 }
 
@@ -181,15 +174,8 @@ EverCrypt_HMAC_compute_sha2_256(
   Hacl_Hash_Core_SHA2_finish_256(s, dst1);
   uint8_t *hash1 = ipad;
   Hacl_Hash_Core_SHA2_init_256(s);
-  if ((uint32_t)32U == (uint32_t)0U)
-  {
-    EverCrypt_Hash_update_last_256(s, (uint64_t)0U, opad, (uint32_t)64U);
-  }
-  else
-  {
-    EverCrypt_Hash_update_multi_256(s, opad, (uint32_t)1U);
-    EverCrypt_Hash_update_last_256(s, (uint64_t)(uint32_t)64U, hash1, (uint32_t)32U);
-  }
+  EverCrypt_Hash_update_multi_256(s, opad, (uint32_t)1U);
+  EverCrypt_Hash_update_last_256(s, (uint64_t)(uint32_t)64U, hash1, (uint32_t)32U);
   Hacl_Hash_Core_SHA2_finish_256(s, dst);
 }
 
@@ -270,21 +256,11 @@ EverCrypt_HMAC_compute_sha2_384(
   Hacl_Hash_Core_SHA2_finish_384(s, dst1);
   uint8_t *hash1 = ipad;
   Hacl_Hash_Core_SHA2_init_384(s);
-  if ((uint32_t)48U == (uint32_t)0U)
-  {
-    Hacl_Hash_SHA2_update_last_384(s,
-      FStar_UInt128_uint64_to_uint128((uint64_t)0U),
-      opad,
-      (uint32_t)128U);
-  }
-  else
-  {
-    Hacl_Hash_SHA2_update_multi_384(s, opad, (uint32_t)1U);
-    Hacl_Hash_SHA2_update_last_384(s,
-      FStar_UInt128_uint64_to_uint128((uint64_t)(uint32_t)128U),
-      hash1,
-      (uint32_t)48U);
-  }
+  Hacl_Hash_SHA2_update_multi_384(s, opad, (uint32_t)1U);
+  Hacl_Hash_SHA2_update_last_384(s,
+    FStar_UInt128_uint64_to_uint128((uint64_t)(uint32_t)128U),
+    hash1,
+    (uint32_t)48U);
   Hacl_Hash_Core_SHA2_finish_384(s, dst);
 }
 
@@ -365,21 +341,11 @@ EverCrypt_HMAC_compute_sha2_512(
   Hacl_Hash_Core_SHA2_finish_512(s, dst1);
   uint8_t *hash1 = ipad;
   Hacl_Hash_Core_SHA2_init_512(s);
-  if ((uint32_t)64U == (uint32_t)0U)
-  {
-    Hacl_Hash_SHA2_update_last_512(s,
-      FStar_UInt128_uint64_to_uint128((uint64_t)0U),
-      opad,
-      (uint32_t)128U);
-  }
-  else
-  {
-    Hacl_Hash_SHA2_update_multi_512(s, opad, (uint32_t)1U);
-    Hacl_Hash_SHA2_update_last_512(s,
-      FStar_UInt128_uint64_to_uint128((uint64_t)(uint32_t)128U),
-      hash1,
-      (uint32_t)64U);
-  }
+  Hacl_Hash_SHA2_update_multi_512(s, opad, (uint32_t)1U);
+  Hacl_Hash_SHA2_update_last_512(s,
+    FStar_UInt128_uint64_to_uint128((uint64_t)(uint32_t)128U),
+    hash1,
+    (uint32_t)64U);
   Hacl_Hash_Core_SHA2_finish_512(s, dst);
 }
 
@@ -545,25 +511,15 @@ EverCrypt_HMAC_compute_blake2s(
   r1[2U] = iv6;
   r1[3U] = iv7;
   uint64_t ev0 = (uint64_t)0U;
-  uint64_t ev11;
-  if ((uint32_t)32U == (uint32_t)0U)
-  {
-    uint64_t
-    ev1 = Hacl_Hash_Blake2_update_last_blake2s_32(s0, ev0, (uint64_t)0U, opad, (uint32_t)64U);
-    ev11 = ev1;
-  }
-  else
-  {
-    uint64_t ev1 = Hacl_Hash_Blake2_update_multi_blake2s_32(s0, ev0, opad, (uint32_t)1U);
-    uint64_t
-    ev2 =
-      Hacl_Hash_Blake2_update_last_blake2s_32(s0,
-        ev1,
-        (uint64_t)(uint32_t)64U,
-        hash1,
-        (uint32_t)32U);
-    ev11 = ev2;
-  }
+  uint64_t ev1 = Hacl_Hash_Blake2_update_multi_blake2s_32(s0, ev0, opad, (uint32_t)1U);
+  uint64_t
+  ev2 =
+    Hacl_Hash_Blake2_update_last_blake2s_32(s0,
+      ev1,
+      (uint64_t)(uint32_t)64U,
+      hash1,
+      (uint32_t)32U);
+  uint64_t ev11 = ev2;
   Hacl_Hash_Core_Blake2_finish_blake2s_32(s0, ev11, dst);
 }
 
@@ -740,31 +696,16 @@ EverCrypt_HMAC_compute_blake2b(
   r1[2U] = iv6;
   r1[3U] = iv7;
   FStar_UInt128_uint128 ev0 = FStar_UInt128_uint64_to_uint128((uint64_t)0U);
-  FStar_UInt128_uint128 ev11;
-  if ((uint32_t)64U == (uint32_t)0U)
-  {
-    FStar_UInt128_uint128
-    ev1 =
-      Hacl_Hash_Blake2_update_last_blake2b_32(s0,
-        ev0,
-        FStar_UInt128_uint64_to_uint128((uint64_t)0U),
-        opad,
-        (uint32_t)128U);
-    ev11 = ev1;
-  }
-  else
-  {
-    FStar_UInt128_uint128
-    ev1 = Hacl_Hash_Blake2_update_multi_blake2b_32(s0, ev0, opad, (uint32_t)1U);
-    FStar_UInt128_uint128
-    ev2 =
-      Hacl_Hash_Blake2_update_last_blake2b_32(s0,
-        ev1,
-        FStar_UInt128_uint64_to_uint128((uint64_t)(uint32_t)128U),
-        hash1,
-        (uint32_t)64U);
-    ev11 = ev2;
-  }
+  FStar_UInt128_uint128
+  ev1 = Hacl_Hash_Blake2_update_multi_blake2b_32(s0, ev0, opad, (uint32_t)1U);
+  FStar_UInt128_uint128
+  ev2 =
+    Hacl_Hash_Blake2_update_last_blake2b_32(s0,
+      ev1,
+      FStar_UInt128_uint64_to_uint128((uint64_t)(uint32_t)128U),
+      hash1,
+      (uint32_t)64U);
+  FStar_UInt128_uint128 ev11 = ev2;
   Hacl_Hash_Core_Blake2_finish_blake2b_32(s0, ev11, dst);
 }
 

--- a/dist/gcc-compatible/Hacl_HMAC.c
+++ b/dist/gcc-compatible/Hacl_HMAC.c
@@ -98,15 +98,8 @@ Hacl_HMAC_legacy_compute_sha1(
   Hacl_Hash_Core_SHA1_legacy_finish(s, dst1);
   uint8_t *hash1 = ipad;
   Hacl_Hash_Core_SHA1_legacy_init(s);
-  if ((uint32_t)20U == (uint32_t)0U)
-  {
-    Hacl_Hash_SHA1_legacy_update_last(s, (uint64_t)0U, opad, (uint32_t)64U);
-  }
-  else
-  {
-    Hacl_Hash_SHA1_legacy_update_multi(s, opad, (uint32_t)1U);
-    Hacl_Hash_SHA1_legacy_update_last(s, (uint64_t)(uint32_t)64U, hash1, (uint32_t)20U);
-  }
+  Hacl_Hash_SHA1_legacy_update_multi(s, opad, (uint32_t)1U);
+  Hacl_Hash_SHA1_legacy_update_last(s, (uint64_t)(uint32_t)64U, hash1, (uint32_t)20U);
   Hacl_Hash_Core_SHA1_legacy_finish(s, dst);
 }
 
@@ -180,15 +173,8 @@ Hacl_HMAC_compute_sha2_256(
   Hacl_Hash_Core_SHA2_finish_256(s, dst1);
   uint8_t *hash1 = ipad;
   Hacl_Hash_Core_SHA2_init_256(s);
-  if ((uint32_t)32U == (uint32_t)0U)
-  {
-    Hacl_Hash_SHA2_update_last_256(s, (uint64_t)0U, opad, (uint32_t)64U);
-  }
-  else
-  {
-    Hacl_Hash_SHA2_update_multi_256(s, opad, (uint32_t)1U);
-    Hacl_Hash_SHA2_update_last_256(s, (uint64_t)(uint32_t)64U, hash1, (uint32_t)32U);
-  }
+  Hacl_Hash_SHA2_update_multi_256(s, opad, (uint32_t)1U);
+  Hacl_Hash_SHA2_update_last_256(s, (uint64_t)(uint32_t)64U, hash1, (uint32_t)32U);
   Hacl_Hash_Core_SHA2_finish_256(s, dst);
 }
 
@@ -269,21 +255,11 @@ Hacl_HMAC_compute_sha2_384(
   Hacl_Hash_Core_SHA2_finish_384(s, dst1);
   uint8_t *hash1 = ipad;
   Hacl_Hash_Core_SHA2_init_384(s);
-  if ((uint32_t)48U == (uint32_t)0U)
-  {
-    Hacl_Hash_SHA2_update_last_384(s,
-      FStar_UInt128_uint64_to_uint128((uint64_t)0U),
-      opad,
-      (uint32_t)128U);
-  }
-  else
-  {
-    Hacl_Hash_SHA2_update_multi_384(s, opad, (uint32_t)1U);
-    Hacl_Hash_SHA2_update_last_384(s,
-      FStar_UInt128_uint64_to_uint128((uint64_t)(uint32_t)128U),
-      hash1,
-      (uint32_t)48U);
-  }
+  Hacl_Hash_SHA2_update_multi_384(s, opad, (uint32_t)1U);
+  Hacl_Hash_SHA2_update_last_384(s,
+    FStar_UInt128_uint64_to_uint128((uint64_t)(uint32_t)128U),
+    hash1,
+    (uint32_t)48U);
   Hacl_Hash_Core_SHA2_finish_384(s, dst);
 }
 
@@ -364,21 +340,11 @@ Hacl_HMAC_compute_sha2_512(
   Hacl_Hash_Core_SHA2_finish_512(s, dst1);
   uint8_t *hash1 = ipad;
   Hacl_Hash_Core_SHA2_init_512(s);
-  if ((uint32_t)64U == (uint32_t)0U)
-  {
-    Hacl_Hash_SHA2_update_last_512(s,
-      FStar_UInt128_uint64_to_uint128((uint64_t)0U),
-      opad,
-      (uint32_t)128U);
-  }
-  else
-  {
-    Hacl_Hash_SHA2_update_multi_512(s, opad, (uint32_t)1U);
-    Hacl_Hash_SHA2_update_last_512(s,
-      FStar_UInt128_uint64_to_uint128((uint64_t)(uint32_t)128U),
-      hash1,
-      (uint32_t)64U);
-  }
+  Hacl_Hash_SHA2_update_multi_512(s, opad, (uint32_t)1U);
+  Hacl_Hash_SHA2_update_last_512(s,
+    FStar_UInt128_uint64_to_uint128((uint64_t)(uint32_t)128U),
+    hash1,
+    (uint32_t)64U);
   Hacl_Hash_Core_SHA2_finish_512(s, dst);
 }
 
@@ -544,25 +510,15 @@ Hacl_HMAC_compute_blake2s_32(
   r1[2U] = iv6;
   r1[3U] = iv7;
   uint64_t ev0 = (uint64_t)0U;
-  uint64_t ev11;
-  if ((uint32_t)32U == (uint32_t)0U)
-  {
-    uint64_t
-    ev1 = Hacl_Hash_Blake2_update_last_blake2s_32(s0, ev0, (uint64_t)0U, opad, (uint32_t)64U);
-    ev11 = ev1;
-  }
-  else
-  {
-    uint64_t ev1 = Hacl_Hash_Blake2_update_multi_blake2s_32(s0, ev0, opad, (uint32_t)1U);
-    uint64_t
-    ev2 =
-      Hacl_Hash_Blake2_update_last_blake2s_32(s0,
-        ev1,
-        (uint64_t)(uint32_t)64U,
-        hash1,
-        (uint32_t)32U);
-    ev11 = ev2;
-  }
+  uint64_t ev1 = Hacl_Hash_Blake2_update_multi_blake2s_32(s0, ev0, opad, (uint32_t)1U);
+  uint64_t
+  ev2 =
+    Hacl_Hash_Blake2_update_last_blake2s_32(s0,
+      ev1,
+      (uint64_t)(uint32_t)64U,
+      hash1,
+      (uint32_t)32U);
+  uint64_t ev11 = ev2;
   Hacl_Hash_Core_Blake2_finish_blake2s_32(s0, ev11, dst);
 }
 
@@ -739,31 +695,16 @@ Hacl_HMAC_compute_blake2b_32(
   r1[2U] = iv6;
   r1[3U] = iv7;
   FStar_UInt128_uint128 ev0 = FStar_UInt128_uint64_to_uint128((uint64_t)0U);
-  FStar_UInt128_uint128 ev11;
-  if ((uint32_t)64U == (uint32_t)0U)
-  {
-    FStar_UInt128_uint128
-    ev1 =
-      Hacl_Hash_Blake2_update_last_blake2b_32(s0,
-        ev0,
-        FStar_UInt128_uint64_to_uint128((uint64_t)0U),
-        opad,
-        (uint32_t)128U);
-    ev11 = ev1;
-  }
-  else
-  {
-    FStar_UInt128_uint128
-    ev1 = Hacl_Hash_Blake2_update_multi_blake2b_32(s0, ev0, opad, (uint32_t)1U);
-    FStar_UInt128_uint128
-    ev2 =
-      Hacl_Hash_Blake2_update_last_blake2b_32(s0,
-        ev1,
-        FStar_UInt128_uint64_to_uint128((uint64_t)(uint32_t)128U),
-        hash1,
-        (uint32_t)64U);
-    ev11 = ev2;
-  }
+  FStar_UInt128_uint128
+  ev1 = Hacl_Hash_Blake2_update_multi_blake2b_32(s0, ev0, opad, (uint32_t)1U);
+  FStar_UInt128_uint128
+  ev2 =
+    Hacl_Hash_Blake2_update_last_blake2b_32(s0,
+      ev1,
+      FStar_UInt128_uint64_to_uint128((uint64_t)(uint32_t)128U),
+      hash1,
+      (uint32_t)64U);
+  FStar_UInt128_uint128 ev11 = ev2;
   Hacl_Hash_Core_Blake2_finish_blake2b_32(s0, ev11, dst);
 }
 


### PR DESCRIPTION
=. evaluates to FStar.UInt32.eq which F*'s normalizer won't reduce --
there is no need to use the special operator, instead, it suffices to
use =, the polymorphic equality operator, and all is well