### PR TITLE
Refresh dist/gcc-compatible with some code-gen improvements

### DIFF
--- a/dist/gcc-compatible/EverCrypt_Poly1305.c
+++ b/dist/gcc-compatible/EverCrypt_Poly1305.c
@@ -32,18 +32,13 @@ static void poly1305_vale(uint8_t *dst, uint8_t *src, uint32_t len, uint8_t *key
   memcpy(ctx + (uint32_t)24U, key, (uint32_t)32U * sizeof (uint8_t));
   uint32_t n_blocks = len / (uint32_t)16U;
   uint32_t n_extra = len % (uint32_t)16U;
-  uint8_t tmp[16U];
+  uint8_t tmp[16U] = { 0U };
   if (n_extra == (uint32_t)0U)
   {
     uint64_t scrut = x64_poly1305(ctx, src, (uint64_t)len, (uint64_t)1U);
   }
   else
   {
-    uint8_t init = (uint8_t)0U;
-    for (uint32_t i = (uint32_t)0U; i < (uint32_t)16U; i++)
-    {
-      tmp[i] = init;
-    }
     uint32_t len16 = n_blocks * (uint32_t)16U;
     uint8_t *src16 = src;
     memcpy(tmp, src + len16, n_extra * sizeof (uint8_t));

--- a/dist/gcc-compatible/Hacl_Chacha20.c
+++ b/dist/gcc-compatible/Hacl_Chacha20.c
@@ -116,17 +116,15 @@ chacha20_constants[4U] =
 inline void
 Hacl_Impl_Chacha20_chacha20_init(uint32_t *ctx, uint8_t *k, uint8_t *n, uint32_t ctr)
 {
-  uint32_t *uu____0 = ctx;
   for (uint32_t i = (uint32_t)0U; i < (uint32_t)4U; i++)
   {
-    uint32_t *os = uu____0;
+    uint32_t *os = ctx;
     uint32_t x = chacha20_constants[i];
     os[i] = x;
   }
-  uint32_t *uu____1 = ctx + (uint32_t)4U;
   for (uint32_t i = (uint32_t)0U; i < (uint32_t)8U; i++)
   {
-    uint32_t *os = uu____1;
+    uint32_t *os = ctx + (uint32_t)4U;
     uint8_t *bj = k + i * (uint32_t)4U;
     uint32_t u = load32_le(bj);
     uint32_t r = u;
@@ -134,10 +132,9 @@ Hacl_Impl_Chacha20_chacha20_init(uint32_t *ctx, uint8_t *k, uint8_t *n, uint32_t
     os[i] = x;
   }
   ctx[12U] = ctr;
-  uint32_t *uu____2 = ctx + (uint32_t)13U;
   for (uint32_t i = (uint32_t)0U; i < (uint32_t)3U; i++)
   {
-    uint32_t *os = uu____2;
+    uint32_t *os = ctx + (uint32_t)13U;
     uint8_t *bj = n + i * (uint32_t)4U;
     uint32_t u = load32_le(bj);
     uint32_t r = u;

--- a/dist/gcc-compatible/Hacl_Chacha20Poly1305_128.c
+++ b/dist/gcc-compatible/Hacl_Chacha20Poly1305_128.c
@@ -50,9 +50,7 @@ poly1305_padded_128(Lib_IntVector_Intrinsics_vec128 *ctx, uint32_t len, uint8_t 
     for (uint32_t i = (uint32_t)0U; i < nb; i++)
     {
       uint8_t *block = text1 + i * bs;
-      Lib_IntVector_Intrinsics_vec128 e[5U];
-      for (uint32_t _i = 0U; _i < (uint32_t)5U; ++_i)
-        e[_i] = Lib_IntVector_Intrinsics_vec128_zero;
+      Lib_IntVector_Intrinsics_vec128 e[5U] = { 0U };
       Lib_IntVector_Intrinsics_vec128 b1 = Lib_IntVector_Intrinsics_vec128_load64_le(block);
       Lib_IntVector_Intrinsics_vec128
       b2 = Lib_IntVector_Intrinsics_vec128_load64_le(block + (uint32_t)16U);
@@ -275,9 +273,7 @@ poly1305_padded_128(Lib_IntVector_Intrinsics_vec128 *ctx, uint32_t len, uint8_t 
   for (uint32_t i = (uint32_t)0U; i < nb; i++)
   {
     uint8_t *block = t10 + i * (uint32_t)16U;
-    Lib_IntVector_Intrinsics_vec128 e[5U];
-    for (uint32_t _i = 0U; _i < (uint32_t)5U; ++_i)
-      e[_i] = Lib_IntVector_Intrinsics_vec128_zero;
+    Lib_IntVector_Intrinsics_vec128 e[5U] = { 0U };
     uint64_t u0 = load64_le(block);
     uint64_t lo = u0;
     uint64_t u = load64_le(block + (uint32_t)8U);
@@ -484,9 +480,7 @@ poly1305_padded_128(Lib_IntVector_Intrinsics_vec128 *ctx, uint32_t len, uint8_t 
   if (rem1 > (uint32_t)0U)
   {
     uint8_t *last = t10 + nb * (uint32_t)16U;
-    Lib_IntVector_Intrinsics_vec128 e[5U];
-    for (uint32_t _i = 0U; _i < (uint32_t)5U; ++_i)
-      e[_i] = Lib_IntVector_Intrinsics_vec128_zero;
+    Lib_IntVector_Intrinsics_vec128 e[5U] = { 0U };
     uint8_t tmp[16U] = { 0U };
     memcpy(tmp, last, rem1 * sizeof (uint8_t));
     uint64_t u0 = load64_le(tmp);
@@ -698,9 +692,7 @@ poly1305_padded_128(Lib_IntVector_Intrinsics_vec128 *ctx, uint32_t len, uint8_t 
   {
     Lib_IntVector_Intrinsics_vec128 *pre = ctx + (uint32_t)5U;
     Lib_IntVector_Intrinsics_vec128 *acc = ctx;
-    Lib_IntVector_Intrinsics_vec128 e[5U];
-    for (uint32_t _i = 0U; _i < (uint32_t)5U; ++_i)
-      e[_i] = Lib_IntVector_Intrinsics_vec128_zero;
+    Lib_IntVector_Intrinsics_vec128 e[5U] = { 0U };
     uint64_t u0 = load64_le(tmp);
     uint64_t lo = u0;
     uint64_t u = load64_le(tmp + (uint32_t)8U);
@@ -917,9 +909,7 @@ poly1305_do_128(
   uint8_t *out
 )
 {
-  Lib_IntVector_Intrinsics_vec128 ctx[25U];
-  for (uint32_t _i = 0U; _i < (uint32_t)25U; ++_i)
-    ctx[_i] = Lib_IntVector_Intrinsics_vec128_zero;
+  Lib_IntVector_Intrinsics_vec128 ctx[25U] = { 0U };
   uint8_t block[16U] = { 0U };
   Hacl_Poly1305_128_poly1305_init(ctx, k);
   if (aadlen != (uint32_t)0U)
@@ -934,9 +924,7 @@ poly1305_do_128(
   store64_le(block + (uint32_t)8U, (uint64_t)mlen);
   Lib_IntVector_Intrinsics_vec128 *pre = ctx + (uint32_t)5U;
   Lib_IntVector_Intrinsics_vec128 *acc = ctx;
-  Lib_IntVector_Intrinsics_vec128 e[5U];
-  for (uint32_t _i = 0U; _i < (uint32_t)5U; ++_i)
-    e[_i] = Lib_IntVector_Intrinsics_vec128_zero;
+  Lib_IntVector_Intrinsics_vec128 e[5U] = { 0U };
   uint64_t u0 = load64_le(block);
   uint64_t lo = u0;
   uint64_t u = load64_le(block + (uint32_t)8U);

--- a/dist/gcc-compatible/Hacl_Chacha20Poly1305_256.c
+++ b/dist/gcc-compatible/Hacl_Chacha20Poly1305_256.c
@@ -50,9 +50,7 @@ poly1305_padded_256(Lib_IntVector_Intrinsics_vec256 *ctx, uint32_t len, uint8_t 
     for (uint32_t i = (uint32_t)0U; i < nb; i++)
     {
       uint8_t *block = text1 + i * bs;
-      Lib_IntVector_Intrinsics_vec256 e[5U];
-      for (uint32_t _i = 0U; _i < (uint32_t)5U; ++_i)
-        e[_i] = Lib_IntVector_Intrinsics_vec256_zero;
+      Lib_IntVector_Intrinsics_vec256 e[5U] = { 0U };
       Lib_IntVector_Intrinsics_vec256 lo = Lib_IntVector_Intrinsics_vec256_load64_le(block);
       Lib_IntVector_Intrinsics_vec256
       hi = Lib_IntVector_Intrinsics_vec256_load64_le(block + (uint32_t)32U);
@@ -277,9 +275,7 @@ poly1305_padded_256(Lib_IntVector_Intrinsics_vec256 *ctx, uint32_t len, uint8_t 
   for (uint32_t i = (uint32_t)0U; i < nb; i++)
   {
     uint8_t *block = t10 + i * (uint32_t)16U;
-    Lib_IntVector_Intrinsics_vec256 e[5U];
-    for (uint32_t _i = 0U; _i < (uint32_t)5U; ++_i)
-      e[_i] = Lib_IntVector_Intrinsics_vec256_zero;
+    Lib_IntVector_Intrinsics_vec256 e[5U] = { 0U };
     uint64_t u0 = load64_le(block);
     uint64_t lo = u0;
     uint64_t u = load64_le(block + (uint32_t)8U);
@@ -486,9 +482,7 @@ poly1305_padded_256(Lib_IntVector_Intrinsics_vec256 *ctx, uint32_t len, uint8_t 
   if (rem1 > (uint32_t)0U)
   {
     uint8_t *last = t10 + nb * (uint32_t)16U;
-    Lib_IntVector_Intrinsics_vec256 e[5U];
-    for (uint32_t _i = 0U; _i < (uint32_t)5U; ++_i)
-      e[_i] = Lib_IntVector_Intrinsics_vec256_zero;
+    Lib_IntVector_Intrinsics_vec256 e[5U] = { 0U };
     uint8_t tmp[16U] = { 0U };
     memcpy(tmp, last, rem1 * sizeof (uint8_t));
     uint64_t u0 = load64_le(tmp);
@@ -700,9 +694,7 @@ poly1305_padded_256(Lib_IntVector_Intrinsics_vec256 *ctx, uint32_t len, uint8_t 
   {
     Lib_IntVector_Intrinsics_vec256 *pre = ctx + (uint32_t)5U;
     Lib_IntVector_Intrinsics_vec256 *acc = ctx;
-    Lib_IntVector_Intrinsics_vec256 e[5U];
-    for (uint32_t _i = 0U; _i < (uint32_t)5U; ++_i)
-      e[_i] = Lib_IntVector_Intrinsics_vec256_zero;
+    Lib_IntVector_Intrinsics_vec256 e[5U] = { 0U };
     uint64_t u0 = load64_le(tmp);
     uint64_t lo = u0;
     uint64_t u = load64_le(tmp + (uint32_t)8U);
@@ -919,9 +911,7 @@ poly1305_do_256(
   uint8_t *out
 )
 {
-  Lib_IntVector_Intrinsics_vec256 ctx[25U];
-  for (uint32_t _i = 0U; _i < (uint32_t)25U; ++_i)
-    ctx[_i] = Lib_IntVector_Intrinsics_vec256_zero;
+  Lib_IntVector_Intrinsics_vec256 ctx[25U] = { 0U };
   uint8_t block[16U] = { 0U };
   Hacl_Poly1305_256_poly1305_init(ctx, k);
   if (aadlen != (uint32_t)0U)
@@ -936,9 +926,7 @@ poly1305_do_256(
   store64_le(block + (uint32_t)8U, (uint64_t)mlen);
   Lib_IntVector_Intrinsics_vec256 *pre = ctx + (uint32_t)5U;
   Lib_IntVector_Intrinsics_vec256 *acc = ctx;
-  Lib_IntVector_Intrinsics_vec256 e[5U];
-  for (uint32_t _i = 0U; _i < (uint32_t)5U; ++_i)
-    e[_i] = Lib_IntVector_Intrinsics_vec256_zero;
+  Lib_IntVector_Intrinsics_vec256 e[5U] = { 0U };
   uint64_t u0 = load64_le(block);
   uint64_t lo = u0;
   uint64_t u = load64_le(block + (uint32_t)8U);

--- a/dist/gcc-compatible/Hacl_Chacha20_Vec128.c
+++ b/dist/gcc-compatible/Hacl_Chacha20_Vec128.c
@@ -212,9 +212,7 @@ Hacl_Chacha20_Vec128_chacha20_encrypt_128(
   uint32_t ctr
 )
 {
-  Lib_IntVector_Intrinsics_vec128 ctx[16U];
-  for (uint32_t _i = 0U; _i < (uint32_t)16U; ++_i)
-    ctx[_i] = Lib_IntVector_Intrinsics_vec128_zero;
+  Lib_IntVector_Intrinsics_vec128 ctx[16U] = { 0U };
   chacha20_init_128(ctx, key, n, ctr);
   uint32_t rem = len % (uint32_t)256U;
   uint32_t nb = len / (uint32_t)256U;
@@ -223,9 +221,7 @@ Hacl_Chacha20_Vec128_chacha20_encrypt_128(
   {
     uint8_t *uu____0 = out + i * (uint32_t)256U;
     uint8_t *uu____1 = text + i * (uint32_t)256U;
-    Lib_IntVector_Intrinsics_vec128 k[16U];
-    for (uint32_t _i = 0U; _i < (uint32_t)16U; ++_i)
-      k[_i] = Lib_IntVector_Intrinsics_vec128_zero;
+    Lib_IntVector_Intrinsics_vec128 k[16U] = { 0U };
     chacha20_core_128(k, ctx, i);
     Lib_IntVector_Intrinsics_vec128 st0 = k[0U];
     Lib_IntVector_Intrinsics_vec128 st1 = k[1U];
@@ -369,9 +365,7 @@ Hacl_Chacha20_Vec128_chacha20_encrypt_128(
     uint8_t *uu____3 = text + nb * (uint32_t)256U;
     uint8_t plain[256U] = { 0U };
     memcpy(plain, uu____3, rem * sizeof (uint8_t));
-    Lib_IntVector_Intrinsics_vec128 k[16U];
-    for (uint32_t _i = 0U; _i < (uint32_t)16U; ++_i)
-      k[_i] = Lib_IntVector_Intrinsics_vec128_zero;
+    Lib_IntVector_Intrinsics_vec128 k[16U] = { 0U };
     chacha20_core_128(k, ctx, nb);
     Lib_IntVector_Intrinsics_vec128 st0 = k[0U];
     Lib_IntVector_Intrinsics_vec128 st1 = k[1U];
@@ -522,9 +516,7 @@ Hacl_Chacha20_Vec128_chacha20_decrypt_128(
   uint32_t ctr
 )
 {
-  Lib_IntVector_Intrinsics_vec128 ctx[16U];
-  for (uint32_t _i = 0U; _i < (uint32_t)16U; ++_i)
-    ctx[_i] = Lib_IntVector_Intrinsics_vec128_zero;
+  Lib_IntVector_Intrinsics_vec128 ctx[16U] = { 0U };
   chacha20_init_128(ctx, key, n, ctr);
   uint32_t rem = len % (uint32_t)256U;
   uint32_t nb = len / (uint32_t)256U;
@@ -533,9 +525,7 @@ Hacl_Chacha20_Vec128_chacha20_decrypt_128(
   {
     uint8_t *uu____0 = out + i * (uint32_t)256U;
     uint8_t *uu____1 = cipher + i * (uint32_t)256U;
-    Lib_IntVector_Intrinsics_vec128 k[16U];
-    for (uint32_t _i = 0U; _i < (uint32_t)16U; ++_i)
-      k[_i] = Lib_IntVector_Intrinsics_vec128_zero;
+    Lib_IntVector_Intrinsics_vec128 k[16U] = { 0U };
     chacha20_core_128(k, ctx, i);
     Lib_IntVector_Intrinsics_vec128 st0 = k[0U];
     Lib_IntVector_Intrinsics_vec128 st1 = k[1U];
@@ -679,9 +669,7 @@ Hacl_Chacha20_Vec128_chacha20_decrypt_128(
     uint8_t *uu____3 = cipher + nb * (uint32_t)256U;
     uint8_t plain[256U] = { 0U };
     memcpy(plain, uu____3, rem * sizeof (uint8_t));
-    Lib_IntVector_Intrinsics_vec128 k[16U];
-    for (uint32_t _i = 0U; _i < (uint32_t)16U; ++_i)
-      k[_i] = Lib_IntVector_Intrinsics_vec128_zero;
+    Lib_IntVector_Intrinsics_vec128 k[16U] = { 0U };
     chacha20_core_128(k, ctx, nb);
     Lib_IntVector_Intrinsics_vec128 st0 = k[0U];
     Lib_IntVector_Intrinsics_vec128 st1 = k[1U];

--- a/dist/gcc-compatible/Hacl_Chacha20_Vec128.c
+++ b/dist/gcc-compatible/Hacl_Chacha20_Vec128.c
@@ -160,17 +160,15 @@ static inline void
 chacha20_init_128(Lib_IntVector_Intrinsics_vec128 *ctx, uint8_t *k, uint8_t *n, uint32_t ctr)
 {
   uint32_t ctx1[16U] = { 0U };
-  uint32_t *uu____0 = ctx1;
   for (uint32_t i = (uint32_t)0U; i < (uint32_t)4U; i++)
   {
-    uint32_t *os = uu____0;
+    uint32_t *os = ctx1;
     uint32_t x = Hacl_Impl_Chacha20_Vec_chacha20_constants[i];
     os[i] = x;
   }
-  uint32_t *uu____1 = ctx1 + (uint32_t)4U;
   for (uint32_t i = (uint32_t)0U; i < (uint32_t)8U; i++)
   {
-    uint32_t *os = uu____1;
+    uint32_t *os = ctx1 + (uint32_t)4U;
     uint8_t *bj = k + i * (uint32_t)4U;
     uint32_t u = load32_le(bj);
     uint32_t r = u;
@@ -178,10 +176,9 @@ chacha20_init_128(Lib_IntVector_Intrinsics_vec128 *ctx, uint8_t *k, uint8_t *n, 
     os[i] = x;
   }
   ctx1[12U] = ctr;
-  uint32_t *uu____2 = ctx1 + (uint32_t)13U;
   for (uint32_t i = (uint32_t)0U; i < (uint32_t)3U; i++)
   {
-    uint32_t *os = uu____2;
+    uint32_t *os = ctx1 + (uint32_t)13U;
     uint8_t *bj = n + i * (uint32_t)4U;
     uint32_t u = load32_le(bj);
     uint32_t r = u;

--- a/dist/gcc-compatible/Hacl_Chacha20_Vec256.c
+++ b/dist/gcc-compatible/Hacl_Chacha20_Vec256.c
@@ -216,9 +216,7 @@ Hacl_Chacha20_Vec256_chacha20_encrypt_256(
   uint32_t ctr
 )
 {
-  Lib_IntVector_Intrinsics_vec256 ctx[16U];
-  for (uint32_t _i = 0U; _i < (uint32_t)16U; ++_i)
-    ctx[_i] = Lib_IntVector_Intrinsics_vec256_zero;
+  Lib_IntVector_Intrinsics_vec256 ctx[16U] = { 0U };
   chacha20_init_256(ctx, key, n, ctr);
   uint32_t rem = len % (uint32_t)512U;
   uint32_t nb = len / (uint32_t)512U;
@@ -227,9 +225,7 @@ Hacl_Chacha20_Vec256_chacha20_encrypt_256(
   {
     uint8_t *uu____0 = out + i * (uint32_t)512U;
     uint8_t *uu____1 = text + i * (uint32_t)512U;
-    Lib_IntVector_Intrinsics_vec256 k[16U];
-    for (uint32_t _i = 0U; _i < (uint32_t)16U; ++_i)
-      k[_i] = Lib_IntVector_Intrinsics_vec256_zero;
+    Lib_IntVector_Intrinsics_vec256 k[16U] = { 0U };
     chacha20_core_256(k, ctx, i);
     Lib_IntVector_Intrinsics_vec256 st0 = k[0U];
     Lib_IntVector_Intrinsics_vec256 st1 = k[1U];
@@ -469,9 +465,7 @@ Hacl_Chacha20_Vec256_chacha20_encrypt_256(
     uint8_t *uu____3 = text + nb * (uint32_t)512U;
     uint8_t plain[512U] = { 0U };
     memcpy(plain, uu____3, rem * sizeof (uint8_t));
-    Lib_IntVector_Intrinsics_vec256 k[16U];
-    for (uint32_t _i = 0U; _i < (uint32_t)16U; ++_i)
-      k[_i] = Lib_IntVector_Intrinsics_vec256_zero;
+    Lib_IntVector_Intrinsics_vec256 k[16U] = { 0U };
     chacha20_core_256(k, ctx, nb);
     Lib_IntVector_Intrinsics_vec256 st0 = k[0U];
     Lib_IntVector_Intrinsics_vec256 st1 = k[1U];
@@ -718,9 +712,7 @@ Hacl_Chacha20_Vec256_chacha20_decrypt_256(
   uint32_t ctr
 )
 {
-  Lib_IntVector_Intrinsics_vec256 ctx[16U];
-  for (uint32_t _i = 0U; _i < (uint32_t)16U; ++_i)
-    ctx[_i] = Lib_IntVector_Intrinsics_vec256_zero;
+  Lib_IntVector_Intrinsics_vec256 ctx[16U] = { 0U };
   chacha20_init_256(ctx, key, n, ctr);
   uint32_t rem = len % (uint32_t)512U;
   uint32_t nb = len / (uint32_t)512U;
@@ -729,9 +721,7 @@ Hacl_Chacha20_Vec256_chacha20_decrypt_256(
   {
     uint8_t *uu____0 = out + i * (uint32_t)512U;
     uint8_t *uu____1 = cipher + i * (uint32_t)512U;
-    Lib_IntVector_Intrinsics_vec256 k[16U];
-    for (uint32_t _i = 0U; _i < (uint32_t)16U; ++_i)
-      k[_i] = Lib_IntVector_Intrinsics_vec256_zero;
+    Lib_IntVector_Intrinsics_vec256 k[16U] = { 0U };
     chacha20_core_256(k, ctx, i);
     Lib_IntVector_Intrinsics_vec256 st0 = k[0U];
     Lib_IntVector_Intrinsics_vec256 st1 = k[1U];
@@ -971,9 +961,7 @@ Hacl_Chacha20_Vec256_chacha20_decrypt_256(
     uint8_t *uu____3 = cipher + nb * (uint32_t)512U;
     uint8_t plain[512U] = { 0U };
     memcpy(plain, uu____3, rem * sizeof (uint8_t));
-    Lib_IntVector_Intrinsics_vec256 k[16U];
-    for (uint32_t _i = 0U; _i < (uint32_t)16U; ++_i)
-      k[_i] = Lib_IntVector_Intrinsics_vec256_zero;
+    Lib_IntVector_Intrinsics_vec256 k[16U] = { 0U };
     chacha20_core_256(k, ctx, nb);
     Lib_IntVector_Intrinsics_vec256 st0 = k[0U];
     Lib_IntVector_Intrinsics_vec256 st1 = k[1U];

--- a/dist/gcc-compatible/Hacl_Chacha20_Vec256.c
+++ b/dist/gcc-compatible/Hacl_Chacha20_Vec256.c
@@ -160,17 +160,15 @@ static inline void
 chacha20_init_256(Lib_IntVector_Intrinsics_vec256 *ctx, uint8_t *k, uint8_t *n, uint32_t ctr)
 {
   uint32_t ctx1[16U] = { 0U };
-  uint32_t *uu____0 = ctx1;
   for (uint32_t i = (uint32_t)0U; i < (uint32_t)4U; i++)
   {
-    uint32_t *os = uu____0;
+    uint32_t *os = ctx1;
     uint32_t x = Hacl_Impl_Chacha20_Vec_chacha20_constants[i];
     os[i] = x;
   }
-  uint32_t *uu____1 = ctx1 + (uint32_t)4U;
   for (uint32_t i = (uint32_t)0U; i < (uint32_t)8U; i++)
   {
-    uint32_t *os = uu____1;
+    uint32_t *os = ctx1 + (uint32_t)4U;
     uint8_t *bj = k + i * (uint32_t)4U;
     uint32_t u = load32_le(bj);
     uint32_t r = u;
@@ -178,10 +176,9 @@ chacha20_init_256(Lib_IntVector_Intrinsics_vec256 *ctx, uint8_t *k, uint8_t *n, 
     os[i] = x;
   }
   ctx1[12U] = ctr;
-  uint32_t *uu____2 = ctx1 + (uint32_t)13U;
   for (uint32_t i = (uint32_t)0U; i < (uint32_t)3U; i++)
   {
-    uint32_t *os = uu____2;
+    uint32_t *os = ctx1 + (uint32_t)13U;
     uint8_t *bj = n + i * (uint32_t)4U;
     uint32_t u = load32_le(bj);
     uint32_t r = u;

--- a/dist/gcc-compatible/Hacl_Chacha20_Vec32.c
+++ b/dist/gcc-compatible/Hacl_Chacha20_Vec32.c
@@ -154,17 +154,15 @@ static inline void chacha20_core_32(uint32_t *k, uint32_t *ctx, uint32_t ctr)
 static inline void chacha20_init_32(uint32_t *ctx, uint8_t *k, uint8_t *n, uint32_t ctr)
 {
   uint32_t ctx1[16U] = { 0U };
-  uint32_t *uu____0 = ctx1;
   for (uint32_t i = (uint32_t)0U; i < (uint32_t)4U; i++)
   {
-    uint32_t *os = uu____0;
+    uint32_t *os = ctx1;
     uint32_t x = Hacl_Impl_Chacha20_Vec_chacha20_constants[i];
     os[i] = x;
   }
-  uint32_t *uu____1 = ctx1 + (uint32_t)4U;
   for (uint32_t i = (uint32_t)0U; i < (uint32_t)8U; i++)
   {
-    uint32_t *os = uu____1;
+    uint32_t *os = ctx1 + (uint32_t)4U;
     uint8_t *bj = k + i * (uint32_t)4U;
     uint32_t u = load32_le(bj);
     uint32_t r = u;
@@ -172,10 +170,9 @@ static inline void chacha20_init_32(uint32_t *ctx, uint8_t *k, uint8_t *n, uint3
     os[i] = x;
   }
   ctx1[12U] = ctr;
-  uint32_t *uu____2 = ctx1 + (uint32_t)13U;
   for (uint32_t i = (uint32_t)0U; i < (uint32_t)3U; i++)
   {
-    uint32_t *os = uu____2;
+    uint32_t *os = ctx1 + (uint32_t)13U;
     uint8_t *bj = n + i * (uint32_t)4U;
     uint32_t u = load32_le(bj);
     uint32_t r = u;

--- a/dist/gcc-compatible/Hacl_HMAC_Blake2b_256.c
+++ b/dist/gcc-compatible/Hacl_HMAC_Blake2b_256.c
@@ -82,9 +82,7 @@ Hacl_HMAC_Blake2b_256_compute_blake2b_256(
     uint8_t yi = key_block[i];
     opad[i] = xi ^ yi;
   }
-  Lib_IntVector_Intrinsics_vec256 s[4U];
-  for (uint32_t _i = 0U; _i < (uint32_t)4U; ++_i)
-    s[_i] = Lib_IntVector_Intrinsics_vec256_zero;
+  Lib_IntVector_Intrinsics_vec256 s[4U] = { 0U };
   Lib_IntVector_Intrinsics_vec256 *r00 = s + (uint32_t)0U * (uint32_t)1U;
   Lib_IntVector_Intrinsics_vec256 *r10 = s + (uint32_t)1U * (uint32_t)1U;
   Lib_IntVector_Intrinsics_vec256 *r20 = s + (uint32_t)2U * (uint32_t)1U;

--- a/dist/gcc-compatible/Hacl_HMAC_Blake2b_256.c
+++ b/dist/gcc-compatible/Hacl_HMAC_Blake2b_256.c
@@ -172,31 +172,16 @@ Hacl_HMAC_Blake2b_256_compute_blake2b_256(
   r0[0U] = Lib_IntVector_Intrinsics_vec256_load64s(iv0_1, iv1, iv2, iv3);
   r1[0U] = Lib_IntVector_Intrinsics_vec256_load64s(iv4, iv5, iv6, iv7);
   FStar_UInt128_uint128 ev0 = FStar_UInt128_uint64_to_uint128((uint64_t)0U);
-  FStar_UInt128_uint128 ev11;
-  if ((uint32_t)64U == (uint32_t)0U)
-  {
-    FStar_UInt128_uint128
-    ev1 =
-      Hacl_Hash_Blake2b_256_update_last_blake2b_256(s0,
-        ev0,
-        FStar_UInt128_uint64_to_uint128((uint64_t)0U),
-        opad,
-        (uint32_t)128U);
-    ev11 = ev1;
-  }
-  else
-  {
-    FStar_UInt128_uint128
-    ev1 = Hacl_Hash_Blake2b_256_update_multi_blake2b_256(s0, ev0, opad, (uint32_t)1U);
-    FStar_UInt128_uint128
-    ev2 =
-      Hacl_Hash_Blake2b_256_update_last_blake2b_256(s0,
-        ev1,
-        FStar_UInt128_uint64_to_uint128((uint64_t)(uint32_t)128U),
-        hash1,
-        (uint32_t)64U);
-    ev11 = ev2;
-  }
+  FStar_UInt128_uint128
+  ev1 = Hacl_Hash_Blake2b_256_update_multi_blake2b_256(s0, ev0, opad, (uint32_t)1U);
+  FStar_UInt128_uint128
+  ev2 =
+    Hacl_Hash_Blake2b_256_update_last_blake2b_256(s0,
+      ev1,
+      FStar_UInt128_uint64_to_uint128((uint64_t)(uint32_t)128U),
+      hash1,
+      (uint32_t)64U);
+  FStar_UInt128_uint128 ev11 = ev2;
   Hacl_Hash_Blake2b_256_finish_blake2b_256(s0, ev11, dst);
 }
 

--- a/dist/gcc-compatible/Hacl_HMAC_Blake2s_128.c
+++ b/dist/gcc-compatible/Hacl_HMAC_Blake2s_128.c
@@ -82,9 +82,7 @@ Hacl_HMAC_Blake2s_128_compute_blake2s_128(
     uint8_t yi = key_block[i];
     opad[i] = xi ^ yi;
   }
-  Lib_IntVector_Intrinsics_vec128 s[4U];
-  for (uint32_t _i = 0U; _i < (uint32_t)4U; ++_i)
-    s[_i] = Lib_IntVector_Intrinsics_vec128_zero;
+  Lib_IntVector_Intrinsics_vec128 s[4U] = { 0U };
   Lib_IntVector_Intrinsics_vec128 *r00 = s + (uint32_t)0U * (uint32_t)1U;
   Lib_IntVector_Intrinsics_vec128 *r10 = s + (uint32_t)1U * (uint32_t)1U;
   Lib_IntVector_Intrinsics_vec128 *r20 = s + (uint32_t)2U * (uint32_t)1U;

--- a/dist/gcc-compatible/Hacl_HMAC_Blake2s_128.c
+++ b/dist/gcc-compatible/Hacl_HMAC_Blake2s_128.c
@@ -166,25 +166,15 @@ Hacl_HMAC_Blake2s_128_compute_blake2s_128(
   r0[0U] = Lib_IntVector_Intrinsics_vec128_load32s(iv0_1, iv1, iv2, iv3);
   r1[0U] = Lib_IntVector_Intrinsics_vec128_load32s(iv4, iv5, iv6, iv7);
   uint64_t ev0 = (uint64_t)0U;
-  uint64_t ev11;
-  if ((uint32_t)32U == (uint32_t)0U)
-  {
-    uint64_t
-    ev1 = Hacl_Hash_Blake2s_128_update_last_blake2s_128(s0, ev0, (uint64_t)0U, opad, (uint32_t)64U);
-    ev11 = ev1;
-  }
-  else
-  {
-    uint64_t ev1 = Hacl_Hash_Blake2s_128_update_multi_blake2s_128(s0, ev0, opad, (uint32_t)1U);
-    uint64_t
-    ev2 =
-      Hacl_Hash_Blake2s_128_update_last_blake2s_128(s0,
-        ev1,
-        (uint64_t)(uint32_t)64U,
-        hash1,
-        (uint32_t)32U);
-    ev11 = ev2;
-  }
+  uint64_t ev1 = Hacl_Hash_Blake2s_128_update_multi_blake2s_128(s0, ev0, opad, (uint32_t)1U);
+  uint64_t
+  ev2 =
+    Hacl_Hash_Blake2s_128_update_last_blake2s_128(s0,
+      ev1,
+      (uint64_t)(uint32_t)64U,
+      hash1,
+      (uint32_t)32U);
+  uint64_t ev11 = ev2;
   Hacl_Hash_Blake2s_128_finish_blake2s_128(s0, ev11, dst);
 }
 

--- a/dist/gcc-compatible/Hacl_HPKE_Curve51_CP128_SHA256.c
+++ b/dist/gcc-compatible/Hacl_HPKE_Curve51_CP128_SHA256.c
@@ -63,14 +63,9 @@ Hacl_HPKE_Curve51_CP128_SHA256_setupBaseS(
       res = (uint32_t)0U;
     }
     uint32_t res20 = res;
-    uint8_t o_kemcontext[64U];
+    uint8_t o_kemcontext[64U] = { 0U };
     if (res20 == (uint32_t)0U)
     {
-      uint8_t init = (uint8_t)0U;
-      for (uint32_t i = (uint32_t)0U; i < (uint32_t)64U; i++)
-      {
-        o_kemcontext[i] = init;
-      }
       memcpy(o_kemcontext, o_pkE, (uint32_t)32U * sizeof (uint8_t));
       uint8_t *o_pkRm = o_kemcontext + (uint32_t)32U;
       uint8_t *o_pkR = o_pkRm;
@@ -343,14 +338,9 @@ Hacl_HPKE_Curve51_CP128_SHA256_setupBaseR(
   uint8_t pkR[32U] = { 0U };
   Hacl_Curve25519_51_secret_to_public(pkR, skR);
   uint32_t res1 = (uint32_t)0U;
-  uint8_t shared[32U];
+  uint8_t shared[32U] = { 0U };
   if (res1 == (uint32_t)0U)
   {
-    uint8_t init = (uint8_t)0U;
-    for (uint32_t i = (uint32_t)0U; i < (uint32_t)32U; i++)
-    {
-      shared[i] = init;
-    }
     uint8_t *pkE = enc;
     uint8_t dh[32U] = { 0U };
     uint8_t zeros[32U] = { 0U };
@@ -372,15 +362,10 @@ Hacl_HPKE_Curve51_CP128_SHA256_setupBaseR(
       res = (uint32_t)0U;
     }
     uint32_t res11 = res;
-    uint8_t kemcontext[64U];
     uint32_t res2;
+    uint8_t kemcontext[64U] = { 0U };
     if (res11 == (uint32_t)0U)
     {
-      uint8_t init = (uint8_t)0U;
-      for (uint32_t i = (uint32_t)0U; i < (uint32_t)64U; i++)
-      {
-        kemcontext[i] = init;
-      }
       uint8_t *pkRm = kemcontext + (uint32_t)32U;
       uint8_t *pkR1 = pkRm;
       Hacl_Curve25519_51_secret_to_public(pkR1, skR);

--- a/dist/gcc-compatible/Hacl_HPKE_Curve51_CP128_SHA512.c
+++ b/dist/gcc-compatible/Hacl_HPKE_Curve51_CP128_SHA512.c
@@ -63,14 +63,9 @@ Hacl_HPKE_Curve51_CP128_SHA512_setupBaseS(
       res = (uint32_t)0U;
     }
     uint32_t res20 = res;
-    uint8_t o_kemcontext[64U];
+    uint8_t o_kemcontext[64U] = { 0U };
     if (res20 == (uint32_t)0U)
     {
-      uint8_t init = (uint8_t)0U;
-      for (uint32_t i = (uint32_t)0U; i < (uint32_t)64U; i++)
-      {
-        o_kemcontext[i] = init;
-      }
       memcpy(o_kemcontext, o_pkE, (uint32_t)32U * sizeof (uint8_t));
       uint8_t *o_pkRm = o_kemcontext + (uint32_t)32U;
       uint8_t *o_pkR = o_pkRm;
@@ -343,14 +338,9 @@ Hacl_HPKE_Curve51_CP128_SHA512_setupBaseR(
   uint8_t pkR[32U] = { 0U };
   Hacl_Curve25519_51_secret_to_public(pkR, skR);
   uint32_t res1 = (uint32_t)0U;
-  uint8_t shared[32U];
+  uint8_t shared[32U] = { 0U };
   if (res1 == (uint32_t)0U)
   {
-    uint8_t init = (uint8_t)0U;
-    for (uint32_t i = (uint32_t)0U; i < (uint32_t)32U; i++)
-    {
-      shared[i] = init;
-    }
     uint8_t *pkE = enc;
     uint8_t dh[32U] = { 0U };
     uint8_t zeros[32U] = { 0U };
@@ -372,15 +362,10 @@ Hacl_HPKE_Curve51_CP128_SHA512_setupBaseR(
       res = (uint32_t)0U;
     }
     uint32_t res11 = res;
-    uint8_t kemcontext[64U];
     uint32_t res2;
+    uint8_t kemcontext[64U] = { 0U };
     if (res11 == (uint32_t)0U)
     {
-      uint8_t init = (uint8_t)0U;
-      for (uint32_t i = (uint32_t)0U; i < (uint32_t)64U; i++)
-      {
-        kemcontext[i] = init;
-      }
       uint8_t *pkRm = kemcontext + (uint32_t)32U;
       uint8_t *pkR1 = pkRm;
       Hacl_Curve25519_51_secret_to_public(pkR1, skR);

--- a/dist/gcc-compatible/Hacl_HPKE_Curve51_CP256_SHA256.c
+++ b/dist/gcc-compatible/Hacl_HPKE_Curve51_CP256_SHA256.c
@@ -63,14 +63,9 @@ Hacl_HPKE_Curve51_CP256_SHA256_setupBaseS(
       res = (uint32_t)0U;
     }
     uint32_t res20 = res;
-    uint8_t o_kemcontext[64U];
+    uint8_t o_kemcontext[64U] = { 0U };
     if (res20 == (uint32_t)0U)
     {
-      uint8_t init = (uint8_t)0U;
-      for (uint32_t i = (uint32_t)0U; i < (uint32_t)64U; i++)
-      {
-        o_kemcontext[i] = init;
-      }
       memcpy(o_kemcontext, o_pkE, (uint32_t)32U * sizeof (uint8_t));
       uint8_t *o_pkRm = o_kemcontext + (uint32_t)32U;
       uint8_t *o_pkR = o_pkRm;
@@ -343,14 +338,9 @@ Hacl_HPKE_Curve51_CP256_SHA256_setupBaseR(
   uint8_t pkR[32U] = { 0U };
   Hacl_Curve25519_51_secret_to_public(pkR, skR);
   uint32_t res1 = (uint32_t)0U;
-  uint8_t shared[32U];
+  uint8_t shared[32U] = { 0U };
   if (res1 == (uint32_t)0U)
   {
-    uint8_t init = (uint8_t)0U;
-    for (uint32_t i = (uint32_t)0U; i < (uint32_t)32U; i++)
-    {
-      shared[i] = init;
-    }
     uint8_t *pkE = enc;
     uint8_t dh[32U] = { 0U };
     uint8_t zeros[32U] = { 0U };
@@ -372,15 +362,10 @@ Hacl_HPKE_Curve51_CP256_SHA256_setupBaseR(
       res = (uint32_t)0U;
     }
     uint32_t res11 = res;
-    uint8_t kemcontext[64U];
     uint32_t res2;
+    uint8_t kemcontext[64U] = { 0U };
     if (res11 == (uint32_t)0U)
     {
-      uint8_t init = (uint8_t)0U;
-      for (uint32_t i = (uint32_t)0U; i < (uint32_t)64U; i++)
-      {
-        kemcontext[i] = init;
-      }
       uint8_t *pkRm = kemcontext + (uint32_t)32U;
       uint8_t *pkR1 = pkRm;
       Hacl_Curve25519_51_secret_to_public(pkR1, skR);

--- a/dist/gcc-compatible/Hacl_HPKE_Curve51_CP256_SHA512.c
+++ b/dist/gcc-compatible/Hacl_HPKE_Curve51_CP256_SHA512.c
@@ -63,14 +63,9 @@ Hacl_HPKE_Curve51_CP256_SHA512_setupBaseS(
       res = (uint32_t)0U;
     }
     uint32_t res20 = res;
-    uint8_t o_kemcontext[64U];
+    uint8_t o_kemcontext[64U] = { 0U };
     if (res20 == (uint32_t)0U)
     {
-      uint8_t init = (uint8_t)0U;
-      for (uint32_t i = (uint32_t)0U; i < (uint32_t)64U; i++)
-      {
-        o_kemcontext[i] = init;
-      }
       memcpy(o_kemcontext, o_pkE, (uint32_t)32U * sizeof (uint8_t));
       uint8_t *o_pkRm = o_kemcontext + (uint32_t)32U;
       uint8_t *o_pkR = o_pkRm;
@@ -343,14 +338,9 @@ Hacl_HPKE_Curve51_CP256_SHA512_setupBaseR(
   uint8_t pkR[32U] = { 0U };
   Hacl_Curve25519_51_secret_to_public(pkR, skR);
   uint32_t res1 = (uint32_t)0U;
-  uint8_t shared[32U];
+  uint8_t shared[32U] = { 0U };
   if (res1 == (uint32_t)0U)
   {
-    uint8_t init = (uint8_t)0U;
-    for (uint32_t i = (uint32_t)0U; i < (uint32_t)32U; i++)
-    {
-      shared[i] = init;
-    }
     uint8_t *pkE = enc;
     uint8_t dh[32U] = { 0U };
     uint8_t zeros[32U] = { 0U };
@@ -372,15 +362,10 @@ Hacl_HPKE_Curve51_CP256_SHA512_setupBaseR(
       res = (uint32_t)0U;
     }
     uint32_t res11 = res;
-    uint8_t kemcontext[64U];
     uint32_t res2;
+    uint8_t kemcontext[64U] = { 0U };
     if (res11 == (uint32_t)0U)
     {
-      uint8_t init = (uint8_t)0U;
-      for (uint32_t i = (uint32_t)0U; i < (uint32_t)64U; i++)
-      {
-        kemcontext[i] = init;
-      }
       uint8_t *pkRm = kemcontext + (uint32_t)32U;
       uint8_t *pkR1 = pkRm;
       Hacl_Curve25519_51_secret_to_public(pkR1, skR);

--- a/dist/gcc-compatible/Hacl_HPKE_Curve51_CP32_SHA256.c
+++ b/dist/gcc-compatible/Hacl_HPKE_Curve51_CP32_SHA256.c
@@ -63,14 +63,9 @@ Hacl_HPKE_Curve51_CP32_SHA256_setupBaseS(
       res = (uint32_t)0U;
     }
     uint32_t res20 = res;
-    uint8_t o_kemcontext[64U];
+    uint8_t o_kemcontext[64U] = { 0U };
     if (res20 == (uint32_t)0U)
     {
-      uint8_t init = (uint8_t)0U;
-      for (uint32_t i = (uint32_t)0U; i < (uint32_t)64U; i++)
-      {
-        o_kemcontext[i] = init;
-      }
       memcpy(o_kemcontext, o_pkE, (uint32_t)32U * sizeof (uint8_t));
       uint8_t *o_pkRm = o_kemcontext + (uint32_t)32U;
       uint8_t *o_pkR = o_pkRm;
@@ -343,14 +338,9 @@ Hacl_HPKE_Curve51_CP32_SHA256_setupBaseR(
   uint8_t pkR[32U] = { 0U };
   Hacl_Curve25519_51_secret_to_public(pkR, skR);
   uint32_t res1 = (uint32_t)0U;
-  uint8_t shared[32U];
+  uint8_t shared[32U] = { 0U };
   if (res1 == (uint32_t)0U)
   {
-    uint8_t init = (uint8_t)0U;
-    for (uint32_t i = (uint32_t)0U; i < (uint32_t)32U; i++)
-    {
-      shared[i] = init;
-    }
     uint8_t *pkE = enc;
     uint8_t dh[32U] = { 0U };
     uint8_t zeros[32U] = { 0U };
@@ -372,15 +362,10 @@ Hacl_HPKE_Curve51_CP32_SHA256_setupBaseR(
       res = (uint32_t)0U;
     }
     uint32_t res11 = res;
-    uint8_t kemcontext[64U];
     uint32_t res2;
+    uint8_t kemcontext[64U] = { 0U };
     if (res11 == (uint32_t)0U)
     {
-      uint8_t init = (uint8_t)0U;
-      for (uint32_t i = (uint32_t)0U; i < (uint32_t)64U; i++)
-      {
-        kemcontext[i] = init;
-      }
       uint8_t *pkRm = kemcontext + (uint32_t)32U;
       uint8_t *pkR1 = pkRm;
       Hacl_Curve25519_51_secret_to_public(pkR1, skR);

--- a/dist/gcc-compatible/Hacl_HPKE_Curve51_CP32_SHA512.c
+++ b/dist/gcc-compatible/Hacl_HPKE_Curve51_CP32_SHA512.c
@@ -63,14 +63,9 @@ Hacl_HPKE_Curve51_CP32_SHA512_setupBaseS(
       res = (uint32_t)0U;
     }
     uint32_t res20 = res;
-    uint8_t o_kemcontext[64U];
+    uint8_t o_kemcontext[64U] = { 0U };
     if (res20 == (uint32_t)0U)
     {
-      uint8_t init = (uint8_t)0U;
-      for (uint32_t i = (uint32_t)0U; i < (uint32_t)64U; i++)
-      {
-        o_kemcontext[i] = init;
-      }
       memcpy(o_kemcontext, o_pkE, (uint32_t)32U * sizeof (uint8_t));
       uint8_t *o_pkRm = o_kemcontext + (uint32_t)32U;
       uint8_t *o_pkR = o_pkRm;
@@ -343,14 +338,9 @@ Hacl_HPKE_Curve51_CP32_SHA512_setupBaseR(
   uint8_t pkR[32U] = { 0U };
   Hacl_Curve25519_51_secret_to_public(pkR, skR);
   uint32_t res1 = (uint32_t)0U;
-  uint8_t shared[32U];
+  uint8_t shared[32U] = { 0U };
   if (res1 == (uint32_t)0U)
   {
-    uint8_t init = (uint8_t)0U;
-    for (uint32_t i = (uint32_t)0U; i < (uint32_t)32U; i++)
-    {
-      shared[i] = init;
-    }
     uint8_t *pkE = enc;
     uint8_t dh[32U] = { 0U };
     uint8_t zeros[32U] = { 0U };
@@ -372,15 +362,10 @@ Hacl_HPKE_Curve51_CP32_SHA512_setupBaseR(
       res = (uint32_t)0U;
     }
     uint32_t res11 = res;
-    uint8_t kemcontext[64U];
     uint32_t res2;
+    uint8_t kemcontext[64U] = { 0U };
     if (res11 == (uint32_t)0U)
     {
-      uint8_t init = (uint8_t)0U;
-      for (uint32_t i = (uint32_t)0U; i < (uint32_t)64U; i++)
-      {
-        kemcontext[i] = init;
-      }
       uint8_t *pkRm = kemcontext + (uint32_t)32U;
       uint8_t *pkR1 = pkRm;
       Hacl_Curve25519_51_secret_to_public(pkR1, skR);

--- a/dist/gcc-compatible/Hacl_HPKE_Curve64_CP128_SHA256.c
+++ b/dist/gcc-compatible/Hacl_HPKE_Curve64_CP128_SHA256.c
@@ -63,14 +63,9 @@ Hacl_HPKE_Curve64_CP128_SHA256_setupBaseS(
       res = (uint32_t)0U;
     }
     uint32_t res20 = res;
-    uint8_t o_kemcontext[64U];
+    uint8_t o_kemcontext[64U] = { 0U };
     if (res20 == (uint32_t)0U)
     {
-      uint8_t init = (uint8_t)0U;
-      for (uint32_t i = (uint32_t)0U; i < (uint32_t)64U; i++)
-      {
-        o_kemcontext[i] = init;
-      }
       memcpy(o_kemcontext, o_pkE, (uint32_t)32U * sizeof (uint8_t));
       uint8_t *o_pkRm = o_kemcontext + (uint32_t)32U;
       uint8_t *o_pkR = o_pkRm;
@@ -343,14 +338,9 @@ Hacl_HPKE_Curve64_CP128_SHA256_setupBaseR(
   uint8_t pkR[32U] = { 0U };
   Hacl_Curve25519_64_secret_to_public(pkR, skR);
   uint32_t res1 = (uint32_t)0U;
-  uint8_t shared[32U];
+  uint8_t shared[32U] = { 0U };
   if (res1 == (uint32_t)0U)
   {
-    uint8_t init = (uint8_t)0U;
-    for (uint32_t i = (uint32_t)0U; i < (uint32_t)32U; i++)
-    {
-      shared[i] = init;
-    }
     uint8_t *pkE = enc;
     uint8_t dh[32U] = { 0U };
     uint8_t zeros[32U] = { 0U };
@@ -372,15 +362,10 @@ Hacl_HPKE_Curve64_CP128_SHA256_setupBaseR(
       res = (uint32_t)0U;
     }
     uint32_t res11 = res;
-    uint8_t kemcontext[64U];
     uint32_t res2;
+    uint8_t kemcontext[64U] = { 0U };
     if (res11 == (uint32_t)0U)
     {
-      uint8_t init = (uint8_t)0U;
-      for (uint32_t i = (uint32_t)0U; i < (uint32_t)64U; i++)
-      {
-        kemcontext[i] = init;
-      }
       uint8_t *pkRm = kemcontext + (uint32_t)32U;
       uint8_t *pkR1 = pkRm;
       Hacl_Curve25519_64_secret_to_public(pkR1, skR);

--- a/dist/gcc-compatible/Hacl_HPKE_Curve64_CP128_SHA512.c
+++ b/dist/gcc-compatible/Hacl_HPKE_Curve64_CP128_SHA512.c
@@ -63,14 +63,9 @@ Hacl_HPKE_Curve64_CP128_SHA512_setupBaseS(
       res = (uint32_t)0U;
     }
     uint32_t res20 = res;
-    uint8_t o_kemcontext[64U];
+    uint8_t o_kemcontext[64U] = { 0U };
     if (res20 == (uint32_t)0U)
     {
-      uint8_t init = (uint8_t)0U;
-      for (uint32_t i = (uint32_t)0U; i < (uint32_t)64U; i++)
-      {
-        o_kemcontext[i] = init;
-      }
       memcpy(o_kemcontext, o_pkE, (uint32_t)32U * sizeof (uint8_t));
       uint8_t *o_pkRm = o_kemcontext + (uint32_t)32U;
       uint8_t *o_pkR = o_pkRm;
@@ -343,14 +338,9 @@ Hacl_HPKE_Curve64_CP128_SHA512_setupBaseR(
   uint8_t pkR[32U] = { 0U };
   Hacl_Curve25519_64_secret_to_public(pkR, skR);
   uint32_t res1 = (uint32_t)0U;
-  uint8_t shared[32U];
+  uint8_t shared[32U] = { 0U };
   if (res1 == (uint32_t)0U)
   {
-    uint8_t init = (uint8_t)0U;
-    for (uint32_t i = (uint32_t)0U; i < (uint32_t)32U; i++)
-    {
-      shared[i] = init;
-    }
     uint8_t *pkE = enc;
     uint8_t dh[32U] = { 0U };
     uint8_t zeros[32U] = { 0U };
@@ -372,15 +362,10 @@ Hacl_HPKE_Curve64_CP128_SHA512_setupBaseR(
       res = (uint32_t)0U;
     }
     uint32_t res11 = res;
-    uint8_t kemcontext[64U];
     uint32_t res2;
+    uint8_t kemcontext[64U] = { 0U };
     if (res11 == (uint32_t)0U)
     {
-      uint8_t init = (uint8_t)0U;
-      for (uint32_t i = (uint32_t)0U; i < (uint32_t)64U; i++)
-      {
-        kemcontext[i] = init;
-      }
       uint8_t *pkRm = kemcontext + (uint32_t)32U;
       uint8_t *pkR1 = pkRm;
       Hacl_Curve25519_64_secret_to_public(pkR1, skR);

--- a/dist/gcc-compatible/Hacl_HPKE_Curve64_CP256_SHA256.c
+++ b/dist/gcc-compatible/Hacl_HPKE_Curve64_CP256_SHA256.c
@@ -63,14 +63,9 @@ Hacl_HPKE_Curve64_CP256_SHA256_setupBaseS(
       res = (uint32_t)0U;
     }
     uint32_t res20 = res;
-    uint8_t o_kemcontext[64U];
+    uint8_t o_kemcontext[64U] = { 0U };
     if (res20 == (uint32_t)0U)
     {
-      uint8_t init = (uint8_t)0U;
-      for (uint32_t i = (uint32_t)0U; i < (uint32_t)64U; i++)
-      {
-        o_kemcontext[i] = init;
-      }
       memcpy(o_kemcontext, o_pkE, (uint32_t)32U * sizeof (uint8_t));
       uint8_t *o_pkRm = o_kemcontext + (uint32_t)32U;
       uint8_t *o_pkR = o_pkRm;
@@ -343,14 +338,9 @@ Hacl_HPKE_Curve64_CP256_SHA256_setupBaseR(
   uint8_t pkR[32U] = { 0U };
   Hacl_Curve25519_64_secret_to_public(pkR, skR);
   uint32_t res1 = (uint32_t)0U;
-  uint8_t shared[32U];
+  uint8_t shared[32U] = { 0U };
   if (res1 == (uint32_t)0U)
   {
-    uint8_t init = (uint8_t)0U;
-    for (uint32_t i = (uint32_t)0U; i < (uint32_t)32U; i++)
-    {
-      shared[i] = init;
-    }
     uint8_t *pkE = enc;
     uint8_t dh[32U] = { 0U };
     uint8_t zeros[32U] = { 0U };
@@ -372,15 +362,10 @@ Hacl_HPKE_Curve64_CP256_SHA256_setupBaseR(
       res = (uint32_t)0U;
     }
     uint32_t res11 = res;
-    uint8_t kemcontext[64U];
     uint32_t res2;
+    uint8_t kemcontext[64U] = { 0U };
     if (res11 == (uint32_t)0U)
     {
-      uint8_t init = (uint8_t)0U;
-      for (uint32_t i = (uint32_t)0U; i < (uint32_t)64U; i++)
-      {
-        kemcontext[i] = init;
-      }
       uint8_t *pkRm = kemcontext + (uint32_t)32U;
       uint8_t *pkR1 = pkRm;
       Hacl_Curve25519_64_secret_to_public(pkR1, skR);

--- a/dist/gcc-compatible/Hacl_HPKE_Curve64_CP256_SHA512.c
+++ b/dist/gcc-compatible/Hacl_HPKE_Curve64_CP256_SHA512.c
@@ -63,14 +63,9 @@ Hacl_HPKE_Curve64_CP256_SHA512_setupBaseS(
       res = (uint32_t)0U;
     }
     uint32_t res20 = res;
-    uint8_t o_kemcontext[64U];
+    uint8_t o_kemcontext[64U] = { 0U };
     if (res20 == (uint32_t)0U)
     {
-      uint8_t init = (uint8_t)0U;
-      for (uint32_t i = (uint32_t)0U; i < (uint32_t)64U; i++)
-      {
-        o_kemcontext[i] = init;
-      }
       memcpy(o_kemcontext, o_pkE, (uint32_t)32U * sizeof (uint8_t));
       uint8_t *o_pkRm = o_kemcontext + (uint32_t)32U;
       uint8_t *o_pkR = o_pkRm;
@@ -343,14 +338,9 @@ Hacl_HPKE_Curve64_CP256_SHA512_setupBaseR(
   uint8_t pkR[32U] = { 0U };
   Hacl_Curve25519_64_secret_to_public(pkR, skR);
   uint32_t res1 = (uint32_t)0U;
-  uint8_t shared[32U];
+  uint8_t shared[32U] = { 0U };
   if (res1 == (uint32_t)0U)
   {
-    uint8_t init = (uint8_t)0U;
-    for (uint32_t i = (uint32_t)0U; i < (uint32_t)32U; i++)
-    {
-      shared[i] = init;
-    }
     uint8_t *pkE = enc;
     uint8_t dh[32U] = { 0U };
     uint8_t zeros[32U] = { 0U };
@@ -372,15 +362,10 @@ Hacl_HPKE_Curve64_CP256_SHA512_setupBaseR(
       res = (uint32_t)0U;
     }
     uint32_t res11 = res;
-    uint8_t kemcontext[64U];
     uint32_t res2;
+    uint8_t kemcontext[64U] = { 0U };
     if (res11 == (uint32_t)0U)
     {
-      uint8_t init = (uint8_t)0U;
-      for (uint32_t i = (uint32_t)0U; i < (uint32_t)64U; i++)
-      {
-        kemcontext[i] = init;
-      }
       uint8_t *pkRm = kemcontext + (uint32_t)32U;
       uint8_t *pkR1 = pkRm;
       Hacl_Curve25519_64_secret_to_public(pkR1, skR);

--- a/dist/gcc-compatible/Hacl_HPKE_Curve64_CP32_SHA256.c
+++ b/dist/gcc-compatible/Hacl_HPKE_Curve64_CP32_SHA256.c
@@ -63,14 +63,9 @@ Hacl_HPKE_Curve64_CP32_SHA256_setupBaseS(
       res = (uint32_t)0U;
     }
     uint32_t res20 = res;
-    uint8_t o_kemcontext[64U];
+    uint8_t o_kemcontext[64U] = { 0U };
     if (res20 == (uint32_t)0U)
     {
-      uint8_t init = (uint8_t)0U;
-      for (uint32_t i = (uint32_t)0U; i < (uint32_t)64U; i++)
-      {
-        o_kemcontext[i] = init;
-      }
       memcpy(o_kemcontext, o_pkE, (uint32_t)32U * sizeof (uint8_t));
       uint8_t *o_pkRm = o_kemcontext + (uint32_t)32U;
       uint8_t *o_pkR = o_pkRm;
@@ -343,14 +338,9 @@ Hacl_HPKE_Curve64_CP32_SHA256_setupBaseR(
   uint8_t pkR[32U] = { 0U };
   Hacl_Curve25519_64_secret_to_public(pkR, skR);
   uint32_t res1 = (uint32_t)0U;
-  uint8_t shared[32U];
+  uint8_t shared[32U] = { 0U };
   if (res1 == (uint32_t)0U)
   {
-    uint8_t init = (uint8_t)0U;
-    for (uint32_t i = (uint32_t)0U; i < (uint32_t)32U; i++)
-    {
-      shared[i] = init;
-    }
     uint8_t *pkE = enc;
     uint8_t dh[32U] = { 0U };
     uint8_t zeros[32U] = { 0U };
@@ -372,15 +362,10 @@ Hacl_HPKE_Curve64_CP32_SHA256_setupBaseR(
       res = (uint32_t)0U;
     }
     uint32_t res11 = res;
-    uint8_t kemcontext[64U];
     uint32_t res2;
+    uint8_t kemcontext[64U] = { 0U };
     if (res11 == (uint32_t)0U)
     {
-      uint8_t init = (uint8_t)0U;
-      for (uint32_t i = (uint32_t)0U; i < (uint32_t)64U; i++)
-      {
-        kemcontext[i] = init;
-      }
       uint8_t *pkRm = kemcontext + (uint32_t)32U;
       uint8_t *pkR1 = pkRm;
       Hacl_Curve25519_64_secret_to_public(pkR1, skR);

--- a/dist/gcc-compatible/Hacl_HPKE_Curve64_CP32_SHA512.c
+++ b/dist/gcc-compatible/Hacl_HPKE_Curve64_CP32_SHA512.c
@@ -63,14 +63,9 @@ Hacl_HPKE_Curve64_CP32_SHA512_setupBaseS(
       res = (uint32_t)0U;
     }
     uint32_t res20 = res;
-    uint8_t o_kemcontext[64U];
+    uint8_t o_kemcontext[64U] = { 0U };
     if (res20 == (uint32_t)0U)
     {
-      uint8_t init = (uint8_t)0U;
-      for (uint32_t i = (uint32_t)0U; i < (uint32_t)64U; i++)
-      {
-        o_kemcontext[i] = init;
-      }
       memcpy(o_kemcontext, o_pkE, (uint32_t)32U * sizeof (uint8_t));
       uint8_t *o_pkRm = o_kemcontext + (uint32_t)32U;
       uint8_t *o_pkR = o_pkRm;
@@ -343,14 +338,9 @@ Hacl_HPKE_Curve64_CP32_SHA512_setupBaseR(
   uint8_t pkR[32U] = { 0U };
   Hacl_Curve25519_64_secret_to_public(pkR, skR);
   uint32_t res1 = (uint32_t)0U;
-  uint8_t shared[32U];
+  uint8_t shared[32U] = { 0U };
   if (res1 == (uint32_t)0U)
   {
-    uint8_t init = (uint8_t)0U;
-    for (uint32_t i = (uint32_t)0U; i < (uint32_t)32U; i++)
-    {
-      shared[i] = init;
-    }
     uint8_t *pkE = enc;
     uint8_t dh[32U] = { 0U };
     uint8_t zeros[32U] = { 0U };
@@ -372,15 +362,10 @@ Hacl_HPKE_Curve64_CP32_SHA512_setupBaseR(
       res = (uint32_t)0U;
     }
     uint32_t res11 = res;
-    uint8_t kemcontext[64U];
     uint32_t res2;
+    uint8_t kemcontext[64U] = { 0U };
     if (res11 == (uint32_t)0U)
     {
-      uint8_t init = (uint8_t)0U;
-      for (uint32_t i = (uint32_t)0U; i < (uint32_t)64U; i++)
-      {
-        kemcontext[i] = init;
-      }
       uint8_t *pkRm = kemcontext + (uint32_t)32U;
       uint8_t *pkR1 = pkRm;
       Hacl_Curve25519_64_secret_to_public(pkR1, skR);

--- a/dist/gcc-compatible/Hacl_HPKE_P256_CP128_SHA256.c
+++ b/dist/gcc-compatible/Hacl_HPKE_P256_CP128_SHA256.c
@@ -94,14 +94,9 @@ Hacl_HPKE_P256_CP128_SHA256_setupBaseS(
     {
       res2 = (uint32_t)1U;
     }
-    uint8_t o_kemcontext[130U];
+    uint8_t o_kemcontext[130U] = { 0U };
     if (res2 == (uint32_t)0U)
     {
-      uint8_t init = (uint8_t)0U;
-      for (uint32_t i = (uint32_t)0U; i < (uint32_t)130U; i++)
-      {
-        o_kemcontext[i] = init;
-      }
       memcpy(o_kemcontext, o_pkE, (uint32_t)65U * sizeof (uint8_t));
       uint8_t *o_pkRm = o_kemcontext + (uint32_t)65U;
       uint8_t *o_pkR = o_pkRm + (uint32_t)1U;
@@ -395,14 +390,9 @@ Hacl_HPKE_P256_CP128_SHA256_setupBaseR(
   {
     res1 = (uint32_t)1U;
   }
-  uint8_t shared[32U];
+  uint8_t shared[32U] = { 0U };
   if (res1 == (uint32_t)0U)
   {
-    uint8_t init = (uint8_t)0U;
-    for (uint32_t i = (uint32_t)0U; i < (uint32_t)32U; i++)
-    {
-      shared[i] = init;
-    }
     uint8_t *pkE = enc + (uint32_t)1U;
     uint8_t dh[64U] = { 0U };
     uint8_t tmp0[64U] = { 0U };
@@ -434,15 +424,10 @@ Hacl_HPKE_P256_CP128_SHA256_setupBaseR(
     {
       res11 = (uint32_t)1U;
     }
-    uint8_t kemcontext[130U];
     uint32_t res20;
+    uint8_t kemcontext[130U] = { 0U };
     if (res11 == (uint32_t)0U)
     {
-      uint8_t init = (uint8_t)0U;
-      for (uint32_t i = (uint32_t)0U; i < (uint32_t)130U; i++)
-      {
-        kemcontext[i] = init;
-      }
       uint8_t *pkRm = kemcontext + (uint32_t)65U;
       uint8_t *pkR1 = pkRm + (uint32_t)1U;
       uint64_t tempBuffer[100U] = { 0U };

--- a/dist/gcc-compatible/Hacl_HPKE_P256_CP256_SHA256.c
+++ b/dist/gcc-compatible/Hacl_HPKE_P256_CP256_SHA256.c
@@ -94,14 +94,9 @@ Hacl_HPKE_P256_CP256_SHA256_setupBaseS(
     {
       res2 = (uint32_t)1U;
     }
-    uint8_t o_kemcontext[130U];
+    uint8_t o_kemcontext[130U] = { 0U };
     if (res2 == (uint32_t)0U)
     {
-      uint8_t init = (uint8_t)0U;
-      for (uint32_t i = (uint32_t)0U; i < (uint32_t)130U; i++)
-      {
-        o_kemcontext[i] = init;
-      }
       memcpy(o_kemcontext, o_pkE, (uint32_t)65U * sizeof (uint8_t));
       uint8_t *o_pkRm = o_kemcontext + (uint32_t)65U;
       uint8_t *o_pkR = o_pkRm + (uint32_t)1U;
@@ -395,14 +390,9 @@ Hacl_HPKE_P256_CP256_SHA256_setupBaseR(
   {
     res1 = (uint32_t)1U;
   }
-  uint8_t shared[32U];
+  uint8_t shared[32U] = { 0U };
   if (res1 == (uint32_t)0U)
   {
-    uint8_t init = (uint8_t)0U;
-    for (uint32_t i = (uint32_t)0U; i < (uint32_t)32U; i++)
-    {
-      shared[i] = init;
-    }
     uint8_t *pkE = enc + (uint32_t)1U;
     uint8_t dh[64U] = { 0U };
     uint8_t tmp0[64U] = { 0U };
@@ -434,15 +424,10 @@ Hacl_HPKE_P256_CP256_SHA256_setupBaseR(
     {
       res11 = (uint32_t)1U;
     }
-    uint8_t kemcontext[130U];
     uint32_t res20;
+    uint8_t kemcontext[130U] = { 0U };
     if (res11 == (uint32_t)0U)
     {
-      uint8_t init = (uint8_t)0U;
-      for (uint32_t i = (uint32_t)0U; i < (uint32_t)130U; i++)
-      {
-        kemcontext[i] = init;
-      }
       uint8_t *pkRm = kemcontext + (uint32_t)65U;
       uint8_t *pkR1 = pkRm + (uint32_t)1U;
       uint64_t tempBuffer[100U] = { 0U };

--- a/dist/gcc-compatible/Hacl_HPKE_P256_CP32_SHA256.c
+++ b/dist/gcc-compatible/Hacl_HPKE_P256_CP32_SHA256.c
@@ -94,14 +94,9 @@ Hacl_HPKE_P256_CP32_SHA256_setupBaseS(
     {
       res2 = (uint32_t)1U;
     }
-    uint8_t o_kemcontext[130U];
+    uint8_t o_kemcontext[130U] = { 0U };
     if (res2 == (uint32_t)0U)
     {
-      uint8_t init = (uint8_t)0U;
-      for (uint32_t i = (uint32_t)0U; i < (uint32_t)130U; i++)
-      {
-        o_kemcontext[i] = init;
-      }
       memcpy(o_kemcontext, o_pkE, (uint32_t)65U * sizeof (uint8_t));
       uint8_t *o_pkRm = o_kemcontext + (uint32_t)65U;
       uint8_t *o_pkR = o_pkRm + (uint32_t)1U;
@@ -395,14 +390,9 @@ Hacl_HPKE_P256_CP32_SHA256_setupBaseR(
   {
     res1 = (uint32_t)1U;
   }
-  uint8_t shared[32U];
+  uint8_t shared[32U] = { 0U };
   if (res1 == (uint32_t)0U)
   {
-    uint8_t init = (uint8_t)0U;
-    for (uint32_t i = (uint32_t)0U; i < (uint32_t)32U; i++)
-    {
-      shared[i] = init;
-    }
     uint8_t *pkE = enc + (uint32_t)1U;
     uint8_t dh[64U] = { 0U };
     uint8_t tmp0[64U] = { 0U };
@@ -434,15 +424,10 @@ Hacl_HPKE_P256_CP32_SHA256_setupBaseR(
     {
       res11 = (uint32_t)1U;
     }
-    uint8_t kemcontext[130U];
     uint32_t res20;
+    uint8_t kemcontext[130U] = { 0U };
     if (res11 == (uint32_t)0U)
     {
-      uint8_t init = (uint8_t)0U;
-      for (uint32_t i = (uint32_t)0U; i < (uint32_t)130U; i++)
-      {
-        kemcontext[i] = init;
-      }
       uint8_t *pkRm = kemcontext + (uint32_t)65U;
       uint8_t *pkR1 = pkRm + (uint32_t)1U;
       uint64_t tempBuffer[100U] = { 0U };

--- a/dist/gcc-compatible/Hacl_Hash_Blake2b_256.c
+++ b/dist/gcc-compatible/Hacl_Hash_Blake2b_256.c
@@ -34,9 +34,7 @@ update_blake2b_256(
   uint8_t *block
 )
 {
-  Lib_IntVector_Intrinsics_vec256 wv[4U];
-  for (uint32_t _i = 0U; _i < (uint32_t)4U; ++_i)
-    wv[_i] = Lib_IntVector_Intrinsics_vec256_zero;
+  Lib_IntVector_Intrinsics_vec256 wv[4U] = { 0U };
   FStar_UInt128_uint128
   totlen1 =
     FStar_UInt128_add_mod(totlen,

--- a/dist/gcc-compatible/Hacl_Hash_Blake2s_128.c
+++ b/dist/gcc-compatible/Hacl_Hash_Blake2s_128.c
@@ -30,9 +30,7 @@
 static uint64_t
 update_blake2s_128(Lib_IntVector_Intrinsics_vec128 *s, uint64_t totlen, uint8_t *block)
 {
-  Lib_IntVector_Intrinsics_vec128 wv[4U];
-  for (uint32_t _i = 0U; _i < (uint32_t)4U; ++_i)
-    wv[_i] = Lib_IntVector_Intrinsics_vec128_zero;
+  Lib_IntVector_Intrinsics_vec128 wv[4U] = { 0U };
   uint64_t totlen1 = totlen + (uint64_t)(uint32_t)64U;
   uint32_t m_w[16U] = { 0U };
   for (uint32_t i = (uint32_t)0U; i < (uint32_t)16U; i++)

--- a/dist/gcc-compatible/Hacl_Hash_MD5.c
+++ b/dist/gcc-compatible/Hacl_Hash_MD5.c
@@ -1126,10 +1126,9 @@ static void legacy_pad(uint64_t len, uint8_t *dst)
 
 void Hacl_Hash_Core_MD5_legacy_finish(uint32_t *s, uint8_t *dst)
 {
-  uint32_t *uu____0 = s;
   for (uint32_t i = (uint32_t)0U; i < (uint32_t)4U; i++)
   {
-    store32_le(dst + i * (uint32_t)4U, uu____0[i]);
+    store32_le(dst + i * (uint32_t)4U, s[i]);
   }
 }
 

--- a/dist/gcc-compatible/Hacl_Hash_SHA1.c
+++ b/dist/gcc-compatible/Hacl_Hash_SHA1.c
@@ -159,10 +159,9 @@ static void legacy_pad(uint64_t len, uint8_t *dst)
 
 void Hacl_Hash_Core_SHA1_legacy_finish(uint32_t *s, uint8_t *dst)
 {
-  uint32_t *uu____0 = s;
   for (uint32_t i = (uint32_t)0U; i < (uint32_t)5U; i++)
   {
-    store32_be(dst + i * (uint32_t)4U, uu____0[i]);
+    store32_be(dst + i * (uint32_t)4U, s[i]);
   }
 }
 

--- a/dist/gcc-compatible/Hacl_Hash_SHA2.c
+++ b/dist/gcc-compatible/Hacl_Hash_SHA2.c
@@ -557,37 +557,33 @@ static void pad_512(FStar_UInt128_uint128 len, uint8_t *dst)
 
 void Hacl_Hash_Core_SHA2_finish_224(uint32_t *s, uint8_t *dst)
 {
-  uint32_t *uu____0 = s;
   for (uint32_t i = (uint32_t)0U; i < (uint32_t)7U; i++)
   {
-    store32_be(dst + i * (uint32_t)4U, uu____0[i]);
+    store32_be(dst + i * (uint32_t)4U, s[i]);
   }
 }
 
 void Hacl_Hash_Core_SHA2_finish_256(uint32_t *s, uint8_t *dst)
 {
-  uint32_t *uu____0 = s;
   for (uint32_t i = (uint32_t)0U; i < (uint32_t)8U; i++)
   {
-    store32_be(dst + i * (uint32_t)4U, uu____0[i]);
+    store32_be(dst + i * (uint32_t)4U, s[i]);
   }
 }
 
 void Hacl_Hash_Core_SHA2_finish_384(uint64_t *s, uint8_t *dst)
 {
-  uint64_t *uu____0 = s;
   for (uint32_t i = (uint32_t)0U; i < (uint32_t)6U; i++)
   {
-    store64_be(dst + i * (uint32_t)8U, uu____0[i]);
+    store64_be(dst + i * (uint32_t)8U, s[i]);
   }
 }
 
 void Hacl_Hash_Core_SHA2_finish_512(uint64_t *s, uint8_t *dst)
 {
-  uint64_t *uu____0 = s;
   for (uint32_t i = (uint32_t)0U; i < (uint32_t)8U; i++)
   {
-    store64_be(dst + i * (uint32_t)8U, uu____0[i]);
+    store64_be(dst + i * (uint32_t)8U, s[i]);
   }
 }
 

--- a/dist/gcc-compatible/Hacl_Poly1305_128.c
+++ b/dist/gcc-compatible/Hacl_Poly1305_128.c
@@ -29,9 +29,7 @@
 void
 Hacl_Impl_Poly1305_Field32xN_128_load_acc2(Lib_IntVector_Intrinsics_vec128 *acc, uint8_t *b)
 {
-  Lib_IntVector_Intrinsics_vec128 e[5U];
-  for (uint32_t _i = 0U; _i < (uint32_t)5U; ++_i)
-    e[_i] = Lib_IntVector_Intrinsics_vec128_zero;
+  Lib_IntVector_Intrinsics_vec128 e[5U] = { 0U };
   Lib_IntVector_Intrinsics_vec128 b1 = Lib_IntVector_Intrinsics_vec128_load64_le(b);
   Lib_IntVector_Intrinsics_vec128
   b2 = Lib_IntVector_Intrinsics_vec128_load64_le(b + (uint32_t)16U);
@@ -573,9 +571,7 @@ void Hacl_Poly1305_128_poly1305_update1(Lib_IntVector_Intrinsics_vec128 *ctx, ui
 {
   Lib_IntVector_Intrinsics_vec128 *pre = ctx + (uint32_t)5U;
   Lib_IntVector_Intrinsics_vec128 *acc = ctx;
-  Lib_IntVector_Intrinsics_vec128 e[5U];
-  for (uint32_t _i = 0U; _i < (uint32_t)5U; ++_i)
-    e[_i] = Lib_IntVector_Intrinsics_vec128_zero;
+  Lib_IntVector_Intrinsics_vec128 e[5U] = { 0U };
   uint64_t u0 = load64_le(text);
   uint64_t lo = u0;
   uint64_t u = load64_le(text + (uint32_t)8U);
@@ -803,9 +799,7 @@ Hacl_Poly1305_128_poly1305_update(
     for (uint32_t i = (uint32_t)0U; i < nb; i++)
     {
       uint8_t *block = text1 + i * bs;
-      Lib_IntVector_Intrinsics_vec128 e[5U];
-      for (uint32_t _i = 0U; _i < (uint32_t)5U; ++_i)
-        e[_i] = Lib_IntVector_Intrinsics_vec128_zero;
+      Lib_IntVector_Intrinsics_vec128 e[5U] = { 0U };
       Lib_IntVector_Intrinsics_vec128 b1 = Lib_IntVector_Intrinsics_vec128_load64_le(block);
       Lib_IntVector_Intrinsics_vec128
       b2 = Lib_IntVector_Intrinsics_vec128_load64_le(block + (uint32_t)16U);
@@ -1028,9 +1022,7 @@ Hacl_Poly1305_128_poly1305_update(
   for (uint32_t i = (uint32_t)0U; i < nb; i++)
   {
     uint8_t *block = t1 + i * (uint32_t)16U;
-    Lib_IntVector_Intrinsics_vec128 e[5U];
-    for (uint32_t _i = 0U; _i < (uint32_t)5U; ++_i)
-      e[_i] = Lib_IntVector_Intrinsics_vec128_zero;
+    Lib_IntVector_Intrinsics_vec128 e[5U] = { 0U };
     uint64_t u0 = load64_le(block);
     uint64_t lo = u0;
     uint64_t u = load64_le(block + (uint32_t)8U);
@@ -1237,9 +1229,7 @@ Hacl_Poly1305_128_poly1305_update(
   if (rem > (uint32_t)0U)
   {
     uint8_t *last = t1 + nb * (uint32_t)16U;
-    Lib_IntVector_Intrinsics_vec128 e[5U];
-    for (uint32_t _i = 0U; _i < (uint32_t)5U; ++_i)
-      e[_i] = Lib_IntVector_Intrinsics_vec128_zero;
+    Lib_IntVector_Intrinsics_vec128 e[5U] = { 0U };
     uint8_t tmp[16U] = { 0U };
     memcpy(tmp, last, rem * sizeof (uint8_t));
     uint64_t u0 = load64_le(tmp);
@@ -1620,9 +1610,7 @@ Hacl_Poly1305_128_poly1305_finish(
 
 void Hacl_Poly1305_128_poly1305_mac(uint8_t *tag, uint32_t len, uint8_t *text, uint8_t *key)
 {
-  Lib_IntVector_Intrinsics_vec128 ctx[25U];
-  for (uint32_t _i = 0U; _i < (uint32_t)25U; ++_i)
-    ctx[_i] = Lib_IntVector_Intrinsics_vec128_zero;
+  Lib_IntVector_Intrinsics_vec128 ctx[25U] = { 0U };
   Hacl_Poly1305_128_poly1305_init(ctx, key);
   Hacl_Poly1305_128_poly1305_update(ctx, len, text);
   Hacl_Poly1305_128_poly1305_finish(tag, key, ctx);

--- a/dist/gcc-compatible/Hacl_Poly1305_256.c
+++ b/dist/gcc-compatible/Hacl_Poly1305_256.c
@@ -29,9 +29,7 @@
 void
 Hacl_Impl_Poly1305_Field32xN_256_load_acc4(Lib_IntVector_Intrinsics_vec256 *acc, uint8_t *b)
 {
-  Lib_IntVector_Intrinsics_vec256 e[5U];
-  for (uint32_t _i = 0U; _i < (uint32_t)5U; ++_i)
-    e[_i] = Lib_IntVector_Intrinsics_vec256_zero;
+  Lib_IntVector_Intrinsics_vec256 e[5U] = { 0U };
   Lib_IntVector_Intrinsics_vec256 lo = Lib_IntVector_Intrinsics_vec256_load64_le(b);
   Lib_IntVector_Intrinsics_vec256
   hi = Lib_IntVector_Intrinsics_vec256_load64_le(b + (uint32_t)32U);
@@ -1042,9 +1040,7 @@ void Hacl_Poly1305_256_poly1305_update1(Lib_IntVector_Intrinsics_vec256 *ctx, ui
 {
   Lib_IntVector_Intrinsics_vec256 *pre = ctx + (uint32_t)5U;
   Lib_IntVector_Intrinsics_vec256 *acc = ctx;
-  Lib_IntVector_Intrinsics_vec256 e[5U];
-  for (uint32_t _i = 0U; _i < (uint32_t)5U; ++_i)
-    e[_i] = Lib_IntVector_Intrinsics_vec256_zero;
+  Lib_IntVector_Intrinsics_vec256 e[5U] = { 0U };
   uint64_t u0 = load64_le(text);
   uint64_t lo = u0;
   uint64_t u = load64_le(text + (uint32_t)8U);
@@ -1272,9 +1268,7 @@ Hacl_Poly1305_256_poly1305_update(
     for (uint32_t i = (uint32_t)0U; i < nb; i++)
     {
       uint8_t *block = text1 + i * bs;
-      Lib_IntVector_Intrinsics_vec256 e[5U];
-      for (uint32_t _i = 0U; _i < (uint32_t)5U; ++_i)
-        e[_i] = Lib_IntVector_Intrinsics_vec256_zero;
+      Lib_IntVector_Intrinsics_vec256 e[5U] = { 0U };
       Lib_IntVector_Intrinsics_vec256 lo = Lib_IntVector_Intrinsics_vec256_load64_le(block);
       Lib_IntVector_Intrinsics_vec256
       hi = Lib_IntVector_Intrinsics_vec256_load64_le(block + (uint32_t)32U);
@@ -1499,9 +1493,7 @@ Hacl_Poly1305_256_poly1305_update(
   for (uint32_t i = (uint32_t)0U; i < nb; i++)
   {
     uint8_t *block = t1 + i * (uint32_t)16U;
-    Lib_IntVector_Intrinsics_vec256 e[5U];
-    for (uint32_t _i = 0U; _i < (uint32_t)5U; ++_i)
-      e[_i] = Lib_IntVector_Intrinsics_vec256_zero;
+    Lib_IntVector_Intrinsics_vec256 e[5U] = { 0U };
     uint64_t u0 = load64_le(block);
     uint64_t lo = u0;
     uint64_t u = load64_le(block + (uint32_t)8U);
@@ -1708,9 +1700,7 @@ Hacl_Poly1305_256_poly1305_update(
   if (rem > (uint32_t)0U)
   {
     uint8_t *last = t1 + nb * (uint32_t)16U;
-    Lib_IntVector_Intrinsics_vec256 e[5U];
-    for (uint32_t _i = 0U; _i < (uint32_t)5U; ++_i)
-      e[_i] = Lib_IntVector_Intrinsics_vec256_zero;
+    Lib_IntVector_Intrinsics_vec256 e[5U] = { 0U };
     uint8_t tmp[16U] = { 0U };
     memcpy(tmp, last, rem * sizeof (uint8_t));
     uint64_t u0 = load64_le(tmp);
@@ -2091,9 +2081,7 @@ Hacl_Poly1305_256_poly1305_finish(
 
 void Hacl_Poly1305_256_poly1305_mac(uint8_t *tag, uint32_t len, uint8_t *text, uint8_t *key)
 {
-  Lib_IntVector_Intrinsics_vec256 ctx[25U];
-  for (uint32_t _i = 0U; _i < (uint32_t)25U; ++_i)
-    ctx[_i] = Lib_IntVector_Intrinsics_vec256_zero;
+  Lib_IntVector_Intrinsics_vec256 ctx[25U] = { 0U };
   Hacl_Poly1305_256_poly1305_init(ctx, key);
   Hacl_Poly1305_256_poly1305_update(ctx, len, text);
   Hacl_Poly1305_256_poly1305_finish(tag, key, ctx);

--- a/dist/gcc-compatible/Hacl_SHA2_Vec128.c
+++ b/dist/gcc-compatible/Hacl_SHA2_Vec128.c
@@ -29,12 +29,8 @@
 static inline void
 sha224_update4(Hacl_Impl_SHA2_Types_uint8_4p block, Lib_IntVector_Intrinsics_vec128 *hash)
 {
-  Lib_IntVector_Intrinsics_vec128 hash_old[8U];
-  for (uint32_t _i = 0U; _i < (uint32_t)8U; ++_i)
-    hash_old[_i] = Lib_IntVector_Intrinsics_vec128_zero;
-  Lib_IntVector_Intrinsics_vec128 ws[16U];
-  for (uint32_t _i = 0U; _i < (uint32_t)16U; ++_i)
-    ws[_i] = Lib_IntVector_Intrinsics_vec128_zero;
+  Lib_IntVector_Intrinsics_vec128 hash_old[8U] = { 0U };
+  Lib_IntVector_Intrinsics_vec128 ws[16U] = { 0U };
   memcpy(hash_old, hash, (uint32_t)8U * sizeof (Lib_IntVector_Intrinsics_vec128));
   uint8_t *b3 = block.snd.snd.snd;
   uint8_t *b2 = block.snd.snd.fst;
@@ -294,9 +290,7 @@ Hacl_SHA2_Vec128_sha224_4(
   ib = { .fst = input0, .snd = { .fst = input1, .snd = { .fst = input2, .snd = input3 } } };
   Hacl_Impl_SHA2_Types_uint8_4p
   rb = { .fst = dst0, .snd = { .fst = dst1, .snd = { .fst = dst2, .snd = dst3 } } };
-  Lib_IntVector_Intrinsics_vec128 st[8U];
-  for (uint32_t _i = 0U; _i < (uint32_t)8U; ++_i)
-    st[_i] = Lib_IntVector_Intrinsics_vec128_zero;
+  Lib_IntVector_Intrinsics_vec128 st[8U] = { 0U };
   for (uint32_t i = (uint32_t)0U; i < (uint32_t)8U; i++)
   {
     Lib_IntVector_Intrinsics_vec128 *os = st;
@@ -482,12 +476,8 @@ Hacl_SHA2_Vec128_sha224_4(
 static inline void
 sha256_update4(Hacl_Impl_SHA2_Types_uint8_4p block, Lib_IntVector_Intrinsics_vec128 *hash)
 {
-  Lib_IntVector_Intrinsics_vec128 hash_old[8U];
-  for (uint32_t _i = 0U; _i < (uint32_t)8U; ++_i)
-    hash_old[_i] = Lib_IntVector_Intrinsics_vec128_zero;
-  Lib_IntVector_Intrinsics_vec128 ws[16U];
-  for (uint32_t _i = 0U; _i < (uint32_t)16U; ++_i)
-    ws[_i] = Lib_IntVector_Intrinsics_vec128_zero;
+  Lib_IntVector_Intrinsics_vec128 hash_old[8U] = { 0U };
+  Lib_IntVector_Intrinsics_vec128 ws[16U] = { 0U };
   memcpy(hash_old, hash, (uint32_t)8U * sizeof (Lib_IntVector_Intrinsics_vec128));
   uint8_t *b3 = block.snd.snd.snd;
   uint8_t *b2 = block.snd.snd.fst;
@@ -747,9 +737,7 @@ Hacl_SHA2_Vec128_sha256_4(
   ib = { .fst = input0, .snd = { .fst = input1, .snd = { .fst = input2, .snd = input3 } } };
   Hacl_Impl_SHA2_Types_uint8_4p
   rb = { .fst = dst0, .snd = { .fst = dst1, .snd = { .fst = dst2, .snd = dst3 } } };
-  Lib_IntVector_Intrinsics_vec128 st[8U];
-  for (uint32_t _i = 0U; _i < (uint32_t)8U; ++_i)
-    st[_i] = Lib_IntVector_Intrinsics_vec128_zero;
+  Lib_IntVector_Intrinsics_vec128 st[8U] = { 0U };
   for (uint32_t i = (uint32_t)0U; i < (uint32_t)8U; i++)
   {
     Lib_IntVector_Intrinsics_vec128 *os = st;

--- a/dist/gcc-compatible/Hacl_SHA2_Vec256.c
+++ b/dist/gcc-compatible/Hacl_SHA2_Vec256.c
@@ -29,12 +29,8 @@
 static inline void
 sha224_update8(Hacl_Impl_SHA2_Types_uint8_8p block, Lib_IntVector_Intrinsics_vec256 *hash)
 {
-  Lib_IntVector_Intrinsics_vec256 hash_old[8U];
-  for (uint32_t _i = 0U; _i < (uint32_t)8U; ++_i)
-    hash_old[_i] = Lib_IntVector_Intrinsics_vec256_zero;
-  Lib_IntVector_Intrinsics_vec256 ws[16U];
-  for (uint32_t _i = 0U; _i < (uint32_t)16U; ++_i)
-    ws[_i] = Lib_IntVector_Intrinsics_vec256_zero;
+  Lib_IntVector_Intrinsics_vec256 hash_old[8U] = { 0U };
+  Lib_IntVector_Intrinsics_vec256 ws[16U] = { 0U };
   memcpy(hash_old, hash, (uint32_t)8U * sizeof (Lib_IntVector_Intrinsics_vec256));
   uint8_t *b7 = block.snd.snd.snd.snd.snd.snd.snd;
   uint8_t *b6 = block.snd.snd.snd.snd.snd.snd.fst;
@@ -415,9 +411,7 @@ Hacl_SHA2_Vec256_sha224_8(
         }
       }
     };
-  Lib_IntVector_Intrinsics_vec256 st[8U];
-  for (uint32_t _i = 0U; _i < (uint32_t)8U; ++_i)
-    st[_i] = Lib_IntVector_Intrinsics_vec256_zero;
+  Lib_IntVector_Intrinsics_vec256 st[8U] = { 0U };
   for (uint32_t i = (uint32_t)0U; i < (uint32_t)8U; i++)
   {
     Lib_IntVector_Intrinsics_vec256 *os = st;
@@ -755,12 +749,8 @@ Hacl_SHA2_Vec256_sha224_8(
 static inline void
 sha256_update8(Hacl_Impl_SHA2_Types_uint8_8p block, Lib_IntVector_Intrinsics_vec256 *hash)
 {
-  Lib_IntVector_Intrinsics_vec256 hash_old[8U];
-  for (uint32_t _i = 0U; _i < (uint32_t)8U; ++_i)
-    hash_old[_i] = Lib_IntVector_Intrinsics_vec256_zero;
-  Lib_IntVector_Intrinsics_vec256 ws[16U];
-  for (uint32_t _i = 0U; _i < (uint32_t)16U; ++_i)
-    ws[_i] = Lib_IntVector_Intrinsics_vec256_zero;
+  Lib_IntVector_Intrinsics_vec256 hash_old[8U] = { 0U };
+  Lib_IntVector_Intrinsics_vec256 ws[16U] = { 0U };
   memcpy(hash_old, hash, (uint32_t)8U * sizeof (Lib_IntVector_Intrinsics_vec256));
   uint8_t *b7 = block.snd.snd.snd.snd.snd.snd.snd;
   uint8_t *b6 = block.snd.snd.snd.snd.snd.snd.fst;
@@ -1141,9 +1131,7 @@ Hacl_SHA2_Vec256_sha256_8(
         }
       }
     };
-  Lib_IntVector_Intrinsics_vec256 st[8U];
-  for (uint32_t _i = 0U; _i < (uint32_t)8U; ++_i)
-    st[_i] = Lib_IntVector_Intrinsics_vec256_zero;
+  Lib_IntVector_Intrinsics_vec256 st[8U] = { 0U };
   for (uint32_t i = (uint32_t)0U; i < (uint32_t)8U; i++)
   {
     Lib_IntVector_Intrinsics_vec256 *os = st;
@@ -1481,12 +1469,8 @@ Hacl_SHA2_Vec256_sha256_8(
 static inline void
 sha384_update4(Hacl_Impl_SHA2_Types_uint8_4p block, Lib_IntVector_Intrinsics_vec256 *hash)
 {
-  Lib_IntVector_Intrinsics_vec256 hash_old[8U];
-  for (uint32_t _i = 0U; _i < (uint32_t)8U; ++_i)
-    hash_old[_i] = Lib_IntVector_Intrinsics_vec256_zero;
-  Lib_IntVector_Intrinsics_vec256 ws[16U];
-  for (uint32_t _i = 0U; _i < (uint32_t)16U; ++_i)
-    ws[_i] = Lib_IntVector_Intrinsics_vec256_zero;
+  Lib_IntVector_Intrinsics_vec256 hash_old[8U] = { 0U };
+  Lib_IntVector_Intrinsics_vec256 ws[16U] = { 0U };
   memcpy(hash_old, hash, (uint32_t)8U * sizeof (Lib_IntVector_Intrinsics_vec256));
   uint8_t *b3 = block.snd.snd.snd;
   uint8_t *b2 = block.snd.snd.fst;
@@ -1730,9 +1714,7 @@ Hacl_SHA2_Vec256_sha384_4(
   ib = { .fst = input0, .snd = { .fst = input1, .snd = { .fst = input2, .snd = input3 } } };
   Hacl_Impl_SHA2_Types_uint8_4p
   rb = { .fst = dst0, .snd = { .fst = dst1, .snd = { .fst = dst2, .snd = dst3 } } };
-  Lib_IntVector_Intrinsics_vec256 st[8U];
-  for (uint32_t _i = 0U; _i < (uint32_t)8U; ++_i)
-    st[_i] = Lib_IntVector_Intrinsics_vec256_zero;
+  Lib_IntVector_Intrinsics_vec256 st[8U] = { 0U };
   for (uint32_t i = (uint32_t)0U; i < (uint32_t)8U; i++)
   {
     Lib_IntVector_Intrinsics_vec256 *os = st;
@@ -1910,12 +1892,8 @@ Hacl_SHA2_Vec256_sha384_4(
 static inline void
 sha512_update4(Hacl_Impl_SHA2_Types_uint8_4p block, Lib_IntVector_Intrinsics_vec256 *hash)
 {
-  Lib_IntVector_Intrinsics_vec256 hash_old[8U];
-  for (uint32_t _i = 0U; _i < (uint32_t)8U; ++_i)
-    hash_old[_i] = Lib_IntVector_Intrinsics_vec256_zero;
-  Lib_IntVector_Intrinsics_vec256 ws[16U];
-  for (uint32_t _i = 0U; _i < (uint32_t)16U; ++_i)
-    ws[_i] = Lib_IntVector_Intrinsics_vec256_zero;
+  Lib_IntVector_Intrinsics_vec256 hash_old[8U] = { 0U };
+  Lib_IntVector_Intrinsics_vec256 ws[16U] = { 0U };
   memcpy(hash_old, hash, (uint32_t)8U * sizeof (Lib_IntVector_Intrinsics_vec256));
   uint8_t *b3 = block.snd.snd.snd;
   uint8_t *b2 = block.snd.snd.fst;
@@ -2159,9 +2137,7 @@ Hacl_SHA2_Vec256_sha512_4(
   ib = { .fst = input0, .snd = { .fst = input1, .snd = { .fst = input2, .snd = input3 } } };
   Hacl_Impl_SHA2_Types_uint8_4p
   rb = { .fst = dst0, .snd = { .fst = dst1, .snd = { .fst = dst2, .snd = dst3 } } };
-  Lib_IntVector_Intrinsics_vec256 st[8U];
-  for (uint32_t _i = 0U; _i < (uint32_t)8U; ++_i)
-    st[_i] = Lib_IntVector_Intrinsics_vec256_zero;
+  Lib_IntVector_Intrinsics_vec256 st[8U] = { 0U };
   for (uint32_t i = (uint32_t)0U; i < (uint32_t)8U; i++)
   {
     Lib_IntVector_Intrinsics_vec256 *os = st;

--- a/dist/gcc-compatible/Hacl_Streaming_Blake2b_256.c
+++ b/dist/gcc-compatible/Hacl_Streaming_Blake2b_256.c
@@ -40,13 +40,9 @@ Hacl_Streaming_Blake2b_256_blake2b_256_state
         Hacl_Impl_Blake2_Core_M256),
       sizeof (uint8_t));
   Lib_IntVector_Intrinsics_vec256
-  *wv = KRML_HOST_MALLOC(sizeof (Lib_IntVector_Intrinsics_vec256) * (uint32_t)4U);
-  for (uint32_t _i = 0U; _i < (uint32_t)4U; ++_i)
-    wv[_i] = Lib_IntVector_Intrinsics_vec256_zero;
+  *wv = KRML_HOST_CALLOC((uint32_t)4U, sizeof (Lib_IntVector_Intrinsics_vec256));
   Lib_IntVector_Intrinsics_vec256
-  *b = KRML_HOST_MALLOC(sizeof (Lib_IntVector_Intrinsics_vec256) * (uint32_t)4U);
-  for (uint32_t _i = 0U; _i < (uint32_t)4U; ++_i)
-    b[_i] = Lib_IntVector_Intrinsics_vec256_zero;
+  *b = KRML_HOST_CALLOC((uint32_t)4U, sizeof (Lib_IntVector_Intrinsics_vec256));
   Hacl_Streaming_Blake2b_256_blake2b_256_block_state block_state = { .fst = wv, .snd = b };
   Hacl_Streaming_Blake2b_256_blake2b_256_state
   s = { .block_state = block_state, .buf = buf, .total_len = (uint64_t)0U };

--- a/dist/gcc-compatible/Hacl_Streaming_Blake2s_128.c
+++ b/dist/gcc-compatible/Hacl_Streaming_Blake2s_128.c
@@ -40,13 +40,9 @@ Hacl_Streaming_Blake2s_128_blake2s_128_state
         Hacl_Impl_Blake2_Core_M128),
       sizeof (uint8_t));
   Lib_IntVector_Intrinsics_vec128
-  *wv = KRML_HOST_MALLOC(sizeof (Lib_IntVector_Intrinsics_vec128) * (uint32_t)4U);
-  for (uint32_t _i = 0U; _i < (uint32_t)4U; ++_i)
-    wv[_i] = Lib_IntVector_Intrinsics_vec128_zero;
+  *wv = KRML_HOST_CALLOC((uint32_t)4U, sizeof (Lib_IntVector_Intrinsics_vec128));
   Lib_IntVector_Intrinsics_vec128
-  *b = KRML_HOST_MALLOC(sizeof (Lib_IntVector_Intrinsics_vec128) * (uint32_t)4U);
-  for (uint32_t _i = 0U; _i < (uint32_t)4U; ++_i)
-    b[_i] = Lib_IntVector_Intrinsics_vec128_zero;
+  *b = KRML_HOST_CALLOC((uint32_t)4U, sizeof (Lib_IntVector_Intrinsics_vec128));
   Hacl_Streaming_Blake2s_128_blake2s_128_block_state block_state = { .fst = wv, .snd = b };
   Hacl_Streaming_Blake2s_128_blake2s_128_state
   s = { .block_state = block_state, .buf = buf, .total_len = (uint64_t)0U };

--- a/dist/gcc-compatible/Hacl_Streaming_Poly1305_128.c
+++ b/dist/gcc-compatible/Hacl_Streaming_Poly1305_128.c
@@ -31,9 +31,7 @@ Hacl_Streaming_Poly1305_128_poly1305_128_state
 {
   uint8_t *buf = KRML_HOST_CALLOC((uint32_t)32U, sizeof (uint8_t));
   Lib_IntVector_Intrinsics_vec128
-  *r1 = KRML_HOST_MALLOC(sizeof (Lib_IntVector_Intrinsics_vec128) * (uint32_t)25U);
-  for (uint32_t _i = 0U; _i < (uint32_t)25U; ++_i)
-    r1[_i] = Lib_IntVector_Intrinsics_vec128_zero;
+  *r1 = KRML_HOST_CALLOC((uint32_t)25U, sizeof (Lib_IntVector_Intrinsics_vec128));
   Lib_IntVector_Intrinsics_vec128 *block_state = r1;
   uint8_t *k_ = KRML_HOST_CALLOC((uint32_t)32U, sizeof (uint8_t));
   memcpy(k_, k, (uint32_t)32U * sizeof (uint8_t));
@@ -271,9 +269,7 @@ Hacl_Streaming_Poly1305_128_finish(
     r = (uint32_t)(total_len % (uint64_t)(uint32_t)32U);
   }
   uint8_t *buf_1 = buf_;
-  Lib_IntVector_Intrinsics_vec128 r1[25U];
-  for (uint32_t _i = 0U; _i < (uint32_t)25U; ++_i)
-    r1[_i] = Lib_IntVector_Intrinsics_vec128_zero;
+  Lib_IntVector_Intrinsics_vec128 r1[25U] = { 0U };
   Lib_IntVector_Intrinsics_vec128 *tmp_block_state = r1;
   memcpy(tmp_block_state, block_state, (uint32_t)25U * sizeof (Lib_IntVector_Intrinsics_vec128));
   uint32_t ite0;
@@ -317,9 +313,7 @@ Hacl_Streaming_Poly1305_128_finish(
     ite2 = r % (uint32_t)16U;
   }
   Hacl_Poly1305_128_poly1305_update(tmp_block_state, ite2, buf_last);
-  Lib_IntVector_Intrinsics_vec128 tmp[25U];
-  for (uint32_t _i = 0U; _i < (uint32_t)25U; ++_i)
-    tmp[_i] = Lib_IntVector_Intrinsics_vec128_zero;
+  Lib_IntVector_Intrinsics_vec128 tmp[25U] = { 0U };
   memcpy(tmp, tmp_block_state, (uint32_t)25U * sizeof (Lib_IntVector_Intrinsics_vec128));
   Hacl_Poly1305_128_poly1305_finish(dst, k_, tmp);
 }

--- a/dist/gcc-compatible/Hacl_Streaming_Poly1305_256.c
+++ b/dist/gcc-compatible/Hacl_Streaming_Poly1305_256.c
@@ -31,9 +31,7 @@ Hacl_Streaming_Poly1305_256_poly1305_256_state
 {
   uint8_t *buf = KRML_HOST_CALLOC((uint32_t)64U, sizeof (uint8_t));
   Lib_IntVector_Intrinsics_vec256
-  *r1 = KRML_HOST_MALLOC(sizeof (Lib_IntVector_Intrinsics_vec256) * (uint32_t)25U);
-  for (uint32_t _i = 0U; _i < (uint32_t)25U; ++_i)
-    r1[_i] = Lib_IntVector_Intrinsics_vec256_zero;
+  *r1 = KRML_HOST_CALLOC((uint32_t)25U, sizeof (Lib_IntVector_Intrinsics_vec256));
   Lib_IntVector_Intrinsics_vec256 *block_state = r1;
   uint8_t *k_ = KRML_HOST_CALLOC((uint32_t)32U, sizeof (uint8_t));
   memcpy(k_, k, (uint32_t)32U * sizeof (uint8_t));
@@ -271,9 +269,7 @@ Hacl_Streaming_Poly1305_256_finish(
     r = (uint32_t)(total_len % (uint64_t)(uint32_t)64U);
   }
   uint8_t *buf_1 = buf_;
-  Lib_IntVector_Intrinsics_vec256 r1[25U];
-  for (uint32_t _i = 0U; _i < (uint32_t)25U; ++_i)
-    r1[_i] = Lib_IntVector_Intrinsics_vec256_zero;
+  Lib_IntVector_Intrinsics_vec256 r1[25U] = { 0U };
   Lib_IntVector_Intrinsics_vec256 *tmp_block_state = r1;
   memcpy(tmp_block_state, block_state, (uint32_t)25U * sizeof (Lib_IntVector_Intrinsics_vec256));
   uint32_t ite0;
@@ -317,9 +313,7 @@ Hacl_Streaming_Poly1305_256_finish(
     ite2 = r % (uint32_t)16U;
   }
   Hacl_Poly1305_256_poly1305_update(tmp_block_state, ite2, buf_last);
-  Lib_IntVector_Intrinsics_vec256 tmp[25U];
-  for (uint32_t _i = 0U; _i < (uint32_t)25U; ++_i)
-    tmp[_i] = Lib_IntVector_Intrinsics_vec256_zero;
+  Lib_IntVector_Intrinsics_vec256 tmp[25U] = { 0U };
   memcpy(tmp, tmp_block_state, (uint32_t)25U * sizeof (Lib_IntVector_Intrinsics_vec256));
   Hacl_Poly1305_256_poly1305_finish(dst, k_, tmp);
 }

--- a/dist/gcc-compatible/INFO.txt
+++ b/dist/gcc-compatible/INFO.txt
@@ -1,4 +1,4 @@
 This code was generated with the following toolchain.
-F* version: 5bcd16865e5161ccbc7b2b9ead96ba099618adf8
-KaRaMeL version: 4854fd3134c59540e329675a44e5c9a7afb19e4a
+F* version: c803362efccbc67f166138a12f90809f9e22f022
+KaRaMeL version: 4507656e7bc801ebe09e0c8a3cd04a2e8b4a7ef7
 Vale version: 0.3.19

--- a/dist/gcc-compatible/MerkleTree.c
+++ b/dist/gcc-compatible/MerkleTree.c
@@ -521,44 +521,29 @@ void mt_sha256_compress(uint8_t *src1, uint8_t *src2, uint8_t *dst)
   uint8_t cb[64U] = { 0U };
   memcpy(cb, src1, hash_size * sizeof (uint8_t));
   memcpy(cb + (uint32_t)32U, src2, hash_size * sizeof (uint8_t));
-  uint32_t buf0[4U];
-  uint32_t buf1[5U];
-  uint32_t buf2[8U];
-  uint32_t buf3[8U];
-  uint64_t buf4[8U];
-  uint64_t buf5[8U];
-  uint32_t buf6[16U];
-  uint64_t buf[16U];
   EverCrypt_Hash_state_s s;
+  uint32_t buf0[4U] = { 0U };
+  uint32_t buf1[5U] = { 0U };
+  uint32_t buf2[8U] = { 0U };
+  uint32_t buf3[8U] = { 0U };
+  uint64_t buf4[8U] = { 0U };
+  uint64_t buf5[8U] = { 0U };
+  uint32_t buf6[16U] = { 0U };
+  uint64_t buf[16U] = { 0U };
   switch (hash_alg)
   {
     case Spec_Hash_Definitions_MD5:
       {
-        uint32_t init = (uint32_t)0U;
-        for (uint32_t i = (uint32_t)0U; i < (uint32_t)4U; i++)
-        {
-          buf0[i] = init;
-        }
         s = ((EverCrypt_Hash_state_s){ .tag = EverCrypt_Hash_MD5_s, { .case_MD5_s = buf0 } });
         break;
       }
     case Spec_Hash_Definitions_SHA1:
       {
-        uint32_t init = (uint32_t)0U;
-        for (uint32_t i = (uint32_t)0U; i < (uint32_t)5U; i++)
-        {
-          buf1[i] = init;
-        }
         s = ((EverCrypt_Hash_state_s){ .tag = EverCrypt_Hash_SHA1_s, { .case_SHA1_s = buf1 } });
         break;
       }
     case Spec_Hash_Definitions_SHA2_224:
       {
-        uint32_t init = (uint32_t)0U;
-        for (uint32_t i = (uint32_t)0U; i < (uint32_t)8U; i++)
-        {
-          buf2[i] = init;
-        }
         s =
           (
             (EverCrypt_Hash_state_s){
@@ -570,11 +555,6 @@ void mt_sha256_compress(uint8_t *src1, uint8_t *src2, uint8_t *dst)
       }
     case Spec_Hash_Definitions_SHA2_256:
       {
-        uint32_t init = (uint32_t)0U;
-        for (uint32_t i = (uint32_t)0U; i < (uint32_t)8U; i++)
-        {
-          buf3[i] = init;
-        }
         s =
           (
             (EverCrypt_Hash_state_s){
@@ -586,11 +566,6 @@ void mt_sha256_compress(uint8_t *src1, uint8_t *src2, uint8_t *dst)
       }
     case Spec_Hash_Definitions_SHA2_384:
       {
-        uint64_t init = (uint64_t)0U;
-        for (uint32_t i = (uint32_t)0U; i < (uint32_t)8U; i++)
-        {
-          buf4[i] = init;
-        }
         s =
           (
             (EverCrypt_Hash_state_s){
@@ -602,11 +577,6 @@ void mt_sha256_compress(uint8_t *src1, uint8_t *src2, uint8_t *dst)
       }
     case Spec_Hash_Definitions_SHA2_512:
       {
-        uint64_t init = (uint64_t)0U;
-        for (uint32_t i = (uint32_t)0U; i < (uint32_t)8U; i++)
-        {
-          buf5[i] = init;
-        }
         s =
           (
             (EverCrypt_Hash_state_s){
@@ -618,22 +588,12 @@ void mt_sha256_compress(uint8_t *src1, uint8_t *src2, uint8_t *dst)
       }
     case Spec_Hash_Definitions_Blake2S:
       {
-        uint32_t init = (uint32_t)0U;
-        for (uint32_t i = (uint32_t)0U; i < (uint32_t)16U; i++)
-        {
-          buf6[i] = init;
-        }
         s =
           ((EverCrypt_Hash_state_s){ .tag = EverCrypt_Hash_Blake2S_s, { .case_Blake2S_s = buf6 } });
         break;
       }
     case Spec_Hash_Definitions_Blake2B:
       {
-        uint64_t init = (uint64_t)0U;
-        for (uint32_t i = (uint32_t)0U; i < (uint32_t)16U; i++)
-        {
-          buf[i] = init;
-        }
         s = ((EverCrypt_Hash_state_s){ .tag = EverCrypt_Hash_Blake2B_s, { .case_Blake2B_s = buf } });
         break;
       }


### PR DESCRIPTION
I recently pushed a series of fixes to krml: from the changelog

```
    Improve code-generation for arrays of vectors.
    
    - krml is now aware that HACL's vec128_zero, vec256_zero and so on are
      zeroes and as such that a for-loop is not needed for compiling
      allocations, and a zero-initializer suffices
    - an if-statement that is about to compiled as an ifdef can be safely
      ignored for the sake of the buffer-hoisting phase
    - improved buffer hoisting: if the initial value is a closed term, do
      not bother with a copy assignment and lift the array declaration
      wholesale
```

This refreshes dist/ accordingly.