### PR TITLE
Macro-based loop unrolling

### DIFF
--- a/dist/gcc-compatible/Hacl_Bignum.c
+++ b/dist/gcc-compatible/Hacl_Bignum.c
@@ -1879,12 +1879,13 @@ Hacl_Bignum_Exponentiation_bn_mod_exp_vartime_precomp_u32(
   memcpy(table, resM, len * sizeof (uint32_t));
   uint32_t *t1 = table + len;
   memcpy(t1, aM, len * sizeof (uint32_t));
-  for (uint32_t i = (uint32_t)0U; i < (uint32_t)15U; i++)
-  {
+  KRML_MAYBE_FOR15(i,
+    (uint32_t)0U,
+    (uint32_t)15U,
+    (uint32_t)1U,
     uint32_t *t11 = table + i * len;
     uint32_t *t2 = table + i * len + len;
-    bn_almost_mont_mul_u32(len, n, mu, aM, t11, t2);
-  }
+    bn_almost_mont_mul_u32(len, n, mu, aM, t11, t2););
   if (bBits % (uint32_t)4U != (uint32_t)0U)
   {
     uint32_t mask_l = (uint32_t)16U - (uint32_t)1U;
@@ -1907,10 +1908,11 @@ Hacl_Bignum_Exponentiation_bn_mod_exp_vartime_precomp_u32(
   }
   for (uint32_t i = (uint32_t)0U; i < bBits / (uint32_t)4U; i++)
   {
-    for (uint32_t i0 = (uint32_t)0U; i0 < (uint32_t)4U; i0++)
-    {
-      bn_almost_mont_sqr_u32(len, n, mu, resM, resM);
-    }
+    KRML_MAYBE_FOR4(i0,
+      (uint32_t)0U,
+      (uint32_t)4U,
+      (uint32_t)1U,
+      bn_almost_mont_sqr_u32(len, n, mu, resM, resM););
     uint32_t bk = bBits - bBits % (uint32_t)4U;
     uint32_t mask_l = (uint32_t)16U - (uint32_t)1U;
     uint32_t i1 = (bk - (uint32_t)4U * i - (uint32_t)4U) / (uint32_t)32U;
@@ -2040,12 +2042,13 @@ Hacl_Bignum_Exponentiation_bn_mod_exp_consttime_precomp_u32(
   memcpy(table, resM, len * sizeof (uint32_t));
   uint32_t *t1 = table + len;
   memcpy(t1, aM, len * sizeof (uint32_t));
-  for (uint32_t i = (uint32_t)0U; i < (uint32_t)15U; i++)
-  {
+  KRML_MAYBE_FOR15(i,
+    (uint32_t)0U,
+    (uint32_t)15U,
+    (uint32_t)1U,
     uint32_t *t11 = table + i * len;
     uint32_t *t2 = table + i * len + len;
-    bn_almost_mont_mul_u32(len, n, mu, aM, t11, t2);
-  }
+    bn_almost_mont_mul_u32(len, n, mu, aM, t11, t2););
   if (bBits % (uint32_t)4U != (uint32_t)0U)
   {
     uint32_t mask_l = (uint32_t)16U - (uint32_t)1U;
@@ -2063,8 +2066,10 @@ Hacl_Bignum_Exponentiation_bn_mod_exp_consttime_precomp_u32(
     }
     uint32_t bits_c = ite & mask_l;
     memcpy(resM, table, len * sizeof (uint32_t));
-    for (uint32_t i1 = (uint32_t)0U; i1 < (uint32_t)15U; i1++)
-    {
+    KRML_MAYBE_FOR15(i1,
+      (uint32_t)0U,
+      (uint32_t)15U,
+      (uint32_t)1U,
       uint32_t c = FStar_UInt32_eq_mask(bits_c, i1 + (uint32_t)1U);
       uint32_t *res_j = table + (i1 + (uint32_t)1U) * len;
       for (uint32_t i = (uint32_t)0U; i < len; i++)
@@ -2072,15 +2077,15 @@ Hacl_Bignum_Exponentiation_bn_mod_exp_consttime_precomp_u32(
         uint32_t *os = resM;
         uint32_t x = (c & res_j[i]) | (~c & resM[i]);
         os[i] = x;
-      }
-    }
+      });
   }
   for (uint32_t i0 = (uint32_t)0U; i0 < bBits / (uint32_t)4U; i0++)
   {
-    for (uint32_t i = (uint32_t)0U; i < (uint32_t)4U; i++)
-    {
-      bn_almost_mont_sqr_u32(len, n, mu, resM, resM);
-    }
+    KRML_MAYBE_FOR4(i,
+      (uint32_t)0U,
+      (uint32_t)4U,
+      (uint32_t)1U,
+      bn_almost_mont_sqr_u32(len, n, mu, resM, resM););
     uint32_t bk = bBits - bBits % (uint32_t)4U;
     uint32_t mask_l = (uint32_t)16U - (uint32_t)1U;
     uint32_t i1 = (bk - (uint32_t)4U * i0 - (uint32_t)4U) / (uint32_t)32U;
@@ -2100,8 +2105,10 @@ Hacl_Bignum_Exponentiation_bn_mod_exp_consttime_precomp_u32(
     uint32_t a_bits_l[len];
     memset(a_bits_l, 0U, len * sizeof (uint32_t));
     memcpy(a_bits_l, table, len * sizeof (uint32_t));
-    for (uint32_t i2 = (uint32_t)0U; i2 < (uint32_t)15U; i2++)
-    {
+    KRML_MAYBE_FOR15(i2,
+      (uint32_t)0U,
+      (uint32_t)15U,
+      (uint32_t)1U,
       uint32_t c = FStar_UInt32_eq_mask(bits_l, i2 + (uint32_t)1U);
       uint32_t *res_j = table + (i2 + (uint32_t)1U) * len;
       for (uint32_t i = (uint32_t)0U; i < len; i++)
@@ -2109,8 +2116,7 @@ Hacl_Bignum_Exponentiation_bn_mod_exp_consttime_precomp_u32(
         uint32_t *os = a_bits_l;
         uint32_t x = (c & res_j[i]) | (~c & a_bits_l[i]);
         os[i] = x;
-      }
-    }
+      });
     bn_almost_mont_mul_u32(len, n, mu, resM, a_bits_l, resM);
   }
   KRML_CHECK_SIZE(sizeof (uint32_t), len + len);
@@ -2313,12 +2319,13 @@ Hacl_Bignum_Exponentiation_bn_mod_exp_vartime_precomp_u64(
   memcpy(table, resM, len * sizeof (uint64_t));
   uint64_t *t1 = table + len;
   memcpy(t1, aM, len * sizeof (uint64_t));
-  for (uint32_t i = (uint32_t)0U; i < (uint32_t)15U; i++)
-  {
+  KRML_MAYBE_FOR15(i,
+    (uint32_t)0U,
+    (uint32_t)15U,
+    (uint32_t)1U,
     uint64_t *t11 = table + i * len;
     uint64_t *t2 = table + i * len + len;
-    bn_almost_mont_mul_u64(len, n, mu, aM, t11, t2);
-  }
+    bn_almost_mont_mul_u64(len, n, mu, aM, t11, t2););
   if (bBits % (uint32_t)4U != (uint32_t)0U)
   {
     uint64_t mask_l = (uint64_t)16U - (uint64_t)1U;
@@ -2341,10 +2348,11 @@ Hacl_Bignum_Exponentiation_bn_mod_exp_vartime_precomp_u64(
   }
   for (uint32_t i = (uint32_t)0U; i < bBits / (uint32_t)4U; i++)
   {
-    for (uint32_t i0 = (uint32_t)0U; i0 < (uint32_t)4U; i0++)
-    {
-      bn_almost_mont_sqr_u64(len, n, mu, resM, resM);
-    }
+    KRML_MAYBE_FOR4(i0,
+      (uint32_t)0U,
+      (uint32_t)4U,
+      (uint32_t)1U,
+      bn_almost_mont_sqr_u64(len, n, mu, resM, resM););
     uint32_t bk = bBits - bBits % (uint32_t)4U;
     uint64_t mask_l = (uint64_t)16U - (uint64_t)1U;
     uint32_t i1 = (bk - (uint32_t)4U * i - (uint32_t)4U) / (uint32_t)64U;
@@ -2474,12 +2482,13 @@ Hacl_Bignum_Exponentiation_bn_mod_exp_consttime_precomp_u64(
   memcpy(table, resM, len * sizeof (uint64_t));
   uint64_t *t1 = table + len;
   memcpy(t1, aM, len * sizeof (uint64_t));
-  for (uint32_t i = (uint32_t)0U; i < (uint32_t)15U; i++)
-  {
+  KRML_MAYBE_FOR15(i,
+    (uint32_t)0U,
+    (uint32_t)15U,
+    (uint32_t)1U,
     uint64_t *t11 = table + i * len;
     uint64_t *t2 = table + i * len + len;
-    bn_almost_mont_mul_u64(len, n, mu, aM, t11, t2);
-  }
+    bn_almost_mont_mul_u64(len, n, mu, aM, t11, t2););
   if (bBits % (uint32_t)4U != (uint32_t)0U)
   {
     uint64_t mask_l = (uint64_t)16U - (uint64_t)1U;
@@ -2497,8 +2506,10 @@ Hacl_Bignum_Exponentiation_bn_mod_exp_consttime_precomp_u64(
     }
     uint64_t bits_c = ite & mask_l;
     memcpy(resM, table, len * sizeof (uint64_t));
-    for (uint32_t i1 = (uint32_t)0U; i1 < (uint32_t)15U; i1++)
-    {
+    KRML_MAYBE_FOR15(i1,
+      (uint32_t)0U,
+      (uint32_t)15U,
+      (uint32_t)1U,
       uint64_t c = FStar_UInt64_eq_mask(bits_c, (uint64_t)(i1 + (uint32_t)1U));
       uint64_t *res_j = table + (i1 + (uint32_t)1U) * len;
       for (uint32_t i = (uint32_t)0U; i < len; i++)
@@ -2506,15 +2517,15 @@ Hacl_Bignum_Exponentiation_bn_mod_exp_consttime_precomp_u64(
         uint64_t *os = resM;
         uint64_t x = (c & res_j[i]) | (~c & resM[i]);
         os[i] = x;
-      }
-    }
+      });
   }
   for (uint32_t i0 = (uint32_t)0U; i0 < bBits / (uint32_t)4U; i0++)
   {
-    for (uint32_t i = (uint32_t)0U; i < (uint32_t)4U; i++)
-    {
-      bn_almost_mont_sqr_u64(len, n, mu, resM, resM);
-    }
+    KRML_MAYBE_FOR4(i,
+      (uint32_t)0U,
+      (uint32_t)4U,
+      (uint32_t)1U,
+      bn_almost_mont_sqr_u64(len, n, mu, resM, resM););
     uint32_t bk = bBits - bBits % (uint32_t)4U;
     uint64_t mask_l = (uint64_t)16U - (uint64_t)1U;
     uint32_t i1 = (bk - (uint32_t)4U * i0 - (uint32_t)4U) / (uint32_t)64U;
@@ -2534,8 +2545,10 @@ Hacl_Bignum_Exponentiation_bn_mod_exp_consttime_precomp_u64(
     uint64_t a_bits_l[len];
     memset(a_bits_l, 0U, len * sizeof (uint64_t));
     memcpy(a_bits_l, table, len * sizeof (uint64_t));
-    for (uint32_t i2 = (uint32_t)0U; i2 < (uint32_t)15U; i2++)
-    {
+    KRML_MAYBE_FOR15(i2,
+      (uint32_t)0U,
+      (uint32_t)15U,
+      (uint32_t)1U,
       uint64_t c = FStar_UInt64_eq_mask(bits_l, (uint64_t)(i2 + (uint32_t)1U));
       uint64_t *res_j = table + (i2 + (uint32_t)1U) * len;
       for (uint32_t i = (uint32_t)0U; i < len; i++)
@@ -2543,8 +2556,7 @@ Hacl_Bignum_Exponentiation_bn_mod_exp_consttime_precomp_u64(
         uint64_t *os = a_bits_l;
         uint64_t x = (c & res_j[i]) | (~c & a_bits_l[i]);
         os[i] = x;
-      }
-    }
+      });
     bn_almost_mont_mul_u64(len, n, mu, resM, a_bits_l, resM);
   }
   KRML_CHECK_SIZE(sizeof (uint64_t), len + len);

--- a/dist/gcc-compatible/Hacl_Bignum25519_51.h
+++ b/dist/gcc-compatible/Hacl_Bignum25519_51.h
@@ -661,12 +661,13 @@ static inline void
 Hacl_Impl_Curve25519_Field51_cswap2(uint64_t bit, uint64_t *p1, uint64_t *p2)
 {
   uint64_t mask = (uint64_t)0U - bit;
-  for (uint32_t i = (uint32_t)0U; i < (uint32_t)10U; i++)
-  {
+  KRML_MAYBE_FOR10(i,
+    (uint32_t)0U,
+    (uint32_t)10U,
+    (uint32_t)1U,
     uint64_t dummy = mask & (p1[i] ^ p2[i]);
     p1[i] = p1[i] ^ dummy;
-    p2[i] = p2[i] ^ dummy;
-  }
+    p2[i] = p2[i] ^ dummy;);
 }
 
 #if defined(__cplusplus)

--- a/dist/gcc-compatible/Hacl_Bignum256.c
+++ b/dist/gcc-compatible/Hacl_Bignum256.c
@@ -59,8 +59,10 @@ Write `a + b mod 2^256` in `res`.
 uint64_t Hacl_Bignum256_add(uint64_t *a, uint64_t *b, uint64_t *res)
 {
   uint64_t c = (uint64_t)0U;
-  for (uint32_t i = (uint32_t)0U; i < (uint32_t)1U; i++)
-  {
+  KRML_MAYBE_FOR1(i,
+    (uint32_t)0U,
+    (uint32_t)1U,
+    (uint32_t)1U,
     uint64_t t1 = a[(uint32_t)4U * i];
     uint64_t t20 = b[(uint32_t)4U * i];
     uint64_t *res_i0 = res + (uint32_t)4U * i;
@@ -76,15 +78,15 @@ uint64_t Hacl_Bignum256_add(uint64_t *a, uint64_t *b, uint64_t *res)
     uint64_t t12 = a[(uint32_t)4U * i + (uint32_t)3U];
     uint64_t t2 = b[(uint32_t)4U * i + (uint32_t)3U];
     uint64_t *res_i = res + (uint32_t)4U * i + (uint32_t)3U;
-    c = Lib_IntTypes_Intrinsics_add_carry_u64(c, t12, t2, res_i);
-  }
-  for (uint32_t i = (uint32_t)4U; i < (uint32_t)4U; i++)
-  {
+    c = Lib_IntTypes_Intrinsics_add_carry_u64(c, t12, t2, res_i););
+  KRML_MAYBE_FOR0(i,
+    (uint32_t)4U,
+    (uint32_t)4U,
+    (uint32_t)1U,
     uint64_t t1 = a[i];
     uint64_t t2 = b[i];
     uint64_t *res_i = res + i;
-    c = Lib_IntTypes_Intrinsics_add_carry_u64(c, t1, t2, res_i);
-  }
+    c = Lib_IntTypes_Intrinsics_add_carry_u64(c, t1, t2, res_i););
   return c;
 }
 
@@ -98,8 +100,10 @@ Write `a - b mod 2^256` in `res`.
 uint64_t Hacl_Bignum256_sub(uint64_t *a, uint64_t *b, uint64_t *res)
 {
   uint64_t c = (uint64_t)0U;
-  for (uint32_t i = (uint32_t)0U; i < (uint32_t)1U; i++)
-  {
+  KRML_MAYBE_FOR1(i,
+    (uint32_t)0U,
+    (uint32_t)1U,
+    (uint32_t)1U,
     uint64_t t1 = a[(uint32_t)4U * i];
     uint64_t t20 = b[(uint32_t)4U * i];
     uint64_t *res_i0 = res + (uint32_t)4U * i;
@@ -115,15 +119,15 @@ uint64_t Hacl_Bignum256_sub(uint64_t *a, uint64_t *b, uint64_t *res)
     uint64_t t12 = a[(uint32_t)4U * i + (uint32_t)3U];
     uint64_t t2 = b[(uint32_t)4U * i + (uint32_t)3U];
     uint64_t *res_i = res + (uint32_t)4U * i + (uint32_t)3U;
-    c = Lib_IntTypes_Intrinsics_sub_borrow_u64(c, t12, t2, res_i);
-  }
-  for (uint32_t i = (uint32_t)4U; i < (uint32_t)4U; i++)
-  {
+    c = Lib_IntTypes_Intrinsics_sub_borrow_u64(c, t12, t2, res_i););
+  KRML_MAYBE_FOR0(i,
+    (uint32_t)4U,
+    (uint32_t)4U,
+    (uint32_t)1U,
     uint64_t t1 = a[i];
     uint64_t t2 = b[i];
     uint64_t *res_i = res + i;
-    c = Lib_IntTypes_Intrinsics_sub_borrow_u64(c, t1, t2, res_i);
-  }
+    c = Lib_IntTypes_Intrinsics_sub_borrow_u64(c, t1, t2, res_i););
   return c;
 }
 
@@ -140,8 +144,10 @@ Write `(a + b) mod n` in `res`.
 void Hacl_Bignum256_add_mod(uint64_t *n, uint64_t *a, uint64_t *b, uint64_t *res)
 {
   uint64_t c0 = (uint64_t)0U;
-  for (uint32_t i = (uint32_t)0U; i < (uint32_t)1U; i++)
-  {
+  KRML_MAYBE_FOR1(i,
+    (uint32_t)0U,
+    (uint32_t)1U,
+    (uint32_t)1U,
     uint64_t t1 = a[(uint32_t)4U * i];
     uint64_t t20 = b[(uint32_t)4U * i];
     uint64_t *res_i0 = res + (uint32_t)4U * i;
@@ -157,20 +163,22 @@ void Hacl_Bignum256_add_mod(uint64_t *n, uint64_t *a, uint64_t *b, uint64_t *res
     uint64_t t12 = a[(uint32_t)4U * i + (uint32_t)3U];
     uint64_t t2 = b[(uint32_t)4U * i + (uint32_t)3U];
     uint64_t *res_i = res + (uint32_t)4U * i + (uint32_t)3U;
-    c0 = Lib_IntTypes_Intrinsics_add_carry_u64(c0, t12, t2, res_i);
-  }
-  for (uint32_t i = (uint32_t)4U; i < (uint32_t)4U; i++)
-  {
+    c0 = Lib_IntTypes_Intrinsics_add_carry_u64(c0, t12, t2, res_i););
+  KRML_MAYBE_FOR0(i,
+    (uint32_t)4U,
+    (uint32_t)4U,
+    (uint32_t)1U,
     uint64_t t1 = a[i];
     uint64_t t2 = b[i];
     uint64_t *res_i = res + i;
-    c0 = Lib_IntTypes_Intrinsics_add_carry_u64(c0, t1, t2, res_i);
-  }
+    c0 = Lib_IntTypes_Intrinsics_add_carry_u64(c0, t1, t2, res_i););
   uint64_t c00 = c0;
   uint64_t tmp[4U] = { 0U };
   uint64_t c = (uint64_t)0U;
-  for (uint32_t i = (uint32_t)0U; i < (uint32_t)1U; i++)
-  {
+  KRML_MAYBE_FOR1(i,
+    (uint32_t)0U,
+    (uint32_t)1U,
+    (uint32_t)1U,
     uint64_t t1 = res[(uint32_t)4U * i];
     uint64_t t20 = n[(uint32_t)4U * i];
     uint64_t *res_i0 = tmp + (uint32_t)4U * i;
@@ -186,23 +194,24 @@ void Hacl_Bignum256_add_mod(uint64_t *n, uint64_t *a, uint64_t *b, uint64_t *res
     uint64_t t12 = res[(uint32_t)4U * i + (uint32_t)3U];
     uint64_t t2 = n[(uint32_t)4U * i + (uint32_t)3U];
     uint64_t *res_i = tmp + (uint32_t)4U * i + (uint32_t)3U;
-    c = Lib_IntTypes_Intrinsics_sub_borrow_u64(c, t12, t2, res_i);
-  }
-  for (uint32_t i = (uint32_t)4U; i < (uint32_t)4U; i++)
-  {
+    c = Lib_IntTypes_Intrinsics_sub_borrow_u64(c, t12, t2, res_i););
+  KRML_MAYBE_FOR0(i,
+    (uint32_t)4U,
+    (uint32_t)4U,
+    (uint32_t)1U,
     uint64_t t1 = res[i];
     uint64_t t2 = n[i];
     uint64_t *res_i = tmp + i;
-    c = Lib_IntTypes_Intrinsics_sub_borrow_u64(c, t1, t2, res_i);
-  }
+    c = Lib_IntTypes_Intrinsics_sub_borrow_u64(c, t1, t2, res_i););
   uint64_t c1 = c;
   uint64_t c2 = c00 - c1;
-  for (uint32_t i = (uint32_t)0U; i < (uint32_t)4U; i++)
-  {
+  KRML_MAYBE_FOR4(i,
+    (uint32_t)0U,
+    (uint32_t)4U,
+    (uint32_t)1U,
     uint64_t *os = res;
     uint64_t x = (c2 & res[i]) | (~c2 & tmp[i]);
-    os[i] = x;
-  }
+    os[i] = x;);
 }
 
 /*
@@ -218,8 +227,10 @@ Write `(a - b) mod n` in `res`.
 void Hacl_Bignum256_sub_mod(uint64_t *n, uint64_t *a, uint64_t *b, uint64_t *res)
 {
   uint64_t c0 = (uint64_t)0U;
-  for (uint32_t i = (uint32_t)0U; i < (uint32_t)1U; i++)
-  {
+  KRML_MAYBE_FOR1(i,
+    (uint32_t)0U,
+    (uint32_t)1U,
+    (uint32_t)1U,
     uint64_t t1 = a[(uint32_t)4U * i];
     uint64_t t20 = b[(uint32_t)4U * i];
     uint64_t *res_i0 = res + (uint32_t)4U * i;
@@ -235,20 +246,22 @@ void Hacl_Bignum256_sub_mod(uint64_t *n, uint64_t *a, uint64_t *b, uint64_t *res
     uint64_t t12 = a[(uint32_t)4U * i + (uint32_t)3U];
     uint64_t t2 = b[(uint32_t)4U * i + (uint32_t)3U];
     uint64_t *res_i = res + (uint32_t)4U * i + (uint32_t)3U;
-    c0 = Lib_IntTypes_Intrinsics_sub_borrow_u64(c0, t12, t2, res_i);
-  }
-  for (uint32_t i = (uint32_t)4U; i < (uint32_t)4U; i++)
-  {
+    c0 = Lib_IntTypes_Intrinsics_sub_borrow_u64(c0, t12, t2, res_i););
+  KRML_MAYBE_FOR0(i,
+    (uint32_t)4U,
+    (uint32_t)4U,
+    (uint32_t)1U,
     uint64_t t1 = a[i];
     uint64_t t2 = b[i];
     uint64_t *res_i = res + i;
-    c0 = Lib_IntTypes_Intrinsics_sub_borrow_u64(c0, t1, t2, res_i);
-  }
+    c0 = Lib_IntTypes_Intrinsics_sub_borrow_u64(c0, t1, t2, res_i););
   uint64_t c00 = c0;
   uint64_t tmp[4U] = { 0U };
   uint64_t c = (uint64_t)0U;
-  for (uint32_t i = (uint32_t)0U; i < (uint32_t)1U; i++)
-  {
+  KRML_MAYBE_FOR1(i,
+    (uint32_t)0U,
+    (uint32_t)1U,
+    (uint32_t)1U,
     uint64_t t1 = res[(uint32_t)4U * i];
     uint64_t t20 = n[(uint32_t)4U * i];
     uint64_t *res_i0 = tmp + (uint32_t)4U * i;
@@ -264,23 +277,24 @@ void Hacl_Bignum256_sub_mod(uint64_t *n, uint64_t *a, uint64_t *b, uint64_t *res
     uint64_t t12 = res[(uint32_t)4U * i + (uint32_t)3U];
     uint64_t t2 = n[(uint32_t)4U * i + (uint32_t)3U];
     uint64_t *res_i = tmp + (uint32_t)4U * i + (uint32_t)3U;
-    c = Lib_IntTypes_Intrinsics_add_carry_u64(c, t12, t2, res_i);
-  }
-  for (uint32_t i = (uint32_t)4U; i < (uint32_t)4U; i++)
-  {
+    c = Lib_IntTypes_Intrinsics_add_carry_u64(c, t12, t2, res_i););
+  KRML_MAYBE_FOR0(i,
+    (uint32_t)4U,
+    (uint32_t)4U,
+    (uint32_t)1U,
     uint64_t t1 = res[i];
     uint64_t t2 = n[i];
     uint64_t *res_i = tmp + i;
-    c = Lib_IntTypes_Intrinsics_add_carry_u64(c, t1, t2, res_i);
-  }
+    c = Lib_IntTypes_Intrinsics_add_carry_u64(c, t1, t2, res_i););
   uint64_t c1 = c;
   uint64_t c2 = (uint64_t)0U - c00;
-  for (uint32_t i = (uint32_t)0U; i < (uint32_t)4U; i++)
-  {
+  KRML_MAYBE_FOR4(i,
+    (uint32_t)0U,
+    (uint32_t)4U,
+    (uint32_t)1U,
     uint64_t *os = res;
     uint64_t x = (c2 & tmp[i]) | (~c2 & res[i]);
-    os[i] = x;
-  }
+    os[i] = x;);
 }
 
 /*
@@ -292,13 +306,17 @@ Write `a * b` in `res`.
 void Hacl_Bignum256_mul(uint64_t *a, uint64_t *b, uint64_t *res)
 {
   memset(res, 0U, (uint32_t)8U * sizeof (uint64_t));
-  for (uint32_t i0 = (uint32_t)0U; i0 < (uint32_t)4U; i0++)
-  {
+  KRML_MAYBE_FOR4(i0,
+    (uint32_t)0U,
+    (uint32_t)4U,
+    (uint32_t)1U,
     uint64_t bj = b[i0];
     uint64_t *res_j = res + i0;
     uint64_t c = (uint64_t)0U;
-    for (uint32_t i = (uint32_t)0U; i < (uint32_t)1U; i++)
-    {
+    KRML_MAYBE_FOR1(i,
+      (uint32_t)0U,
+      (uint32_t)1U,
+      (uint32_t)1U,
       uint64_t a_i = a[(uint32_t)4U * i];
       uint64_t *res_i0 = res_j + (uint32_t)4U * i;
       c = Hacl_Bignum_Base_mul_wide_add2_u64(a_i, bj, c, res_i0);
@@ -310,17 +328,16 @@ void Hacl_Bignum256_mul(uint64_t *a, uint64_t *b, uint64_t *res)
       c = Hacl_Bignum_Base_mul_wide_add2_u64(a_i1, bj, c, res_i2);
       uint64_t a_i2 = a[(uint32_t)4U * i + (uint32_t)3U];
       uint64_t *res_i = res_j + (uint32_t)4U * i + (uint32_t)3U;
-      c = Hacl_Bignum_Base_mul_wide_add2_u64(a_i2, bj, c, res_i);
-    }
-    for (uint32_t i = (uint32_t)4U; i < (uint32_t)4U; i++)
-    {
+      c = Hacl_Bignum_Base_mul_wide_add2_u64(a_i2, bj, c, res_i););
+    KRML_MAYBE_FOR0(i,
+      (uint32_t)4U,
+      (uint32_t)4U,
+      (uint32_t)1U,
       uint64_t a_i = a[i];
       uint64_t *res_i = res_j + i;
-      c = Hacl_Bignum_Base_mul_wide_add2_u64(a_i, bj, c, res_i);
-    }
+      c = Hacl_Bignum_Base_mul_wide_add2_u64(a_i, bj, c, res_i););
     uint64_t r = c;
-    res[(uint32_t)4U + i0] = r;
-  }
+    res[(uint32_t)4U + i0] = r;);
 }
 
 /*
@@ -332,8 +349,10 @@ Write `a * a` in `res`.
 void Hacl_Bignum256_sqr(uint64_t *a, uint64_t *res)
 {
   memset(res, 0U, (uint32_t)8U * sizeof (uint64_t));
-  for (uint32_t i0 = (uint32_t)0U; i0 < (uint32_t)4U; i0++)
-  {
+  KRML_MAYBE_FOR4(i0,
+    (uint32_t)0U,
+    (uint32_t)4U,
+    (uint32_t)1U,
     uint64_t *ab = a;
     uint64_t a_j = a[i0];
     uint64_t *res_j = res + i0;
@@ -360,18 +379,18 @@ void Hacl_Bignum256_sqr(uint64_t *a, uint64_t *res)
       c = Hacl_Bignum_Base_mul_wide_add2_u64(a_i, a_j, c, res_i);
     }
     uint64_t r = c;
-    res[i0 + i0] = r;
-  }
+    res[i0 + i0] = r;);
   uint64_t c0 = Hacl_Bignum_Addition_bn_add_eq_len_u64((uint32_t)8U, res, res, res);
   uint64_t tmp[8U] = { 0U };
-  for (uint32_t i = (uint32_t)0U; i < (uint32_t)4U; i++)
-  {
+  KRML_MAYBE_FOR4(i,
+    (uint32_t)0U,
+    (uint32_t)4U,
+    (uint32_t)1U,
     FStar_UInt128_uint128 res1 = FStar_UInt128_mul_wide(a[i], a[i]);
     uint64_t hi = FStar_UInt128_uint128_to_uint64(FStar_UInt128_shift_right(res1, (uint32_t)64U));
     uint64_t lo = FStar_UInt128_uint128_to_uint64(res1);
     tmp[(uint32_t)2U * i] = lo;
-    tmp[(uint32_t)2U * i + (uint32_t)1U] = hi;
-  }
+    tmp[(uint32_t)2U * i + (uint32_t)1U] = hi;);
   uint64_t c1 = Hacl_Bignum_Addition_bn_add_eq_len_u64((uint32_t)8U, res, tmp, res);
 }
 
@@ -390,13 +409,17 @@ static inline void precompr2(uint32_t nBits, uint64_t *n, uint64_t *res)
 static inline void reduction(uint64_t *n, uint64_t nInv, uint64_t *c, uint64_t *res)
 {
   uint64_t c0 = (uint64_t)0U;
-  for (uint32_t i0 = (uint32_t)0U; i0 < (uint32_t)4U; i0++)
-  {
+  KRML_MAYBE_FOR4(i0,
+    (uint32_t)0U,
+    (uint32_t)4U,
+    (uint32_t)1U,
     uint64_t qj = nInv * c[i0];
     uint64_t *res_j0 = c + i0;
     uint64_t c1 = (uint64_t)0U;
-    for (uint32_t i = (uint32_t)0U; i < (uint32_t)1U; i++)
-    {
+    KRML_MAYBE_FOR1(i,
+      (uint32_t)0U,
+      (uint32_t)1U,
+      (uint32_t)1U,
       uint64_t a_i = n[(uint32_t)4U * i];
       uint64_t *res_i0 = res_j0 + (uint32_t)4U * i;
       c1 = Hacl_Bignum_Base_mul_wide_add2_u64(a_i, qj, c1, res_i0);
@@ -408,26 +431,27 @@ static inline void reduction(uint64_t *n, uint64_t nInv, uint64_t *c, uint64_t *
       c1 = Hacl_Bignum_Base_mul_wide_add2_u64(a_i1, qj, c1, res_i2);
       uint64_t a_i2 = n[(uint32_t)4U * i + (uint32_t)3U];
       uint64_t *res_i = res_j0 + (uint32_t)4U * i + (uint32_t)3U;
-      c1 = Hacl_Bignum_Base_mul_wide_add2_u64(a_i2, qj, c1, res_i);
-    }
-    for (uint32_t i = (uint32_t)4U; i < (uint32_t)4U; i++)
-    {
+      c1 = Hacl_Bignum_Base_mul_wide_add2_u64(a_i2, qj, c1, res_i););
+    KRML_MAYBE_FOR0(i,
+      (uint32_t)4U,
+      (uint32_t)4U,
+      (uint32_t)1U,
       uint64_t a_i = n[i];
       uint64_t *res_i = res_j0 + i;
-      c1 = Hacl_Bignum_Base_mul_wide_add2_u64(a_i, qj, c1, res_i);
-    }
+      c1 = Hacl_Bignum_Base_mul_wide_add2_u64(a_i, qj, c1, res_i););
     uint64_t r = c1;
     uint64_t c10 = r;
     uint64_t *resb = c + (uint32_t)4U + i0;
     uint64_t res_j = c[(uint32_t)4U + i0];
-    c0 = Lib_IntTypes_Intrinsics_add_carry_u64(c0, c10, res_j, resb);
-  }
+    c0 = Lib_IntTypes_Intrinsics_add_carry_u64(c0, c10, res_j, resb););
   memcpy(res, c + (uint32_t)4U, (uint32_t)4U * sizeof (uint64_t));
   uint64_t c00 = c0;
   uint64_t tmp[4U] = { 0U };
   uint64_t c1 = (uint64_t)0U;
-  for (uint32_t i = (uint32_t)0U; i < (uint32_t)1U; i++)
-  {
+  KRML_MAYBE_FOR1(i,
+    (uint32_t)0U,
+    (uint32_t)1U,
+    (uint32_t)1U,
     uint64_t t1 = res[(uint32_t)4U * i];
     uint64_t t20 = n[(uint32_t)4U * i];
     uint64_t *res_i0 = tmp + (uint32_t)4U * i;
@@ -443,35 +467,40 @@ static inline void reduction(uint64_t *n, uint64_t nInv, uint64_t *c, uint64_t *
     uint64_t t12 = res[(uint32_t)4U * i + (uint32_t)3U];
     uint64_t t2 = n[(uint32_t)4U * i + (uint32_t)3U];
     uint64_t *res_i = tmp + (uint32_t)4U * i + (uint32_t)3U;
-    c1 = Lib_IntTypes_Intrinsics_sub_borrow_u64(c1, t12, t2, res_i);
-  }
-  for (uint32_t i = (uint32_t)4U; i < (uint32_t)4U; i++)
-  {
+    c1 = Lib_IntTypes_Intrinsics_sub_borrow_u64(c1, t12, t2, res_i););
+  KRML_MAYBE_FOR0(i,
+    (uint32_t)4U,
+    (uint32_t)4U,
+    (uint32_t)1U,
     uint64_t t1 = res[i];
     uint64_t t2 = n[i];
     uint64_t *res_i = tmp + i;
-    c1 = Lib_IntTypes_Intrinsics_sub_borrow_u64(c1, t1, t2, res_i);
-  }
+    c1 = Lib_IntTypes_Intrinsics_sub_borrow_u64(c1, t1, t2, res_i););
   uint64_t c10 = c1;
   uint64_t c2 = c00 - c10;
-  for (uint32_t i = (uint32_t)0U; i < (uint32_t)4U; i++)
-  {
+  KRML_MAYBE_FOR4(i,
+    (uint32_t)0U,
+    (uint32_t)4U,
+    (uint32_t)1U,
     uint64_t *os = res;
     uint64_t x = (c2 & res[i]) | (~c2 & tmp[i]);
-    os[i] = x;
-  }
+    os[i] = x;);
 }
 
 static inline void areduction(uint64_t *n, uint64_t nInv, uint64_t *c, uint64_t *res)
 {
   uint64_t c0 = (uint64_t)0U;
-  for (uint32_t i0 = (uint32_t)0U; i0 < (uint32_t)4U; i0++)
-  {
+  KRML_MAYBE_FOR4(i0,
+    (uint32_t)0U,
+    (uint32_t)4U,
+    (uint32_t)1U,
     uint64_t qj = nInv * c[i0];
     uint64_t *res_j0 = c + i0;
     uint64_t c1 = (uint64_t)0U;
-    for (uint32_t i = (uint32_t)0U; i < (uint32_t)1U; i++)
-    {
+    KRML_MAYBE_FOR1(i,
+      (uint32_t)0U,
+      (uint32_t)1U,
+      (uint32_t)1U,
       uint64_t a_i = n[(uint32_t)4U * i];
       uint64_t *res_i0 = res_j0 + (uint32_t)4U * i;
       c1 = Hacl_Bignum_Base_mul_wide_add2_u64(a_i, qj, c1, res_i0);
@@ -483,31 +512,31 @@ static inline void areduction(uint64_t *n, uint64_t nInv, uint64_t *c, uint64_t 
       c1 = Hacl_Bignum_Base_mul_wide_add2_u64(a_i1, qj, c1, res_i2);
       uint64_t a_i2 = n[(uint32_t)4U * i + (uint32_t)3U];
       uint64_t *res_i = res_j0 + (uint32_t)4U * i + (uint32_t)3U;
-      c1 = Hacl_Bignum_Base_mul_wide_add2_u64(a_i2, qj, c1, res_i);
-    }
-    for (uint32_t i = (uint32_t)4U; i < (uint32_t)4U; i++)
-    {
+      c1 = Hacl_Bignum_Base_mul_wide_add2_u64(a_i2, qj, c1, res_i););
+    KRML_MAYBE_FOR0(i,
+      (uint32_t)4U,
+      (uint32_t)4U,
+      (uint32_t)1U,
       uint64_t a_i = n[i];
       uint64_t *res_i = res_j0 + i;
-      c1 = Hacl_Bignum_Base_mul_wide_add2_u64(a_i, qj, c1, res_i);
-    }
+      c1 = Hacl_Bignum_Base_mul_wide_add2_u64(a_i, qj, c1, res_i););
     uint64_t r = c1;
     uint64_t c10 = r;
     uint64_t *resb = c + (uint32_t)4U + i0;
     uint64_t res_j = c[(uint32_t)4U + i0];
-    c0 = Lib_IntTypes_Intrinsics_add_carry_u64(c0, c10, res_j, resb);
-  }
+    c0 = Lib_IntTypes_Intrinsics_add_carry_u64(c0, c10, res_j, resb););
   memcpy(res, c + (uint32_t)4U, (uint32_t)4U * sizeof (uint64_t));
   uint64_t c00 = c0;
   uint64_t tmp[4U] = { 0U };
   uint64_t c1 = Hacl_Bignum256_sub(res, n, tmp);
   uint64_t m = (uint64_t)0U - c00;
-  for (uint32_t i = (uint32_t)0U; i < (uint32_t)4U; i++)
-  {
+  KRML_MAYBE_FOR4(i,
+    (uint32_t)0U,
+    (uint32_t)4U,
+    (uint32_t)1U,
     uint64_t *os = res;
     uint64_t x = (m & tmp[i]) | (~m & res[i]);
-    os[i] = x;
-  }
+    os[i] = x;);
 }
 
 static inline void
@@ -515,13 +544,17 @@ amont_mul(uint64_t *n, uint64_t nInv_u64, uint64_t *aM, uint64_t *bM, uint64_t *
 {
   uint64_t c[8U] = { 0U };
   memset(c, 0U, (uint32_t)8U * sizeof (uint64_t));
-  for (uint32_t i0 = (uint32_t)0U; i0 < (uint32_t)4U; i0++)
-  {
+  KRML_MAYBE_FOR4(i0,
+    (uint32_t)0U,
+    (uint32_t)4U,
+    (uint32_t)1U,
     uint64_t bj = bM[i0];
     uint64_t *res_j = c + i0;
     uint64_t c1 = (uint64_t)0U;
-    for (uint32_t i = (uint32_t)0U; i < (uint32_t)1U; i++)
-    {
+    KRML_MAYBE_FOR1(i,
+      (uint32_t)0U,
+      (uint32_t)1U,
+      (uint32_t)1U,
       uint64_t a_i = aM[(uint32_t)4U * i];
       uint64_t *res_i0 = res_j + (uint32_t)4U * i;
       c1 = Hacl_Bignum_Base_mul_wide_add2_u64(a_i, bj, c1, res_i0);
@@ -533,17 +566,16 @@ amont_mul(uint64_t *n, uint64_t nInv_u64, uint64_t *aM, uint64_t *bM, uint64_t *
       c1 = Hacl_Bignum_Base_mul_wide_add2_u64(a_i1, bj, c1, res_i2);
       uint64_t a_i2 = aM[(uint32_t)4U * i + (uint32_t)3U];
       uint64_t *res_i = res_j + (uint32_t)4U * i + (uint32_t)3U;
-      c1 = Hacl_Bignum_Base_mul_wide_add2_u64(a_i2, bj, c1, res_i);
-    }
-    for (uint32_t i = (uint32_t)4U; i < (uint32_t)4U; i++)
-    {
+      c1 = Hacl_Bignum_Base_mul_wide_add2_u64(a_i2, bj, c1, res_i););
+    KRML_MAYBE_FOR0(i,
+      (uint32_t)4U,
+      (uint32_t)4U,
+      (uint32_t)1U,
       uint64_t a_i = aM[i];
       uint64_t *res_i = res_j + i;
-      c1 = Hacl_Bignum_Base_mul_wide_add2_u64(a_i, bj, c1, res_i);
-    }
+      c1 = Hacl_Bignum_Base_mul_wide_add2_u64(a_i, bj, c1, res_i););
     uint64_t r = c1;
-    c[(uint32_t)4U + i0] = r;
-  }
+    c[(uint32_t)4U + i0] = r;);
   areduction(n, nInv_u64, c, resM);
 }
 
@@ -551,8 +583,10 @@ static inline void amont_sqr(uint64_t *n, uint64_t nInv_u64, uint64_t *aM, uint6
 {
   uint64_t c[8U] = { 0U };
   memset(c, 0U, (uint32_t)8U * sizeof (uint64_t));
-  for (uint32_t i0 = (uint32_t)0U; i0 < (uint32_t)4U; i0++)
-  {
+  KRML_MAYBE_FOR4(i0,
+    (uint32_t)0U,
+    (uint32_t)4U,
+    (uint32_t)1U,
     uint64_t *ab = aM;
     uint64_t a_j = aM[i0];
     uint64_t *res_j = c + i0;
@@ -579,18 +613,18 @@ static inline void amont_sqr(uint64_t *n, uint64_t nInv_u64, uint64_t *aM, uint6
       c1 = Hacl_Bignum_Base_mul_wide_add2_u64(a_i, a_j, c1, res_i);
     }
     uint64_t r = c1;
-    c[i0 + i0] = r;
-  }
+    c[i0 + i0] = r;);
   uint64_t c0 = Hacl_Bignum_Addition_bn_add_eq_len_u64((uint32_t)8U, c, c, c);
   uint64_t tmp[8U] = { 0U };
-  for (uint32_t i = (uint32_t)0U; i < (uint32_t)4U; i++)
-  {
+  KRML_MAYBE_FOR4(i,
+    (uint32_t)0U,
+    (uint32_t)4U,
+    (uint32_t)1U,
     FStar_UInt128_uint128 res = FStar_UInt128_mul_wide(aM[i], aM[i]);
     uint64_t hi = FStar_UInt128_uint128_to_uint64(FStar_UInt128_shift_right(res, (uint32_t)64U));
     uint64_t lo = FStar_UInt128_uint128_to_uint64(res);
     tmp[(uint32_t)2U * i] = lo;
-    tmp[(uint32_t)2U * i + (uint32_t)1U] = hi;
-  }
+    tmp[(uint32_t)2U * i + (uint32_t)1U] = hi;);
   uint64_t c1 = Hacl_Bignum_Addition_bn_add_eq_len_u64((uint32_t)8U, c, tmp, c);
   areduction(n, nInv_u64, c, resM);
 }
@@ -602,13 +636,17 @@ bn_slow_precomp(uint64_t *n, uint64_t mu, uint64_t *r2, uint64_t *a, uint64_t *r
   uint64_t a1[8U] = { 0U };
   memcpy(a1, a, (uint32_t)8U * sizeof (uint64_t));
   uint64_t c0 = (uint64_t)0U;
-  for (uint32_t i0 = (uint32_t)0U; i0 < (uint32_t)4U; i0++)
-  {
+  KRML_MAYBE_FOR4(i0,
+    (uint32_t)0U,
+    (uint32_t)4U,
+    (uint32_t)1U,
     uint64_t qj = mu * a1[i0];
     uint64_t *res_j0 = a1 + i0;
     uint64_t c = (uint64_t)0U;
-    for (uint32_t i = (uint32_t)0U; i < (uint32_t)1U; i++)
-    {
+    KRML_MAYBE_FOR1(i,
+      (uint32_t)0U,
+      (uint32_t)1U,
+      (uint32_t)1U,
       uint64_t a_i = n[(uint32_t)4U * i];
       uint64_t *res_i0 = res_j0 + (uint32_t)4U * i;
       c = Hacl_Bignum_Base_mul_wide_add2_u64(a_i, qj, c, res_i0);
@@ -620,31 +658,31 @@ bn_slow_precomp(uint64_t *n, uint64_t mu, uint64_t *r2, uint64_t *a, uint64_t *r
       c = Hacl_Bignum_Base_mul_wide_add2_u64(a_i1, qj, c, res_i2);
       uint64_t a_i2 = n[(uint32_t)4U * i + (uint32_t)3U];
       uint64_t *res_i = res_j0 + (uint32_t)4U * i + (uint32_t)3U;
-      c = Hacl_Bignum_Base_mul_wide_add2_u64(a_i2, qj, c, res_i);
-    }
-    for (uint32_t i = (uint32_t)4U; i < (uint32_t)4U; i++)
-    {
+      c = Hacl_Bignum_Base_mul_wide_add2_u64(a_i2, qj, c, res_i););
+    KRML_MAYBE_FOR0(i,
+      (uint32_t)4U,
+      (uint32_t)4U,
+      (uint32_t)1U,
       uint64_t a_i = n[i];
       uint64_t *res_i = res_j0 + i;
-      c = Hacl_Bignum_Base_mul_wide_add2_u64(a_i, qj, c, res_i);
-    }
+      c = Hacl_Bignum_Base_mul_wide_add2_u64(a_i, qj, c, res_i););
     uint64_t r = c;
     uint64_t c1 = r;
     uint64_t *resb = a1 + (uint32_t)4U + i0;
     uint64_t res_j = a1[(uint32_t)4U + i0];
-    c0 = Lib_IntTypes_Intrinsics_add_carry_u64(c0, c1, res_j, resb);
-  }
+    c0 = Lib_IntTypes_Intrinsics_add_carry_u64(c0, c1, res_j, resb););
   memcpy(a_mod, a1 + (uint32_t)4U, (uint32_t)4U * sizeof (uint64_t));
   uint64_t c00 = c0;
   uint64_t tmp[4U] = { 0U };
   uint64_t c1 = Hacl_Bignum256_sub(a_mod, n, tmp);
   uint64_t m = (uint64_t)0U - c00;
-  for (uint32_t i = (uint32_t)0U; i < (uint32_t)4U; i++)
-  {
+  KRML_MAYBE_FOR4(i,
+    (uint32_t)0U,
+    (uint32_t)4U,
+    (uint32_t)1U,
     uint64_t *os = a_mod;
     uint64_t x = (m & tmp[i]) | (~m & a_mod[i]);
-    os[i] = x;
-  }
+    os[i] = x;);
   uint64_t c[8U] = { 0U };
   Hacl_Bignum256_mul(a_mod, r2, c);
   reduction(n, mu, c, res);
@@ -669,12 +707,13 @@ bool Hacl_Bignum256_mod(uint64_t *n, uint64_t *a, uint64_t *res)
   uint64_t bit0 = n[0U] & (uint64_t)1U;
   uint64_t m0 = (uint64_t)0U - bit0;
   uint64_t acc = (uint64_t)0U;
-  for (uint32_t i = (uint32_t)0U; i < (uint32_t)4U; i++)
-  {
+  KRML_MAYBE_FOR4(i,
+    (uint32_t)0U,
+    (uint32_t)4U,
+    (uint32_t)1U,
     uint64_t beq = FStar_UInt64_eq_mask(one[i], n[i]);
     uint64_t blt = ~FStar_UInt64_gte_mask(one[i], n[i]);
-    acc = (beq & acc) | (~beq & ((blt & (uint64_t)0xFFFFFFFFFFFFFFFFU) | (~blt & (uint64_t)0U)));
-  }
+    acc = (beq & acc) | (~beq & ((blt & (uint64_t)0xFFFFFFFFFFFFFFFFU) | (~blt & (uint64_t)0U))););
   uint64_t m1 = acc;
   uint64_t is_valid_m = m0 & m1;
   uint32_t
@@ -701,12 +740,13 @@ static uint64_t exp_check(uint64_t *n, uint64_t *a, uint32_t bBits, uint64_t *b)
   uint64_t bit0 = n[0U] & (uint64_t)1U;
   uint64_t m0 = (uint64_t)0U - bit0;
   uint64_t acc0 = (uint64_t)0U;
-  for (uint32_t i = (uint32_t)0U; i < (uint32_t)4U; i++)
-  {
+  KRML_MAYBE_FOR4(i,
+    (uint32_t)0U,
+    (uint32_t)4U,
+    (uint32_t)1U,
     uint64_t beq = FStar_UInt64_eq_mask(one[i], n[i]);
     uint64_t blt = ~FStar_UInt64_gte_mask(one[i], n[i]);
-    acc0 = (beq & acc0) | (~beq & ((blt & (uint64_t)0xFFFFFFFFFFFFFFFFU) | (~blt & (uint64_t)0U)));
-  }
+    acc0 = (beq & acc0) | (~beq & ((blt & (uint64_t)0xFFFFFFFFFFFFFFFFU) | (~blt & (uint64_t)0U))););
   uint64_t m10 = acc0;
   uint64_t m00 = m0 & m10;
   uint32_t bLen;
@@ -742,12 +782,13 @@ static uint64_t exp_check(uint64_t *n, uint64_t *a, uint32_t bBits, uint64_t *b)
     m1 = (uint64_t)0xFFFFFFFFFFFFFFFFU;
   }
   uint64_t acc = (uint64_t)0U;
-  for (uint32_t i = (uint32_t)0U; i < (uint32_t)4U; i++)
-  {
+  KRML_MAYBE_FOR4(i,
+    (uint32_t)0U,
+    (uint32_t)4U,
+    (uint32_t)1U,
     uint64_t beq = FStar_UInt64_eq_mask(a[i], n[i]);
     uint64_t blt = ~FStar_UInt64_gte_mask(a[i], n[i]);
-    acc = (beq & acc) | (~beq & ((blt & (uint64_t)0xFFFFFFFFFFFFFFFFU) | (~blt & (uint64_t)0U)));
-  }
+    acc = (beq & acc) | (~beq & ((blt & (uint64_t)0xFFFFFFFFFFFFFFFFU) | (~blt & (uint64_t)0U))););
   uint64_t m2 = acc;
   uint64_t m = m1 & m2;
   return m00 & m;
@@ -812,12 +853,13 @@ exp_vartime_precomp(
   memcpy(table, resM, (uint32_t)4U * sizeof (uint64_t));
   uint64_t *t1 = table + (uint32_t)4U;
   memcpy(t1, aM, (uint32_t)4U * sizeof (uint64_t));
-  for (uint32_t i = (uint32_t)0U; i < (uint32_t)15U; i++)
-  {
+  KRML_MAYBE_FOR15(i,
+    (uint32_t)0U,
+    (uint32_t)15U,
+    (uint32_t)1U,
     uint64_t *t11 = table + i * (uint32_t)4U;
     uint64_t *t2 = table + i * (uint32_t)4U + (uint32_t)4U;
-    amont_mul(n, mu, aM, t11, t2);
-  }
+    amont_mul(n, mu, aM, t11, t2););
   if (bBits % (uint32_t)4U != (uint32_t)0U)
   {
     uint64_t mask_l = (uint64_t)16U - (uint64_t)1U;
@@ -840,10 +882,7 @@ exp_vartime_precomp(
   }
   for (uint32_t i = (uint32_t)0U; i < bBits / (uint32_t)4U; i++)
   {
-    for (uint32_t i0 = (uint32_t)0U; i0 < (uint32_t)4U; i0++)
-    {
-      amont_sqr(n, mu, resM, resM);
-    }
+    KRML_MAYBE_FOR4(i0, (uint32_t)0U, (uint32_t)4U, (uint32_t)1U, amont_sqr(n, mu, resM, resM););
     uint32_t bk = bBits - bBits % (uint32_t)4U;
     uint64_t mask_l = (uint64_t)16U - (uint64_t)1U;
     uint32_t i1 = (bk - (uint32_t)4U * i - (uint32_t)4U) / (uint32_t)64U;
@@ -899,23 +938,25 @@ exp_consttime_precomp(
       uint64_t tmp = b[i1];
       uint64_t bit = tmp >> j & (uint64_t)1U;
       uint64_t sw1 = bit ^ sw;
-      for (uint32_t i = (uint32_t)0U; i < (uint32_t)4U; i++)
-      {
+      KRML_MAYBE_FOR4(i,
+        (uint32_t)0U,
+        (uint32_t)4U,
+        (uint32_t)1U,
         uint64_t dummy = ((uint64_t)0U - sw1) & (resM[i] ^ aM[i]);
         resM[i] = resM[i] ^ dummy;
-        aM[i] = aM[i] ^ dummy;
-      }
+        aM[i] = aM[i] ^ dummy;);
       amont_mul(n, mu, aM, resM, aM);
       amont_sqr(n, mu, resM, resM);
       sw = bit;
     }
     uint64_t sw0 = sw;
-    for (uint32_t i = (uint32_t)0U; i < (uint32_t)4U; i++)
-    {
+    KRML_MAYBE_FOR4(i,
+      (uint32_t)0U,
+      (uint32_t)4U,
+      (uint32_t)1U,
       uint64_t dummy = ((uint64_t)0U - sw0) & (resM[i] ^ aM[i]);
       resM[i] = resM[i] ^ dummy;
-      aM[i] = aM[i] ^ dummy;
-    }
+      aM[i] = aM[i] ^ dummy;);
     uint64_t tmp[8U] = { 0U };
     memcpy(tmp, resM, (uint32_t)4U * sizeof (uint64_t));
     reduction(n, mu, tmp, res);
@@ -942,12 +983,13 @@ exp_consttime_precomp(
   memcpy(table, resM, (uint32_t)4U * sizeof (uint64_t));
   uint64_t *t1 = table + (uint32_t)4U;
   memcpy(t1, aM, (uint32_t)4U * sizeof (uint64_t));
-  for (uint32_t i = (uint32_t)0U; i < (uint32_t)15U; i++)
-  {
+  KRML_MAYBE_FOR15(i,
+    (uint32_t)0U,
+    (uint32_t)15U,
+    (uint32_t)1U,
     uint64_t *t11 = table + i * (uint32_t)4U;
     uint64_t *t2 = table + i * (uint32_t)4U + (uint32_t)4U;
-    amont_mul(n, mu, aM, t11, t2);
-  }
+    amont_mul(n, mu, aM, t11, t2););
   if (bBits % (uint32_t)4U != (uint32_t)0U)
   {
     uint64_t mask_l = (uint64_t)16U - (uint64_t)1U;
@@ -965,24 +1007,23 @@ exp_consttime_precomp(
     }
     uint64_t bits_c = ite & mask_l;
     memcpy(resM, table, (uint32_t)4U * sizeof (uint64_t));
-    for (uint32_t i1 = (uint32_t)0U; i1 < (uint32_t)15U; i1++)
-    {
+    KRML_MAYBE_FOR15(i1,
+      (uint32_t)0U,
+      (uint32_t)15U,
+      (uint32_t)1U,
       uint64_t c = FStar_UInt64_eq_mask(bits_c, (uint64_t)(i1 + (uint32_t)1U));
       uint64_t *res_j = table + (i1 + (uint32_t)1U) * (uint32_t)4U;
-      for (uint32_t i = (uint32_t)0U; i < (uint32_t)4U; i++)
-      {
+      KRML_MAYBE_FOR4(i,
+        (uint32_t)0U,
+        (uint32_t)4U,
+        (uint32_t)1U,
         uint64_t *os = resM;
         uint64_t x = (c & res_j[i]) | (~c & resM[i]);
-        os[i] = x;
-      }
-    }
+        os[i] = x;););
   }
   for (uint32_t i0 = (uint32_t)0U; i0 < bBits / (uint32_t)4U; i0++)
   {
-    for (uint32_t i = (uint32_t)0U; i < (uint32_t)4U; i++)
-    {
-      amont_sqr(n, mu, resM, resM);
-    }
+    KRML_MAYBE_FOR4(i, (uint32_t)0U, (uint32_t)4U, (uint32_t)1U, amont_sqr(n, mu, resM, resM););
     uint32_t bk = bBits - bBits % (uint32_t)4U;
     uint64_t mask_l = (uint64_t)16U - (uint64_t)1U;
     uint32_t i1 = (bk - (uint32_t)4U * i0 - (uint32_t)4U) / (uint32_t)64U;
@@ -1000,17 +1041,19 @@ exp_consttime_precomp(
     uint64_t bits_l = ite & mask_l;
     uint64_t a_bits_l[4U] = { 0U };
     memcpy(a_bits_l, table, (uint32_t)4U * sizeof (uint64_t));
-    for (uint32_t i2 = (uint32_t)0U; i2 < (uint32_t)15U; i2++)
-    {
+    KRML_MAYBE_FOR15(i2,
+      (uint32_t)0U,
+      (uint32_t)15U,
+      (uint32_t)1U,
       uint64_t c = FStar_UInt64_eq_mask(bits_l, (uint64_t)(i2 + (uint32_t)1U));
       uint64_t *res_j = table + (i2 + (uint32_t)1U) * (uint32_t)4U;
-      for (uint32_t i = (uint32_t)0U; i < (uint32_t)4U; i++)
-      {
+      KRML_MAYBE_FOR4(i,
+        (uint32_t)0U,
+        (uint32_t)4U,
+        (uint32_t)1U,
         uint64_t *os = a_bits_l;
         uint64_t x = (c & res_j[i]) | (~c & a_bits_l[i]);
-        os[i] = x;
-      }
-    }
+        os[i] = x;););
     amont_mul(n, mu, resM, a_bits_l, resM);
   }
   uint64_t tmp0[8U] = { 0U };
@@ -1159,31 +1202,34 @@ bool Hacl_Bignum256_mod_inv_prime_vartime(uint64_t *n, uint64_t *a, uint64_t *re
   uint64_t bit0 = n[0U] & (uint64_t)1U;
   uint64_t m0 = (uint64_t)0U - bit0;
   uint64_t acc0 = (uint64_t)0U;
-  for (uint32_t i = (uint32_t)0U; i < (uint32_t)4U; i++)
-  {
+  KRML_MAYBE_FOR4(i,
+    (uint32_t)0U,
+    (uint32_t)4U,
+    (uint32_t)1U,
     uint64_t beq = FStar_UInt64_eq_mask(one[i], n[i]);
     uint64_t blt = ~FStar_UInt64_gte_mask(one[i], n[i]);
-    acc0 = (beq & acc0) | (~beq & ((blt & (uint64_t)0xFFFFFFFFFFFFFFFFU) | (~blt & (uint64_t)0U)));
-  }
+    acc0 = (beq & acc0) | (~beq & ((blt & (uint64_t)0xFFFFFFFFFFFFFFFFU) | (~blt & (uint64_t)0U))););
   uint64_t m1 = acc0;
   uint64_t m00 = m0 & m1;
   uint64_t bn_zero[4U] = { 0U };
   uint64_t mask = (uint64_t)0xFFFFFFFFFFFFFFFFU;
-  for (uint32_t i = (uint32_t)0U; i < (uint32_t)4U; i++)
-  {
+  KRML_MAYBE_FOR4(i,
+    (uint32_t)0U,
+    (uint32_t)4U,
+    (uint32_t)1U,
     uint64_t uu____0 = FStar_UInt64_eq_mask(a[i], bn_zero[i]);
-    mask = uu____0 & mask;
-  }
+    mask = uu____0 & mask;);
   uint64_t mask1 = mask;
   uint64_t res10 = mask1;
   uint64_t m10 = res10;
   uint64_t acc = (uint64_t)0U;
-  for (uint32_t i = (uint32_t)0U; i < (uint32_t)4U; i++)
-  {
+  KRML_MAYBE_FOR4(i,
+    (uint32_t)0U,
+    (uint32_t)4U,
+    (uint32_t)1U,
     uint64_t beq = FStar_UInt64_eq_mask(a[i], n[i]);
     uint64_t blt = ~FStar_UInt64_gte_mask(a[i], n[i]);
-    acc = (beq & acc) | (~beq & ((blt & (uint64_t)0xFFFFFFFFFFFFFFFFU) | (~blt & (uint64_t)0U)));
-  }
+    acc = (beq & acc) | (~beq & ((blt & (uint64_t)0xFFFFFFFFFFFFFFFFU) | (~blt & (uint64_t)0U))););
   uint64_t m2 = acc;
   uint64_t is_valid_m = (m00 & ~m10) & m2;
   uint32_t
@@ -1589,12 +1635,13 @@ Returns 2^64 - 1 if a < b, otherwise returns 0.
 uint64_t Hacl_Bignum256_lt_mask(uint64_t *a, uint64_t *b)
 {
   uint64_t acc = (uint64_t)0U;
-  for (uint32_t i = (uint32_t)0U; i < (uint32_t)4U; i++)
-  {
+  KRML_MAYBE_FOR4(i,
+    (uint32_t)0U,
+    (uint32_t)4U,
+    (uint32_t)1U,
     uint64_t beq = FStar_UInt64_eq_mask(a[i], b[i]);
     uint64_t blt = ~FStar_UInt64_gte_mask(a[i], b[i]);
-    acc = (beq & acc) | (~beq & ((blt & (uint64_t)0xFFFFFFFFFFFFFFFFU) | (~blt & (uint64_t)0U)));
-  }
+    acc = (beq & acc) | (~beq & ((blt & (uint64_t)0xFFFFFFFFFFFFFFFFU) | (~blt & (uint64_t)0U))););
   return acc;
 }
 
@@ -1606,11 +1653,12 @@ Returns 2^64 - 1 if a = b, otherwise returns 0.
 uint64_t Hacl_Bignum256_eq_mask(uint64_t *a, uint64_t *b)
 {
   uint64_t mask = (uint64_t)0xFFFFFFFFFFFFFFFFU;
-  for (uint32_t i = (uint32_t)0U; i < (uint32_t)4U; i++)
-  {
+  KRML_MAYBE_FOR4(i,
+    (uint32_t)0U,
+    (uint32_t)4U,
+    (uint32_t)1U,
     uint64_t uu____0 = FStar_UInt64_eq_mask(a[i], b[i]);
-    mask = uu____0 & mask;
-  }
+    mask = uu____0 & mask;);
   uint64_t mask1 = mask;
   return mask1;
 }

--- a/dist/gcc-compatible/Hacl_Bignum256.c
+++ b/dist/gcc-compatible/Hacl_Bignum256.c
@@ -59,34 +59,24 @@ Write `a + b mod 2^256` in `res`.
 uint64_t Hacl_Bignum256_add(uint64_t *a, uint64_t *b, uint64_t *res)
 {
   uint64_t c = (uint64_t)0U;
-  KRML_MAYBE_FOR1(i,
-    (uint32_t)0U,
-    (uint32_t)1U,
-    (uint32_t)1U,
-    uint64_t t1 = a[(uint32_t)4U * i];
-    uint64_t t20 = b[(uint32_t)4U * i];
-    uint64_t *res_i0 = res + (uint32_t)4U * i;
+  {
+    uint64_t t1 = a[(uint32_t)4U * (uint32_t)0U];
+    uint64_t t20 = b[(uint32_t)4U * (uint32_t)0U];
+    uint64_t *res_i0 = res + (uint32_t)4U * (uint32_t)0U;
     c = Lib_IntTypes_Intrinsics_add_carry_u64(c, t1, t20, res_i0);
-    uint64_t t10 = a[(uint32_t)4U * i + (uint32_t)1U];
-    uint64_t t21 = b[(uint32_t)4U * i + (uint32_t)1U];
-    uint64_t *res_i1 = res + (uint32_t)4U * i + (uint32_t)1U;
+    uint64_t t10 = a[(uint32_t)4U * (uint32_t)0U + (uint32_t)1U];
+    uint64_t t21 = b[(uint32_t)4U * (uint32_t)0U + (uint32_t)1U];
+    uint64_t *res_i1 = res + (uint32_t)4U * (uint32_t)0U + (uint32_t)1U;
     c = Lib_IntTypes_Intrinsics_add_carry_u64(c, t10, t21, res_i1);
-    uint64_t t11 = a[(uint32_t)4U * i + (uint32_t)2U];
-    uint64_t t22 = b[(uint32_t)4U * i + (uint32_t)2U];
-    uint64_t *res_i2 = res + (uint32_t)4U * i + (uint32_t)2U;
+    uint64_t t11 = a[(uint32_t)4U * (uint32_t)0U + (uint32_t)2U];
+    uint64_t t22 = b[(uint32_t)4U * (uint32_t)0U + (uint32_t)2U];
+    uint64_t *res_i2 = res + (uint32_t)4U * (uint32_t)0U + (uint32_t)2U;
     c = Lib_IntTypes_Intrinsics_add_carry_u64(c, t11, t22, res_i2);
-    uint64_t t12 = a[(uint32_t)4U * i + (uint32_t)3U];
-    uint64_t t2 = b[(uint32_t)4U * i + (uint32_t)3U];
-    uint64_t *res_i = res + (uint32_t)4U * i + (uint32_t)3U;
-    c = Lib_IntTypes_Intrinsics_add_carry_u64(c, t12, t2, res_i););
-  KRML_MAYBE_FOR0(i,
-    (uint32_t)4U,
-    (uint32_t)4U,
-    (uint32_t)1U,
-    uint64_t t1 = a[i];
-    uint64_t t2 = b[i];
-    uint64_t *res_i = res + i;
-    c = Lib_IntTypes_Intrinsics_add_carry_u64(c, t1, t2, res_i););
+    uint64_t t12 = a[(uint32_t)4U * (uint32_t)0U + (uint32_t)3U];
+    uint64_t t2 = b[(uint32_t)4U * (uint32_t)0U + (uint32_t)3U];
+    uint64_t *res_i = res + (uint32_t)4U * (uint32_t)0U + (uint32_t)3U;
+    c = Lib_IntTypes_Intrinsics_add_carry_u64(c, t12, t2, res_i);
+  }
   return c;
 }
 
@@ -100,34 +90,24 @@ Write `a - b mod 2^256` in `res`.
 uint64_t Hacl_Bignum256_sub(uint64_t *a, uint64_t *b, uint64_t *res)
 {
   uint64_t c = (uint64_t)0U;
-  KRML_MAYBE_FOR1(i,
-    (uint32_t)0U,
-    (uint32_t)1U,
-    (uint32_t)1U,
-    uint64_t t1 = a[(uint32_t)4U * i];
-    uint64_t t20 = b[(uint32_t)4U * i];
-    uint64_t *res_i0 = res + (uint32_t)4U * i;
+  {
+    uint64_t t1 = a[(uint32_t)4U * (uint32_t)0U];
+    uint64_t t20 = b[(uint32_t)4U * (uint32_t)0U];
+    uint64_t *res_i0 = res + (uint32_t)4U * (uint32_t)0U;
     c = Lib_IntTypes_Intrinsics_sub_borrow_u64(c, t1, t20, res_i0);
-    uint64_t t10 = a[(uint32_t)4U * i + (uint32_t)1U];
-    uint64_t t21 = b[(uint32_t)4U * i + (uint32_t)1U];
-    uint64_t *res_i1 = res + (uint32_t)4U * i + (uint32_t)1U;
+    uint64_t t10 = a[(uint32_t)4U * (uint32_t)0U + (uint32_t)1U];
+    uint64_t t21 = b[(uint32_t)4U * (uint32_t)0U + (uint32_t)1U];
+    uint64_t *res_i1 = res + (uint32_t)4U * (uint32_t)0U + (uint32_t)1U;
     c = Lib_IntTypes_Intrinsics_sub_borrow_u64(c, t10, t21, res_i1);
-    uint64_t t11 = a[(uint32_t)4U * i + (uint32_t)2U];
-    uint64_t t22 = b[(uint32_t)4U * i + (uint32_t)2U];
-    uint64_t *res_i2 = res + (uint32_t)4U * i + (uint32_t)2U;
+    uint64_t t11 = a[(uint32_t)4U * (uint32_t)0U + (uint32_t)2U];
+    uint64_t t22 = b[(uint32_t)4U * (uint32_t)0U + (uint32_t)2U];
+    uint64_t *res_i2 = res + (uint32_t)4U * (uint32_t)0U + (uint32_t)2U;
     c = Lib_IntTypes_Intrinsics_sub_borrow_u64(c, t11, t22, res_i2);
-    uint64_t t12 = a[(uint32_t)4U * i + (uint32_t)3U];
-    uint64_t t2 = b[(uint32_t)4U * i + (uint32_t)3U];
-    uint64_t *res_i = res + (uint32_t)4U * i + (uint32_t)3U;
-    c = Lib_IntTypes_Intrinsics_sub_borrow_u64(c, t12, t2, res_i););
-  KRML_MAYBE_FOR0(i,
-    (uint32_t)4U,
-    (uint32_t)4U,
-    (uint32_t)1U,
-    uint64_t t1 = a[i];
-    uint64_t t2 = b[i];
-    uint64_t *res_i = res + i;
-    c = Lib_IntTypes_Intrinsics_sub_borrow_u64(c, t1, t2, res_i););
+    uint64_t t12 = a[(uint32_t)4U * (uint32_t)0U + (uint32_t)3U];
+    uint64_t t2 = b[(uint32_t)4U * (uint32_t)0U + (uint32_t)3U];
+    uint64_t *res_i = res + (uint32_t)4U * (uint32_t)0U + (uint32_t)3U;
+    c = Lib_IntTypes_Intrinsics_sub_borrow_u64(c, t12, t2, res_i);
+  }
   return c;
 }
 
@@ -144,65 +124,45 @@ Write `(a + b) mod n` in `res`.
 void Hacl_Bignum256_add_mod(uint64_t *n, uint64_t *a, uint64_t *b, uint64_t *res)
 {
   uint64_t c0 = (uint64_t)0U;
-  KRML_MAYBE_FOR1(i,
-    (uint32_t)0U,
-    (uint32_t)1U,
-    (uint32_t)1U,
-    uint64_t t1 = a[(uint32_t)4U * i];
-    uint64_t t20 = b[(uint32_t)4U * i];
-    uint64_t *res_i0 = res + (uint32_t)4U * i;
+  {
+    uint64_t t1 = a[(uint32_t)4U * (uint32_t)0U];
+    uint64_t t20 = b[(uint32_t)4U * (uint32_t)0U];
+    uint64_t *res_i0 = res + (uint32_t)4U * (uint32_t)0U;
     c0 = Lib_IntTypes_Intrinsics_add_carry_u64(c0, t1, t20, res_i0);
-    uint64_t t10 = a[(uint32_t)4U * i + (uint32_t)1U];
-    uint64_t t21 = b[(uint32_t)4U * i + (uint32_t)1U];
-    uint64_t *res_i1 = res + (uint32_t)4U * i + (uint32_t)1U;
+    uint64_t t10 = a[(uint32_t)4U * (uint32_t)0U + (uint32_t)1U];
+    uint64_t t21 = b[(uint32_t)4U * (uint32_t)0U + (uint32_t)1U];
+    uint64_t *res_i1 = res + (uint32_t)4U * (uint32_t)0U + (uint32_t)1U;
     c0 = Lib_IntTypes_Intrinsics_add_carry_u64(c0, t10, t21, res_i1);
-    uint64_t t11 = a[(uint32_t)4U * i + (uint32_t)2U];
-    uint64_t t22 = b[(uint32_t)4U * i + (uint32_t)2U];
-    uint64_t *res_i2 = res + (uint32_t)4U * i + (uint32_t)2U;
+    uint64_t t11 = a[(uint32_t)4U * (uint32_t)0U + (uint32_t)2U];
+    uint64_t t22 = b[(uint32_t)4U * (uint32_t)0U + (uint32_t)2U];
+    uint64_t *res_i2 = res + (uint32_t)4U * (uint32_t)0U + (uint32_t)2U;
     c0 = Lib_IntTypes_Intrinsics_add_carry_u64(c0, t11, t22, res_i2);
-    uint64_t t12 = a[(uint32_t)4U * i + (uint32_t)3U];
-    uint64_t t2 = b[(uint32_t)4U * i + (uint32_t)3U];
-    uint64_t *res_i = res + (uint32_t)4U * i + (uint32_t)3U;
-    c0 = Lib_IntTypes_Intrinsics_add_carry_u64(c0, t12, t2, res_i););
-  KRML_MAYBE_FOR0(i,
-    (uint32_t)4U,
-    (uint32_t)4U,
-    (uint32_t)1U,
-    uint64_t t1 = a[i];
-    uint64_t t2 = b[i];
-    uint64_t *res_i = res + i;
-    c0 = Lib_IntTypes_Intrinsics_add_carry_u64(c0, t1, t2, res_i););
+    uint64_t t12 = a[(uint32_t)4U * (uint32_t)0U + (uint32_t)3U];
+    uint64_t t2 = b[(uint32_t)4U * (uint32_t)0U + (uint32_t)3U];
+    uint64_t *res_i = res + (uint32_t)4U * (uint32_t)0U + (uint32_t)3U;
+    c0 = Lib_IntTypes_Intrinsics_add_carry_u64(c0, t12, t2, res_i);
+  }
   uint64_t c00 = c0;
   uint64_t tmp[4U] = { 0U };
   uint64_t c = (uint64_t)0U;
-  KRML_MAYBE_FOR1(i,
-    (uint32_t)0U,
-    (uint32_t)1U,
-    (uint32_t)1U,
-    uint64_t t1 = res[(uint32_t)4U * i];
-    uint64_t t20 = n[(uint32_t)4U * i];
-    uint64_t *res_i0 = tmp + (uint32_t)4U * i;
+  {
+    uint64_t t1 = res[(uint32_t)4U * (uint32_t)0U];
+    uint64_t t20 = n[(uint32_t)4U * (uint32_t)0U];
+    uint64_t *res_i0 = tmp + (uint32_t)4U * (uint32_t)0U;
     c = Lib_IntTypes_Intrinsics_sub_borrow_u64(c, t1, t20, res_i0);
-    uint64_t t10 = res[(uint32_t)4U * i + (uint32_t)1U];
-    uint64_t t21 = n[(uint32_t)4U * i + (uint32_t)1U];
-    uint64_t *res_i1 = tmp + (uint32_t)4U * i + (uint32_t)1U;
+    uint64_t t10 = res[(uint32_t)4U * (uint32_t)0U + (uint32_t)1U];
+    uint64_t t21 = n[(uint32_t)4U * (uint32_t)0U + (uint32_t)1U];
+    uint64_t *res_i1 = tmp + (uint32_t)4U * (uint32_t)0U + (uint32_t)1U;
     c = Lib_IntTypes_Intrinsics_sub_borrow_u64(c, t10, t21, res_i1);
-    uint64_t t11 = res[(uint32_t)4U * i + (uint32_t)2U];
-    uint64_t t22 = n[(uint32_t)4U * i + (uint32_t)2U];
-    uint64_t *res_i2 = tmp + (uint32_t)4U * i + (uint32_t)2U;
+    uint64_t t11 = res[(uint32_t)4U * (uint32_t)0U + (uint32_t)2U];
+    uint64_t t22 = n[(uint32_t)4U * (uint32_t)0U + (uint32_t)2U];
+    uint64_t *res_i2 = tmp + (uint32_t)4U * (uint32_t)0U + (uint32_t)2U;
     c = Lib_IntTypes_Intrinsics_sub_borrow_u64(c, t11, t22, res_i2);
-    uint64_t t12 = res[(uint32_t)4U * i + (uint32_t)3U];
-    uint64_t t2 = n[(uint32_t)4U * i + (uint32_t)3U];
-    uint64_t *res_i = tmp + (uint32_t)4U * i + (uint32_t)3U;
-    c = Lib_IntTypes_Intrinsics_sub_borrow_u64(c, t12, t2, res_i););
-  KRML_MAYBE_FOR0(i,
-    (uint32_t)4U,
-    (uint32_t)4U,
-    (uint32_t)1U,
-    uint64_t t1 = res[i];
-    uint64_t t2 = n[i];
-    uint64_t *res_i = tmp + i;
-    c = Lib_IntTypes_Intrinsics_sub_borrow_u64(c, t1, t2, res_i););
+    uint64_t t12 = res[(uint32_t)4U * (uint32_t)0U + (uint32_t)3U];
+    uint64_t t2 = n[(uint32_t)4U * (uint32_t)0U + (uint32_t)3U];
+    uint64_t *res_i = tmp + (uint32_t)4U * (uint32_t)0U + (uint32_t)3U;
+    c = Lib_IntTypes_Intrinsics_sub_borrow_u64(c, t12, t2, res_i);
+  }
   uint64_t c1 = c;
   uint64_t c2 = c00 - c1;
   KRML_MAYBE_FOR4(i,
@@ -227,65 +187,45 @@ Write `(a - b) mod n` in `res`.
 void Hacl_Bignum256_sub_mod(uint64_t *n, uint64_t *a, uint64_t *b, uint64_t *res)
 {
   uint64_t c0 = (uint64_t)0U;
-  KRML_MAYBE_FOR1(i,
-    (uint32_t)0U,
-    (uint32_t)1U,
-    (uint32_t)1U,
-    uint64_t t1 = a[(uint32_t)4U * i];
-    uint64_t t20 = b[(uint32_t)4U * i];
-    uint64_t *res_i0 = res + (uint32_t)4U * i;
+  {
+    uint64_t t1 = a[(uint32_t)4U * (uint32_t)0U];
+    uint64_t t20 = b[(uint32_t)4U * (uint32_t)0U];
+    uint64_t *res_i0 = res + (uint32_t)4U * (uint32_t)0U;
     c0 = Lib_IntTypes_Intrinsics_sub_borrow_u64(c0, t1, t20, res_i0);
-    uint64_t t10 = a[(uint32_t)4U * i + (uint32_t)1U];
-    uint64_t t21 = b[(uint32_t)4U * i + (uint32_t)1U];
-    uint64_t *res_i1 = res + (uint32_t)4U * i + (uint32_t)1U;
+    uint64_t t10 = a[(uint32_t)4U * (uint32_t)0U + (uint32_t)1U];
+    uint64_t t21 = b[(uint32_t)4U * (uint32_t)0U + (uint32_t)1U];
+    uint64_t *res_i1 = res + (uint32_t)4U * (uint32_t)0U + (uint32_t)1U;
     c0 = Lib_IntTypes_Intrinsics_sub_borrow_u64(c0, t10, t21, res_i1);
-    uint64_t t11 = a[(uint32_t)4U * i + (uint32_t)2U];
-    uint64_t t22 = b[(uint32_t)4U * i + (uint32_t)2U];
-    uint64_t *res_i2 = res + (uint32_t)4U * i + (uint32_t)2U;
+    uint64_t t11 = a[(uint32_t)4U * (uint32_t)0U + (uint32_t)2U];
+    uint64_t t22 = b[(uint32_t)4U * (uint32_t)0U + (uint32_t)2U];
+    uint64_t *res_i2 = res + (uint32_t)4U * (uint32_t)0U + (uint32_t)2U;
     c0 = Lib_IntTypes_Intrinsics_sub_borrow_u64(c0, t11, t22, res_i2);
-    uint64_t t12 = a[(uint32_t)4U * i + (uint32_t)3U];
-    uint64_t t2 = b[(uint32_t)4U * i + (uint32_t)3U];
-    uint64_t *res_i = res + (uint32_t)4U * i + (uint32_t)3U;
-    c0 = Lib_IntTypes_Intrinsics_sub_borrow_u64(c0, t12, t2, res_i););
-  KRML_MAYBE_FOR0(i,
-    (uint32_t)4U,
-    (uint32_t)4U,
-    (uint32_t)1U,
-    uint64_t t1 = a[i];
-    uint64_t t2 = b[i];
-    uint64_t *res_i = res + i;
-    c0 = Lib_IntTypes_Intrinsics_sub_borrow_u64(c0, t1, t2, res_i););
+    uint64_t t12 = a[(uint32_t)4U * (uint32_t)0U + (uint32_t)3U];
+    uint64_t t2 = b[(uint32_t)4U * (uint32_t)0U + (uint32_t)3U];
+    uint64_t *res_i = res + (uint32_t)4U * (uint32_t)0U + (uint32_t)3U;
+    c0 = Lib_IntTypes_Intrinsics_sub_borrow_u64(c0, t12, t2, res_i);
+  }
   uint64_t c00 = c0;
   uint64_t tmp[4U] = { 0U };
   uint64_t c = (uint64_t)0U;
-  KRML_MAYBE_FOR1(i,
-    (uint32_t)0U,
-    (uint32_t)1U,
-    (uint32_t)1U,
-    uint64_t t1 = res[(uint32_t)4U * i];
-    uint64_t t20 = n[(uint32_t)4U * i];
-    uint64_t *res_i0 = tmp + (uint32_t)4U * i;
+  {
+    uint64_t t1 = res[(uint32_t)4U * (uint32_t)0U];
+    uint64_t t20 = n[(uint32_t)4U * (uint32_t)0U];
+    uint64_t *res_i0 = tmp + (uint32_t)4U * (uint32_t)0U;
     c = Lib_IntTypes_Intrinsics_add_carry_u64(c, t1, t20, res_i0);
-    uint64_t t10 = res[(uint32_t)4U * i + (uint32_t)1U];
-    uint64_t t21 = n[(uint32_t)4U * i + (uint32_t)1U];
-    uint64_t *res_i1 = tmp + (uint32_t)4U * i + (uint32_t)1U;
+    uint64_t t10 = res[(uint32_t)4U * (uint32_t)0U + (uint32_t)1U];
+    uint64_t t21 = n[(uint32_t)4U * (uint32_t)0U + (uint32_t)1U];
+    uint64_t *res_i1 = tmp + (uint32_t)4U * (uint32_t)0U + (uint32_t)1U;
     c = Lib_IntTypes_Intrinsics_add_carry_u64(c, t10, t21, res_i1);
-    uint64_t t11 = res[(uint32_t)4U * i + (uint32_t)2U];
-    uint64_t t22 = n[(uint32_t)4U * i + (uint32_t)2U];
-    uint64_t *res_i2 = tmp + (uint32_t)4U * i + (uint32_t)2U;
+    uint64_t t11 = res[(uint32_t)4U * (uint32_t)0U + (uint32_t)2U];
+    uint64_t t22 = n[(uint32_t)4U * (uint32_t)0U + (uint32_t)2U];
+    uint64_t *res_i2 = tmp + (uint32_t)4U * (uint32_t)0U + (uint32_t)2U;
     c = Lib_IntTypes_Intrinsics_add_carry_u64(c, t11, t22, res_i2);
-    uint64_t t12 = res[(uint32_t)4U * i + (uint32_t)3U];
-    uint64_t t2 = n[(uint32_t)4U * i + (uint32_t)3U];
-    uint64_t *res_i = tmp + (uint32_t)4U * i + (uint32_t)3U;
-    c = Lib_IntTypes_Intrinsics_add_carry_u64(c, t12, t2, res_i););
-  KRML_MAYBE_FOR0(i,
-    (uint32_t)4U,
-    (uint32_t)4U,
-    (uint32_t)1U,
-    uint64_t t1 = res[i];
-    uint64_t t2 = n[i];
-    uint64_t *res_i = tmp + i;
-    c = Lib_IntTypes_Intrinsics_add_carry_u64(c, t1, t2, res_i););
+    uint64_t t12 = res[(uint32_t)4U * (uint32_t)0U + (uint32_t)3U];
+    uint64_t t2 = n[(uint32_t)4U * (uint32_t)0U + (uint32_t)3U];
+    uint64_t *res_i = tmp + (uint32_t)4U * (uint32_t)0U + (uint32_t)3U;
+    c = Lib_IntTypes_Intrinsics_add_carry_u64(c, t12, t2, res_i);
+  }
   uint64_t c1 = c;
   uint64_t c2 = (uint64_t)0U - c00;
   KRML_MAYBE_FOR4(i,
@@ -313,29 +253,20 @@ void Hacl_Bignum256_mul(uint64_t *a, uint64_t *b, uint64_t *res)
     uint64_t bj = b[i0];
     uint64_t *res_j = res + i0;
     uint64_t c = (uint64_t)0U;
-    KRML_MAYBE_FOR1(i,
-      (uint32_t)0U,
-      (uint32_t)1U,
-      (uint32_t)1U,
-      uint64_t a_i = a[(uint32_t)4U * i];
-      uint64_t *res_i0 = res_j + (uint32_t)4U * i;
+    {
+      uint64_t a_i = a[(uint32_t)4U * (uint32_t)0U];
+      uint64_t *res_i0 = res_j + (uint32_t)4U * (uint32_t)0U;
       c = Hacl_Bignum_Base_mul_wide_add2_u64(a_i, bj, c, res_i0);
-      uint64_t a_i0 = a[(uint32_t)4U * i + (uint32_t)1U];
-      uint64_t *res_i1 = res_j + (uint32_t)4U * i + (uint32_t)1U;
+      uint64_t a_i0 = a[(uint32_t)4U * (uint32_t)0U + (uint32_t)1U];
+      uint64_t *res_i1 = res_j + (uint32_t)4U * (uint32_t)0U + (uint32_t)1U;
       c = Hacl_Bignum_Base_mul_wide_add2_u64(a_i0, bj, c, res_i1);
-      uint64_t a_i1 = a[(uint32_t)4U * i + (uint32_t)2U];
-      uint64_t *res_i2 = res_j + (uint32_t)4U * i + (uint32_t)2U;
+      uint64_t a_i1 = a[(uint32_t)4U * (uint32_t)0U + (uint32_t)2U];
+      uint64_t *res_i2 = res_j + (uint32_t)4U * (uint32_t)0U + (uint32_t)2U;
       c = Hacl_Bignum_Base_mul_wide_add2_u64(a_i1, bj, c, res_i2);
-      uint64_t a_i2 = a[(uint32_t)4U * i + (uint32_t)3U];
-      uint64_t *res_i = res_j + (uint32_t)4U * i + (uint32_t)3U;
-      c = Hacl_Bignum_Base_mul_wide_add2_u64(a_i2, bj, c, res_i););
-    KRML_MAYBE_FOR0(i,
-      (uint32_t)4U,
-      (uint32_t)4U,
-      (uint32_t)1U,
-      uint64_t a_i = a[i];
-      uint64_t *res_i = res_j + i;
-      c = Hacl_Bignum_Base_mul_wide_add2_u64(a_i, bj, c, res_i););
+      uint64_t a_i2 = a[(uint32_t)4U * (uint32_t)0U + (uint32_t)3U];
+      uint64_t *res_i = res_j + (uint32_t)4U * (uint32_t)0U + (uint32_t)3U;
+      c = Hacl_Bignum_Base_mul_wide_add2_u64(a_i2, bj, c, res_i);
+    }
     uint64_t r = c;
     res[(uint32_t)4U + i0] = r;);
 }
@@ -416,29 +347,20 @@ static inline void reduction(uint64_t *n, uint64_t nInv, uint64_t *c, uint64_t *
     uint64_t qj = nInv * c[i0];
     uint64_t *res_j0 = c + i0;
     uint64_t c1 = (uint64_t)0U;
-    KRML_MAYBE_FOR1(i,
-      (uint32_t)0U,
-      (uint32_t)1U,
-      (uint32_t)1U,
-      uint64_t a_i = n[(uint32_t)4U * i];
-      uint64_t *res_i0 = res_j0 + (uint32_t)4U * i;
+    {
+      uint64_t a_i = n[(uint32_t)4U * (uint32_t)0U];
+      uint64_t *res_i0 = res_j0 + (uint32_t)4U * (uint32_t)0U;
       c1 = Hacl_Bignum_Base_mul_wide_add2_u64(a_i, qj, c1, res_i0);
-      uint64_t a_i0 = n[(uint32_t)4U * i + (uint32_t)1U];
-      uint64_t *res_i1 = res_j0 + (uint32_t)4U * i + (uint32_t)1U;
+      uint64_t a_i0 = n[(uint32_t)4U * (uint32_t)0U + (uint32_t)1U];
+      uint64_t *res_i1 = res_j0 + (uint32_t)4U * (uint32_t)0U + (uint32_t)1U;
       c1 = Hacl_Bignum_Base_mul_wide_add2_u64(a_i0, qj, c1, res_i1);
-      uint64_t a_i1 = n[(uint32_t)4U * i + (uint32_t)2U];
-      uint64_t *res_i2 = res_j0 + (uint32_t)4U * i + (uint32_t)2U;
+      uint64_t a_i1 = n[(uint32_t)4U * (uint32_t)0U + (uint32_t)2U];
+      uint64_t *res_i2 = res_j0 + (uint32_t)4U * (uint32_t)0U + (uint32_t)2U;
       c1 = Hacl_Bignum_Base_mul_wide_add2_u64(a_i1, qj, c1, res_i2);
-      uint64_t a_i2 = n[(uint32_t)4U * i + (uint32_t)3U];
-      uint64_t *res_i = res_j0 + (uint32_t)4U * i + (uint32_t)3U;
-      c1 = Hacl_Bignum_Base_mul_wide_add2_u64(a_i2, qj, c1, res_i););
-    KRML_MAYBE_FOR0(i,
-      (uint32_t)4U,
-      (uint32_t)4U,
-      (uint32_t)1U,
-      uint64_t a_i = n[i];
-      uint64_t *res_i = res_j0 + i;
-      c1 = Hacl_Bignum_Base_mul_wide_add2_u64(a_i, qj, c1, res_i););
+      uint64_t a_i2 = n[(uint32_t)4U * (uint32_t)0U + (uint32_t)3U];
+      uint64_t *res_i = res_j0 + (uint32_t)4U * (uint32_t)0U + (uint32_t)3U;
+      c1 = Hacl_Bignum_Base_mul_wide_add2_u64(a_i2, qj, c1, res_i);
+    }
     uint64_t r = c1;
     uint64_t c10 = r;
     uint64_t *resb = c + (uint32_t)4U + i0;
@@ -448,34 +370,24 @@ static inline void reduction(uint64_t *n, uint64_t nInv, uint64_t *c, uint64_t *
   uint64_t c00 = c0;
   uint64_t tmp[4U] = { 0U };
   uint64_t c1 = (uint64_t)0U;
-  KRML_MAYBE_FOR1(i,
-    (uint32_t)0U,
-    (uint32_t)1U,
-    (uint32_t)1U,
-    uint64_t t1 = res[(uint32_t)4U * i];
-    uint64_t t20 = n[(uint32_t)4U * i];
-    uint64_t *res_i0 = tmp + (uint32_t)4U * i;
+  {
+    uint64_t t1 = res[(uint32_t)4U * (uint32_t)0U];
+    uint64_t t20 = n[(uint32_t)4U * (uint32_t)0U];
+    uint64_t *res_i0 = tmp + (uint32_t)4U * (uint32_t)0U;
     c1 = Lib_IntTypes_Intrinsics_sub_borrow_u64(c1, t1, t20, res_i0);
-    uint64_t t10 = res[(uint32_t)4U * i + (uint32_t)1U];
-    uint64_t t21 = n[(uint32_t)4U * i + (uint32_t)1U];
-    uint64_t *res_i1 = tmp + (uint32_t)4U * i + (uint32_t)1U;
+    uint64_t t10 = res[(uint32_t)4U * (uint32_t)0U + (uint32_t)1U];
+    uint64_t t21 = n[(uint32_t)4U * (uint32_t)0U + (uint32_t)1U];
+    uint64_t *res_i1 = tmp + (uint32_t)4U * (uint32_t)0U + (uint32_t)1U;
     c1 = Lib_IntTypes_Intrinsics_sub_borrow_u64(c1, t10, t21, res_i1);
-    uint64_t t11 = res[(uint32_t)4U * i + (uint32_t)2U];
-    uint64_t t22 = n[(uint32_t)4U * i + (uint32_t)2U];
-    uint64_t *res_i2 = tmp + (uint32_t)4U * i + (uint32_t)2U;
+    uint64_t t11 = res[(uint32_t)4U * (uint32_t)0U + (uint32_t)2U];
+    uint64_t t22 = n[(uint32_t)4U * (uint32_t)0U + (uint32_t)2U];
+    uint64_t *res_i2 = tmp + (uint32_t)4U * (uint32_t)0U + (uint32_t)2U;
     c1 = Lib_IntTypes_Intrinsics_sub_borrow_u64(c1, t11, t22, res_i2);
-    uint64_t t12 = res[(uint32_t)4U * i + (uint32_t)3U];
-    uint64_t t2 = n[(uint32_t)4U * i + (uint32_t)3U];
-    uint64_t *res_i = tmp + (uint32_t)4U * i + (uint32_t)3U;
-    c1 = Lib_IntTypes_Intrinsics_sub_borrow_u64(c1, t12, t2, res_i););
-  KRML_MAYBE_FOR0(i,
-    (uint32_t)4U,
-    (uint32_t)4U,
-    (uint32_t)1U,
-    uint64_t t1 = res[i];
-    uint64_t t2 = n[i];
-    uint64_t *res_i = tmp + i;
-    c1 = Lib_IntTypes_Intrinsics_sub_borrow_u64(c1, t1, t2, res_i););
+    uint64_t t12 = res[(uint32_t)4U * (uint32_t)0U + (uint32_t)3U];
+    uint64_t t2 = n[(uint32_t)4U * (uint32_t)0U + (uint32_t)3U];
+    uint64_t *res_i = tmp + (uint32_t)4U * (uint32_t)0U + (uint32_t)3U;
+    c1 = Lib_IntTypes_Intrinsics_sub_borrow_u64(c1, t12, t2, res_i);
+  }
   uint64_t c10 = c1;
   uint64_t c2 = c00 - c10;
   KRML_MAYBE_FOR4(i,
@@ -497,29 +409,20 @@ static inline void areduction(uint64_t *n, uint64_t nInv, uint64_t *c, uint64_t 
     uint64_t qj = nInv * c[i0];
     uint64_t *res_j0 = c + i0;
     uint64_t c1 = (uint64_t)0U;
-    KRML_MAYBE_FOR1(i,
-      (uint32_t)0U,
-      (uint32_t)1U,
-      (uint32_t)1U,
-      uint64_t a_i = n[(uint32_t)4U * i];
-      uint64_t *res_i0 = res_j0 + (uint32_t)4U * i;
+    {
+      uint64_t a_i = n[(uint32_t)4U * (uint32_t)0U];
+      uint64_t *res_i0 = res_j0 + (uint32_t)4U * (uint32_t)0U;
       c1 = Hacl_Bignum_Base_mul_wide_add2_u64(a_i, qj, c1, res_i0);
-      uint64_t a_i0 = n[(uint32_t)4U * i + (uint32_t)1U];
-      uint64_t *res_i1 = res_j0 + (uint32_t)4U * i + (uint32_t)1U;
+      uint64_t a_i0 = n[(uint32_t)4U * (uint32_t)0U + (uint32_t)1U];
+      uint64_t *res_i1 = res_j0 + (uint32_t)4U * (uint32_t)0U + (uint32_t)1U;
       c1 = Hacl_Bignum_Base_mul_wide_add2_u64(a_i0, qj, c1, res_i1);
-      uint64_t a_i1 = n[(uint32_t)4U * i + (uint32_t)2U];
-      uint64_t *res_i2 = res_j0 + (uint32_t)4U * i + (uint32_t)2U;
+      uint64_t a_i1 = n[(uint32_t)4U * (uint32_t)0U + (uint32_t)2U];
+      uint64_t *res_i2 = res_j0 + (uint32_t)4U * (uint32_t)0U + (uint32_t)2U;
       c1 = Hacl_Bignum_Base_mul_wide_add2_u64(a_i1, qj, c1, res_i2);
-      uint64_t a_i2 = n[(uint32_t)4U * i + (uint32_t)3U];
-      uint64_t *res_i = res_j0 + (uint32_t)4U * i + (uint32_t)3U;
-      c1 = Hacl_Bignum_Base_mul_wide_add2_u64(a_i2, qj, c1, res_i););
-    KRML_MAYBE_FOR0(i,
-      (uint32_t)4U,
-      (uint32_t)4U,
-      (uint32_t)1U,
-      uint64_t a_i = n[i];
-      uint64_t *res_i = res_j0 + i;
-      c1 = Hacl_Bignum_Base_mul_wide_add2_u64(a_i, qj, c1, res_i););
+      uint64_t a_i2 = n[(uint32_t)4U * (uint32_t)0U + (uint32_t)3U];
+      uint64_t *res_i = res_j0 + (uint32_t)4U * (uint32_t)0U + (uint32_t)3U;
+      c1 = Hacl_Bignum_Base_mul_wide_add2_u64(a_i2, qj, c1, res_i);
+    }
     uint64_t r = c1;
     uint64_t c10 = r;
     uint64_t *resb = c + (uint32_t)4U + i0;
@@ -551,29 +454,20 @@ amont_mul(uint64_t *n, uint64_t nInv_u64, uint64_t *aM, uint64_t *bM, uint64_t *
     uint64_t bj = bM[i0];
     uint64_t *res_j = c + i0;
     uint64_t c1 = (uint64_t)0U;
-    KRML_MAYBE_FOR1(i,
-      (uint32_t)0U,
-      (uint32_t)1U,
-      (uint32_t)1U,
-      uint64_t a_i = aM[(uint32_t)4U * i];
-      uint64_t *res_i0 = res_j + (uint32_t)4U * i;
+    {
+      uint64_t a_i = aM[(uint32_t)4U * (uint32_t)0U];
+      uint64_t *res_i0 = res_j + (uint32_t)4U * (uint32_t)0U;
       c1 = Hacl_Bignum_Base_mul_wide_add2_u64(a_i, bj, c1, res_i0);
-      uint64_t a_i0 = aM[(uint32_t)4U * i + (uint32_t)1U];
-      uint64_t *res_i1 = res_j + (uint32_t)4U * i + (uint32_t)1U;
+      uint64_t a_i0 = aM[(uint32_t)4U * (uint32_t)0U + (uint32_t)1U];
+      uint64_t *res_i1 = res_j + (uint32_t)4U * (uint32_t)0U + (uint32_t)1U;
       c1 = Hacl_Bignum_Base_mul_wide_add2_u64(a_i0, bj, c1, res_i1);
-      uint64_t a_i1 = aM[(uint32_t)4U * i + (uint32_t)2U];
-      uint64_t *res_i2 = res_j + (uint32_t)4U * i + (uint32_t)2U;
+      uint64_t a_i1 = aM[(uint32_t)4U * (uint32_t)0U + (uint32_t)2U];
+      uint64_t *res_i2 = res_j + (uint32_t)4U * (uint32_t)0U + (uint32_t)2U;
       c1 = Hacl_Bignum_Base_mul_wide_add2_u64(a_i1, bj, c1, res_i2);
-      uint64_t a_i2 = aM[(uint32_t)4U * i + (uint32_t)3U];
-      uint64_t *res_i = res_j + (uint32_t)4U * i + (uint32_t)3U;
-      c1 = Hacl_Bignum_Base_mul_wide_add2_u64(a_i2, bj, c1, res_i););
-    KRML_MAYBE_FOR0(i,
-      (uint32_t)4U,
-      (uint32_t)4U,
-      (uint32_t)1U,
-      uint64_t a_i = aM[i];
-      uint64_t *res_i = res_j + i;
-      c1 = Hacl_Bignum_Base_mul_wide_add2_u64(a_i, bj, c1, res_i););
+      uint64_t a_i2 = aM[(uint32_t)4U * (uint32_t)0U + (uint32_t)3U];
+      uint64_t *res_i = res_j + (uint32_t)4U * (uint32_t)0U + (uint32_t)3U;
+      c1 = Hacl_Bignum_Base_mul_wide_add2_u64(a_i2, bj, c1, res_i);
+    }
     uint64_t r = c1;
     c[(uint32_t)4U + i0] = r;);
   areduction(n, nInv_u64, c, resM);
@@ -643,29 +537,20 @@ bn_slow_precomp(uint64_t *n, uint64_t mu, uint64_t *r2, uint64_t *a, uint64_t *r
     uint64_t qj = mu * a1[i0];
     uint64_t *res_j0 = a1 + i0;
     uint64_t c = (uint64_t)0U;
-    KRML_MAYBE_FOR1(i,
-      (uint32_t)0U,
-      (uint32_t)1U,
-      (uint32_t)1U,
-      uint64_t a_i = n[(uint32_t)4U * i];
-      uint64_t *res_i0 = res_j0 + (uint32_t)4U * i;
+    {
+      uint64_t a_i = n[(uint32_t)4U * (uint32_t)0U];
+      uint64_t *res_i0 = res_j0 + (uint32_t)4U * (uint32_t)0U;
       c = Hacl_Bignum_Base_mul_wide_add2_u64(a_i, qj, c, res_i0);
-      uint64_t a_i0 = n[(uint32_t)4U * i + (uint32_t)1U];
-      uint64_t *res_i1 = res_j0 + (uint32_t)4U * i + (uint32_t)1U;
+      uint64_t a_i0 = n[(uint32_t)4U * (uint32_t)0U + (uint32_t)1U];
+      uint64_t *res_i1 = res_j0 + (uint32_t)4U * (uint32_t)0U + (uint32_t)1U;
       c = Hacl_Bignum_Base_mul_wide_add2_u64(a_i0, qj, c, res_i1);
-      uint64_t a_i1 = n[(uint32_t)4U * i + (uint32_t)2U];
-      uint64_t *res_i2 = res_j0 + (uint32_t)4U * i + (uint32_t)2U;
+      uint64_t a_i1 = n[(uint32_t)4U * (uint32_t)0U + (uint32_t)2U];
+      uint64_t *res_i2 = res_j0 + (uint32_t)4U * (uint32_t)0U + (uint32_t)2U;
       c = Hacl_Bignum_Base_mul_wide_add2_u64(a_i1, qj, c, res_i2);
-      uint64_t a_i2 = n[(uint32_t)4U * i + (uint32_t)3U];
-      uint64_t *res_i = res_j0 + (uint32_t)4U * i + (uint32_t)3U;
-      c = Hacl_Bignum_Base_mul_wide_add2_u64(a_i2, qj, c, res_i););
-    KRML_MAYBE_FOR0(i,
-      (uint32_t)4U,
-      (uint32_t)4U,
-      (uint32_t)1U,
-      uint64_t a_i = n[i];
-      uint64_t *res_i = res_j0 + i;
-      c = Hacl_Bignum_Base_mul_wide_add2_u64(a_i, qj, c, res_i););
+      uint64_t a_i2 = n[(uint32_t)4U * (uint32_t)0U + (uint32_t)3U];
+      uint64_t *res_i = res_j0 + (uint32_t)4U * (uint32_t)0U + (uint32_t)3U;
+      c = Hacl_Bignum_Base_mul_wide_add2_u64(a_i2, qj, c, res_i);
+    }
     uint64_t r = c;
     uint64_t c1 = r;
     uint64_t *resb = a1 + (uint32_t)4U + i0;

--- a/dist/gcc-compatible/Hacl_Bignum256_32.c
+++ b/dist/gcc-compatible/Hacl_Bignum256_32.c
@@ -79,14 +79,6 @@ uint32_t Hacl_Bignum256_32_add(uint32_t *a, uint32_t *b, uint32_t *res)
     uint32_t t2 = b[(uint32_t)4U * i + (uint32_t)3U];
     uint32_t *res_i = res + (uint32_t)4U * i + (uint32_t)3U;
     c = Lib_IntTypes_Intrinsics_add_carry_u32(c, t12, t2, res_i););
-  KRML_MAYBE_FOR0(i,
-    (uint32_t)8U,
-    (uint32_t)8U,
-    (uint32_t)1U,
-    uint32_t t1 = a[i];
-    uint32_t t2 = b[i];
-    uint32_t *res_i = res + i;
-    c = Lib_IntTypes_Intrinsics_add_carry_u32(c, t1, t2, res_i););
   return c;
 }
 
@@ -120,14 +112,6 @@ uint32_t Hacl_Bignum256_32_sub(uint32_t *a, uint32_t *b, uint32_t *res)
     uint32_t t2 = b[(uint32_t)4U * i + (uint32_t)3U];
     uint32_t *res_i = res + (uint32_t)4U * i + (uint32_t)3U;
     c = Lib_IntTypes_Intrinsics_sub_borrow_u32(c, t12, t2, res_i););
-  KRML_MAYBE_FOR0(i,
-    (uint32_t)8U,
-    (uint32_t)8U,
-    (uint32_t)1U,
-    uint32_t t1 = a[i];
-    uint32_t t2 = b[i];
-    uint32_t *res_i = res + i;
-    c = Lib_IntTypes_Intrinsics_sub_borrow_u32(c, t1, t2, res_i););
   return c;
 }
 
@@ -164,14 +148,6 @@ void Hacl_Bignum256_32_add_mod(uint32_t *n, uint32_t *a, uint32_t *b, uint32_t *
     uint32_t t2 = b[(uint32_t)4U * i + (uint32_t)3U];
     uint32_t *res_i = res + (uint32_t)4U * i + (uint32_t)3U;
     c0 = Lib_IntTypes_Intrinsics_add_carry_u32(c0, t12, t2, res_i););
-  KRML_MAYBE_FOR0(i,
-    (uint32_t)8U,
-    (uint32_t)8U,
-    (uint32_t)1U,
-    uint32_t t1 = a[i];
-    uint32_t t2 = b[i];
-    uint32_t *res_i = res + i;
-    c0 = Lib_IntTypes_Intrinsics_add_carry_u32(c0, t1, t2, res_i););
   uint32_t c00 = c0;
   uint32_t tmp[8U] = { 0U };
   uint32_t c = (uint32_t)0U;
@@ -195,14 +171,6 @@ void Hacl_Bignum256_32_add_mod(uint32_t *n, uint32_t *a, uint32_t *b, uint32_t *
     uint32_t t2 = n[(uint32_t)4U * i + (uint32_t)3U];
     uint32_t *res_i = tmp + (uint32_t)4U * i + (uint32_t)3U;
     c = Lib_IntTypes_Intrinsics_sub_borrow_u32(c, t12, t2, res_i););
-  KRML_MAYBE_FOR0(i,
-    (uint32_t)8U,
-    (uint32_t)8U,
-    (uint32_t)1U,
-    uint32_t t1 = res[i];
-    uint32_t t2 = n[i];
-    uint32_t *res_i = tmp + i;
-    c = Lib_IntTypes_Intrinsics_sub_borrow_u32(c, t1, t2, res_i););
   uint32_t c1 = c;
   uint32_t c2 = c00 - c1;
   KRML_MAYBE_FOR8(i,
@@ -247,14 +215,6 @@ void Hacl_Bignum256_32_sub_mod(uint32_t *n, uint32_t *a, uint32_t *b, uint32_t *
     uint32_t t2 = b[(uint32_t)4U * i + (uint32_t)3U];
     uint32_t *res_i = res + (uint32_t)4U * i + (uint32_t)3U;
     c0 = Lib_IntTypes_Intrinsics_sub_borrow_u32(c0, t12, t2, res_i););
-  KRML_MAYBE_FOR0(i,
-    (uint32_t)8U,
-    (uint32_t)8U,
-    (uint32_t)1U,
-    uint32_t t1 = a[i];
-    uint32_t t2 = b[i];
-    uint32_t *res_i = res + i;
-    c0 = Lib_IntTypes_Intrinsics_sub_borrow_u32(c0, t1, t2, res_i););
   uint32_t c00 = c0;
   uint32_t tmp[8U] = { 0U };
   uint32_t c = (uint32_t)0U;
@@ -278,14 +238,6 @@ void Hacl_Bignum256_32_sub_mod(uint32_t *n, uint32_t *a, uint32_t *b, uint32_t *
     uint32_t t2 = n[(uint32_t)4U * i + (uint32_t)3U];
     uint32_t *res_i = tmp + (uint32_t)4U * i + (uint32_t)3U;
     c = Lib_IntTypes_Intrinsics_add_carry_u32(c, t12, t2, res_i););
-  KRML_MAYBE_FOR0(i,
-    (uint32_t)8U,
-    (uint32_t)8U,
-    (uint32_t)1U,
-    uint32_t t1 = res[i];
-    uint32_t t2 = n[i];
-    uint32_t *res_i = tmp + i;
-    c = Lib_IntTypes_Intrinsics_add_carry_u32(c, t1, t2, res_i););
   uint32_t c1 = c;
   uint32_t c2 = (uint32_t)0U - c00;
   KRML_MAYBE_FOR8(i,
@@ -329,13 +281,6 @@ void Hacl_Bignum256_32_mul(uint32_t *a, uint32_t *b, uint32_t *res)
       uint32_t a_i2 = a[(uint32_t)4U * i + (uint32_t)3U];
       uint32_t *res_i = res_j + (uint32_t)4U * i + (uint32_t)3U;
       c = Hacl_Bignum_Base_mul_wide_add2_u32(a_i2, bj, c, res_i););
-    KRML_MAYBE_FOR0(i,
-      (uint32_t)8U,
-      (uint32_t)8U,
-      (uint32_t)1U,
-      uint32_t a_i = a[i];
-      uint32_t *res_i = res_j + i;
-      c = Hacl_Bignum_Base_mul_wide_add2_u32(a_i, bj, c, res_i););
     uint32_t r = c;
     res[(uint32_t)8U + i0] = r;);
 }
@@ -432,13 +377,6 @@ static inline void reduction(uint32_t *n, uint32_t nInv, uint32_t *c, uint32_t *
       uint32_t a_i2 = n[(uint32_t)4U * i + (uint32_t)3U];
       uint32_t *res_i = res_j0 + (uint32_t)4U * i + (uint32_t)3U;
       c1 = Hacl_Bignum_Base_mul_wide_add2_u32(a_i2, qj, c1, res_i););
-    KRML_MAYBE_FOR0(i,
-      (uint32_t)8U,
-      (uint32_t)8U,
-      (uint32_t)1U,
-      uint32_t a_i = n[i];
-      uint32_t *res_i = res_j0 + i;
-      c1 = Hacl_Bignum_Base_mul_wide_add2_u32(a_i, qj, c1, res_i););
     uint32_t r = c1;
     uint32_t c10 = r;
     uint32_t *resb = c + (uint32_t)8U + i0;
@@ -468,14 +406,6 @@ static inline void reduction(uint32_t *n, uint32_t nInv, uint32_t *c, uint32_t *
     uint32_t t2 = n[(uint32_t)4U * i + (uint32_t)3U];
     uint32_t *res_i = tmp + (uint32_t)4U * i + (uint32_t)3U;
     c1 = Lib_IntTypes_Intrinsics_sub_borrow_u32(c1, t12, t2, res_i););
-  KRML_MAYBE_FOR0(i,
-    (uint32_t)8U,
-    (uint32_t)8U,
-    (uint32_t)1U,
-    uint32_t t1 = res[i];
-    uint32_t t2 = n[i];
-    uint32_t *res_i = tmp + i;
-    c1 = Lib_IntTypes_Intrinsics_sub_borrow_u32(c1, t1, t2, res_i););
   uint32_t c10 = c1;
   uint32_t c2 = c00 - c10;
   KRML_MAYBE_FOR8(i,
@@ -513,13 +443,6 @@ static inline void areduction(uint32_t *n, uint32_t nInv, uint32_t *c, uint32_t 
       uint32_t a_i2 = n[(uint32_t)4U * i + (uint32_t)3U];
       uint32_t *res_i = res_j0 + (uint32_t)4U * i + (uint32_t)3U;
       c1 = Hacl_Bignum_Base_mul_wide_add2_u32(a_i2, qj, c1, res_i););
-    KRML_MAYBE_FOR0(i,
-      (uint32_t)8U,
-      (uint32_t)8U,
-      (uint32_t)1U,
-      uint32_t a_i = n[i];
-      uint32_t *res_i = res_j0 + i;
-      c1 = Hacl_Bignum_Base_mul_wide_add2_u32(a_i, qj, c1, res_i););
     uint32_t r = c1;
     uint32_t c10 = r;
     uint32_t *resb = c + (uint32_t)8U + i0;
@@ -567,13 +490,6 @@ amont_mul(uint32_t *n, uint32_t nInv_u64, uint32_t *aM, uint32_t *bM, uint32_t *
       uint32_t a_i2 = aM[(uint32_t)4U * i + (uint32_t)3U];
       uint32_t *res_i = res_j + (uint32_t)4U * i + (uint32_t)3U;
       c1 = Hacl_Bignum_Base_mul_wide_add2_u32(a_i2, bj, c1, res_i););
-    KRML_MAYBE_FOR0(i,
-      (uint32_t)8U,
-      (uint32_t)8U,
-      (uint32_t)1U,
-      uint32_t a_i = aM[i];
-      uint32_t *res_i = res_j + i;
-      c1 = Hacl_Bignum_Base_mul_wide_add2_u32(a_i, bj, c1, res_i););
     uint32_t r = c1;
     c[(uint32_t)8U + i0] = r;);
   areduction(n, nInv_u64, c, resM);
@@ -659,13 +575,6 @@ bn_slow_precomp(uint32_t *n, uint32_t mu, uint32_t *r2, uint32_t *a, uint32_t *r
       uint32_t a_i2 = n[(uint32_t)4U * i + (uint32_t)3U];
       uint32_t *res_i = res_j0 + (uint32_t)4U * i + (uint32_t)3U;
       c = Hacl_Bignum_Base_mul_wide_add2_u32(a_i2, qj, c, res_i););
-    KRML_MAYBE_FOR0(i,
-      (uint32_t)8U,
-      (uint32_t)8U,
-      (uint32_t)1U,
-      uint32_t a_i = n[i];
-      uint32_t *res_i = res_j0 + i;
-      c = Hacl_Bignum_Base_mul_wide_add2_u32(a_i, qj, c, res_i););
     uint32_t r = c;
     uint32_t c1 = r;
     uint32_t *resb = a1 + (uint32_t)8U + i0;

--- a/dist/gcc-compatible/Hacl_Bignum256_32.c
+++ b/dist/gcc-compatible/Hacl_Bignum256_32.c
@@ -59,8 +59,10 @@ Write `a + b mod 2^256` in `res`.
 uint32_t Hacl_Bignum256_32_add(uint32_t *a, uint32_t *b, uint32_t *res)
 {
   uint32_t c = (uint32_t)0U;
-  for (uint32_t i = (uint32_t)0U; i < (uint32_t)2U; i++)
-  {
+  KRML_MAYBE_FOR2(i,
+    (uint32_t)0U,
+    (uint32_t)2U,
+    (uint32_t)1U,
     uint32_t t1 = a[(uint32_t)4U * i];
     uint32_t t20 = b[(uint32_t)4U * i];
     uint32_t *res_i0 = res + (uint32_t)4U * i;
@@ -76,15 +78,15 @@ uint32_t Hacl_Bignum256_32_add(uint32_t *a, uint32_t *b, uint32_t *res)
     uint32_t t12 = a[(uint32_t)4U * i + (uint32_t)3U];
     uint32_t t2 = b[(uint32_t)4U * i + (uint32_t)3U];
     uint32_t *res_i = res + (uint32_t)4U * i + (uint32_t)3U;
-    c = Lib_IntTypes_Intrinsics_add_carry_u32(c, t12, t2, res_i);
-  }
-  for (uint32_t i = (uint32_t)8U; i < (uint32_t)8U; i++)
-  {
+    c = Lib_IntTypes_Intrinsics_add_carry_u32(c, t12, t2, res_i););
+  KRML_MAYBE_FOR0(i,
+    (uint32_t)8U,
+    (uint32_t)8U,
+    (uint32_t)1U,
     uint32_t t1 = a[i];
     uint32_t t2 = b[i];
     uint32_t *res_i = res + i;
-    c = Lib_IntTypes_Intrinsics_add_carry_u32(c, t1, t2, res_i);
-  }
+    c = Lib_IntTypes_Intrinsics_add_carry_u32(c, t1, t2, res_i););
   return c;
 }
 
@@ -98,8 +100,10 @@ Write `a - b mod 2^256` in `res`.
 uint32_t Hacl_Bignum256_32_sub(uint32_t *a, uint32_t *b, uint32_t *res)
 {
   uint32_t c = (uint32_t)0U;
-  for (uint32_t i = (uint32_t)0U; i < (uint32_t)2U; i++)
-  {
+  KRML_MAYBE_FOR2(i,
+    (uint32_t)0U,
+    (uint32_t)2U,
+    (uint32_t)1U,
     uint32_t t1 = a[(uint32_t)4U * i];
     uint32_t t20 = b[(uint32_t)4U * i];
     uint32_t *res_i0 = res + (uint32_t)4U * i;
@@ -115,15 +119,15 @@ uint32_t Hacl_Bignum256_32_sub(uint32_t *a, uint32_t *b, uint32_t *res)
     uint32_t t12 = a[(uint32_t)4U * i + (uint32_t)3U];
     uint32_t t2 = b[(uint32_t)4U * i + (uint32_t)3U];
     uint32_t *res_i = res + (uint32_t)4U * i + (uint32_t)3U;
-    c = Lib_IntTypes_Intrinsics_sub_borrow_u32(c, t12, t2, res_i);
-  }
-  for (uint32_t i = (uint32_t)8U; i < (uint32_t)8U; i++)
-  {
+    c = Lib_IntTypes_Intrinsics_sub_borrow_u32(c, t12, t2, res_i););
+  KRML_MAYBE_FOR0(i,
+    (uint32_t)8U,
+    (uint32_t)8U,
+    (uint32_t)1U,
     uint32_t t1 = a[i];
     uint32_t t2 = b[i];
     uint32_t *res_i = res + i;
-    c = Lib_IntTypes_Intrinsics_sub_borrow_u32(c, t1, t2, res_i);
-  }
+    c = Lib_IntTypes_Intrinsics_sub_borrow_u32(c, t1, t2, res_i););
   return c;
 }
 
@@ -140,8 +144,10 @@ Write `(a + b) mod n` in `res`.
 void Hacl_Bignum256_32_add_mod(uint32_t *n, uint32_t *a, uint32_t *b, uint32_t *res)
 {
   uint32_t c0 = (uint32_t)0U;
-  for (uint32_t i = (uint32_t)0U; i < (uint32_t)2U; i++)
-  {
+  KRML_MAYBE_FOR2(i,
+    (uint32_t)0U,
+    (uint32_t)2U,
+    (uint32_t)1U,
     uint32_t t1 = a[(uint32_t)4U * i];
     uint32_t t20 = b[(uint32_t)4U * i];
     uint32_t *res_i0 = res + (uint32_t)4U * i;
@@ -157,20 +163,22 @@ void Hacl_Bignum256_32_add_mod(uint32_t *n, uint32_t *a, uint32_t *b, uint32_t *
     uint32_t t12 = a[(uint32_t)4U * i + (uint32_t)3U];
     uint32_t t2 = b[(uint32_t)4U * i + (uint32_t)3U];
     uint32_t *res_i = res + (uint32_t)4U * i + (uint32_t)3U;
-    c0 = Lib_IntTypes_Intrinsics_add_carry_u32(c0, t12, t2, res_i);
-  }
-  for (uint32_t i = (uint32_t)8U; i < (uint32_t)8U; i++)
-  {
+    c0 = Lib_IntTypes_Intrinsics_add_carry_u32(c0, t12, t2, res_i););
+  KRML_MAYBE_FOR0(i,
+    (uint32_t)8U,
+    (uint32_t)8U,
+    (uint32_t)1U,
     uint32_t t1 = a[i];
     uint32_t t2 = b[i];
     uint32_t *res_i = res + i;
-    c0 = Lib_IntTypes_Intrinsics_add_carry_u32(c0, t1, t2, res_i);
-  }
+    c0 = Lib_IntTypes_Intrinsics_add_carry_u32(c0, t1, t2, res_i););
   uint32_t c00 = c0;
   uint32_t tmp[8U] = { 0U };
   uint32_t c = (uint32_t)0U;
-  for (uint32_t i = (uint32_t)0U; i < (uint32_t)2U; i++)
-  {
+  KRML_MAYBE_FOR2(i,
+    (uint32_t)0U,
+    (uint32_t)2U,
+    (uint32_t)1U,
     uint32_t t1 = res[(uint32_t)4U * i];
     uint32_t t20 = n[(uint32_t)4U * i];
     uint32_t *res_i0 = tmp + (uint32_t)4U * i;
@@ -186,23 +194,24 @@ void Hacl_Bignum256_32_add_mod(uint32_t *n, uint32_t *a, uint32_t *b, uint32_t *
     uint32_t t12 = res[(uint32_t)4U * i + (uint32_t)3U];
     uint32_t t2 = n[(uint32_t)4U * i + (uint32_t)3U];
     uint32_t *res_i = tmp + (uint32_t)4U * i + (uint32_t)3U;
-    c = Lib_IntTypes_Intrinsics_sub_borrow_u32(c, t12, t2, res_i);
-  }
-  for (uint32_t i = (uint32_t)8U; i < (uint32_t)8U; i++)
-  {
+    c = Lib_IntTypes_Intrinsics_sub_borrow_u32(c, t12, t2, res_i););
+  KRML_MAYBE_FOR0(i,
+    (uint32_t)8U,
+    (uint32_t)8U,
+    (uint32_t)1U,
     uint32_t t1 = res[i];
     uint32_t t2 = n[i];
     uint32_t *res_i = tmp + i;
-    c = Lib_IntTypes_Intrinsics_sub_borrow_u32(c, t1, t2, res_i);
-  }
+    c = Lib_IntTypes_Intrinsics_sub_borrow_u32(c, t1, t2, res_i););
   uint32_t c1 = c;
   uint32_t c2 = c00 - c1;
-  for (uint32_t i = (uint32_t)0U; i < (uint32_t)8U; i++)
-  {
+  KRML_MAYBE_FOR8(i,
+    (uint32_t)0U,
+    (uint32_t)8U,
+    (uint32_t)1U,
     uint32_t *os = res;
     uint32_t x = (c2 & res[i]) | (~c2 & tmp[i]);
-    os[i] = x;
-  }
+    os[i] = x;);
 }
 
 /*
@@ -218,8 +227,10 @@ Write `(a - b) mod n` in `res`.
 void Hacl_Bignum256_32_sub_mod(uint32_t *n, uint32_t *a, uint32_t *b, uint32_t *res)
 {
   uint32_t c0 = (uint32_t)0U;
-  for (uint32_t i = (uint32_t)0U; i < (uint32_t)2U; i++)
-  {
+  KRML_MAYBE_FOR2(i,
+    (uint32_t)0U,
+    (uint32_t)2U,
+    (uint32_t)1U,
     uint32_t t1 = a[(uint32_t)4U * i];
     uint32_t t20 = b[(uint32_t)4U * i];
     uint32_t *res_i0 = res + (uint32_t)4U * i;
@@ -235,20 +246,22 @@ void Hacl_Bignum256_32_sub_mod(uint32_t *n, uint32_t *a, uint32_t *b, uint32_t *
     uint32_t t12 = a[(uint32_t)4U * i + (uint32_t)3U];
     uint32_t t2 = b[(uint32_t)4U * i + (uint32_t)3U];
     uint32_t *res_i = res + (uint32_t)4U * i + (uint32_t)3U;
-    c0 = Lib_IntTypes_Intrinsics_sub_borrow_u32(c0, t12, t2, res_i);
-  }
-  for (uint32_t i = (uint32_t)8U; i < (uint32_t)8U; i++)
-  {
+    c0 = Lib_IntTypes_Intrinsics_sub_borrow_u32(c0, t12, t2, res_i););
+  KRML_MAYBE_FOR0(i,
+    (uint32_t)8U,
+    (uint32_t)8U,
+    (uint32_t)1U,
     uint32_t t1 = a[i];
     uint32_t t2 = b[i];
     uint32_t *res_i = res + i;
-    c0 = Lib_IntTypes_Intrinsics_sub_borrow_u32(c0, t1, t2, res_i);
-  }
+    c0 = Lib_IntTypes_Intrinsics_sub_borrow_u32(c0, t1, t2, res_i););
   uint32_t c00 = c0;
   uint32_t tmp[8U] = { 0U };
   uint32_t c = (uint32_t)0U;
-  for (uint32_t i = (uint32_t)0U; i < (uint32_t)2U; i++)
-  {
+  KRML_MAYBE_FOR2(i,
+    (uint32_t)0U,
+    (uint32_t)2U,
+    (uint32_t)1U,
     uint32_t t1 = res[(uint32_t)4U * i];
     uint32_t t20 = n[(uint32_t)4U * i];
     uint32_t *res_i0 = tmp + (uint32_t)4U * i;
@@ -264,23 +277,24 @@ void Hacl_Bignum256_32_sub_mod(uint32_t *n, uint32_t *a, uint32_t *b, uint32_t *
     uint32_t t12 = res[(uint32_t)4U * i + (uint32_t)3U];
     uint32_t t2 = n[(uint32_t)4U * i + (uint32_t)3U];
     uint32_t *res_i = tmp + (uint32_t)4U * i + (uint32_t)3U;
-    c = Lib_IntTypes_Intrinsics_add_carry_u32(c, t12, t2, res_i);
-  }
-  for (uint32_t i = (uint32_t)8U; i < (uint32_t)8U; i++)
-  {
+    c = Lib_IntTypes_Intrinsics_add_carry_u32(c, t12, t2, res_i););
+  KRML_MAYBE_FOR0(i,
+    (uint32_t)8U,
+    (uint32_t)8U,
+    (uint32_t)1U,
     uint32_t t1 = res[i];
     uint32_t t2 = n[i];
     uint32_t *res_i = tmp + i;
-    c = Lib_IntTypes_Intrinsics_add_carry_u32(c, t1, t2, res_i);
-  }
+    c = Lib_IntTypes_Intrinsics_add_carry_u32(c, t1, t2, res_i););
   uint32_t c1 = c;
   uint32_t c2 = (uint32_t)0U - c00;
-  for (uint32_t i = (uint32_t)0U; i < (uint32_t)8U; i++)
-  {
+  KRML_MAYBE_FOR8(i,
+    (uint32_t)0U,
+    (uint32_t)8U,
+    (uint32_t)1U,
     uint32_t *os = res;
     uint32_t x = (c2 & tmp[i]) | (~c2 & res[i]);
-    os[i] = x;
-  }
+    os[i] = x;);
 }
 
 /*
@@ -292,13 +306,17 @@ Write `a * b` in `res`.
 void Hacl_Bignum256_32_mul(uint32_t *a, uint32_t *b, uint32_t *res)
 {
   memset(res, 0U, (uint32_t)16U * sizeof (uint32_t));
-  for (uint32_t i0 = (uint32_t)0U; i0 < (uint32_t)8U; i0++)
-  {
+  KRML_MAYBE_FOR8(i0,
+    (uint32_t)0U,
+    (uint32_t)8U,
+    (uint32_t)1U,
     uint32_t bj = b[i0];
     uint32_t *res_j = res + i0;
     uint32_t c = (uint32_t)0U;
-    for (uint32_t i = (uint32_t)0U; i < (uint32_t)2U; i++)
-    {
+    KRML_MAYBE_FOR2(i,
+      (uint32_t)0U,
+      (uint32_t)2U,
+      (uint32_t)1U,
       uint32_t a_i = a[(uint32_t)4U * i];
       uint32_t *res_i0 = res_j + (uint32_t)4U * i;
       c = Hacl_Bignum_Base_mul_wide_add2_u32(a_i, bj, c, res_i0);
@@ -310,17 +328,16 @@ void Hacl_Bignum256_32_mul(uint32_t *a, uint32_t *b, uint32_t *res)
       c = Hacl_Bignum_Base_mul_wide_add2_u32(a_i1, bj, c, res_i2);
       uint32_t a_i2 = a[(uint32_t)4U * i + (uint32_t)3U];
       uint32_t *res_i = res_j + (uint32_t)4U * i + (uint32_t)3U;
-      c = Hacl_Bignum_Base_mul_wide_add2_u32(a_i2, bj, c, res_i);
-    }
-    for (uint32_t i = (uint32_t)8U; i < (uint32_t)8U; i++)
-    {
+      c = Hacl_Bignum_Base_mul_wide_add2_u32(a_i2, bj, c, res_i););
+    KRML_MAYBE_FOR0(i,
+      (uint32_t)8U,
+      (uint32_t)8U,
+      (uint32_t)1U,
       uint32_t a_i = a[i];
       uint32_t *res_i = res_j + i;
-      c = Hacl_Bignum_Base_mul_wide_add2_u32(a_i, bj, c, res_i);
-    }
+      c = Hacl_Bignum_Base_mul_wide_add2_u32(a_i, bj, c, res_i););
     uint32_t r = c;
-    res[(uint32_t)8U + i0] = r;
-  }
+    res[(uint32_t)8U + i0] = r;);
 }
 
 /*
@@ -332,8 +349,10 @@ Write `a * a` in `res`.
 void Hacl_Bignum256_32_sqr(uint32_t *a, uint32_t *res)
 {
   memset(res, 0U, (uint32_t)16U * sizeof (uint32_t));
-  for (uint32_t i0 = (uint32_t)0U; i0 < (uint32_t)8U; i0++)
-  {
+  KRML_MAYBE_FOR8(i0,
+    (uint32_t)0U,
+    (uint32_t)8U,
+    (uint32_t)1U,
     uint32_t *ab = a;
     uint32_t a_j = a[i0];
     uint32_t *res_j = res + i0;
@@ -360,18 +379,18 @@ void Hacl_Bignum256_32_sqr(uint32_t *a, uint32_t *res)
       c = Hacl_Bignum_Base_mul_wide_add2_u32(a_i, a_j, c, res_i);
     }
     uint32_t r = c;
-    res[i0 + i0] = r;
-  }
+    res[i0 + i0] = r;);
   uint32_t c0 = Hacl_Bignum_Addition_bn_add_eq_len_u32((uint32_t)16U, res, res, res);
   uint32_t tmp[16U] = { 0U };
-  for (uint32_t i = (uint32_t)0U; i < (uint32_t)8U; i++)
-  {
+  KRML_MAYBE_FOR8(i,
+    (uint32_t)0U,
+    (uint32_t)8U,
+    (uint32_t)1U,
     uint64_t res1 = (uint64_t)a[i] * (uint64_t)a[i];
     uint32_t hi = (uint32_t)(res1 >> (uint32_t)32U);
     uint32_t lo = (uint32_t)res1;
     tmp[(uint32_t)2U * i] = lo;
-    tmp[(uint32_t)2U * i + (uint32_t)1U] = hi;
-  }
+    tmp[(uint32_t)2U * i + (uint32_t)1U] = hi;);
   uint32_t c1 = Hacl_Bignum_Addition_bn_add_eq_len_u32((uint32_t)16U, res, tmp, res);
 }
 
@@ -390,13 +409,17 @@ static inline void precompr2(uint32_t nBits, uint32_t *n, uint32_t *res)
 static inline void reduction(uint32_t *n, uint32_t nInv, uint32_t *c, uint32_t *res)
 {
   uint32_t c0 = (uint32_t)0U;
-  for (uint32_t i0 = (uint32_t)0U; i0 < (uint32_t)8U; i0++)
-  {
+  KRML_MAYBE_FOR8(i0,
+    (uint32_t)0U,
+    (uint32_t)8U,
+    (uint32_t)1U,
     uint32_t qj = nInv * c[i0];
     uint32_t *res_j0 = c + i0;
     uint32_t c1 = (uint32_t)0U;
-    for (uint32_t i = (uint32_t)0U; i < (uint32_t)2U; i++)
-    {
+    KRML_MAYBE_FOR2(i,
+      (uint32_t)0U,
+      (uint32_t)2U,
+      (uint32_t)1U,
       uint32_t a_i = n[(uint32_t)4U * i];
       uint32_t *res_i0 = res_j0 + (uint32_t)4U * i;
       c1 = Hacl_Bignum_Base_mul_wide_add2_u32(a_i, qj, c1, res_i0);
@@ -408,26 +431,27 @@ static inline void reduction(uint32_t *n, uint32_t nInv, uint32_t *c, uint32_t *
       c1 = Hacl_Bignum_Base_mul_wide_add2_u32(a_i1, qj, c1, res_i2);
       uint32_t a_i2 = n[(uint32_t)4U * i + (uint32_t)3U];
       uint32_t *res_i = res_j0 + (uint32_t)4U * i + (uint32_t)3U;
-      c1 = Hacl_Bignum_Base_mul_wide_add2_u32(a_i2, qj, c1, res_i);
-    }
-    for (uint32_t i = (uint32_t)8U; i < (uint32_t)8U; i++)
-    {
+      c1 = Hacl_Bignum_Base_mul_wide_add2_u32(a_i2, qj, c1, res_i););
+    KRML_MAYBE_FOR0(i,
+      (uint32_t)8U,
+      (uint32_t)8U,
+      (uint32_t)1U,
       uint32_t a_i = n[i];
       uint32_t *res_i = res_j0 + i;
-      c1 = Hacl_Bignum_Base_mul_wide_add2_u32(a_i, qj, c1, res_i);
-    }
+      c1 = Hacl_Bignum_Base_mul_wide_add2_u32(a_i, qj, c1, res_i););
     uint32_t r = c1;
     uint32_t c10 = r;
     uint32_t *resb = c + (uint32_t)8U + i0;
     uint32_t res_j = c[(uint32_t)8U + i0];
-    c0 = Lib_IntTypes_Intrinsics_add_carry_u32(c0, c10, res_j, resb);
-  }
+    c0 = Lib_IntTypes_Intrinsics_add_carry_u32(c0, c10, res_j, resb););
   memcpy(res, c + (uint32_t)8U, (uint32_t)8U * sizeof (uint32_t));
   uint32_t c00 = c0;
   uint32_t tmp[8U] = { 0U };
   uint32_t c1 = (uint32_t)0U;
-  for (uint32_t i = (uint32_t)0U; i < (uint32_t)2U; i++)
-  {
+  KRML_MAYBE_FOR2(i,
+    (uint32_t)0U,
+    (uint32_t)2U,
+    (uint32_t)1U,
     uint32_t t1 = res[(uint32_t)4U * i];
     uint32_t t20 = n[(uint32_t)4U * i];
     uint32_t *res_i0 = tmp + (uint32_t)4U * i;
@@ -443,35 +467,40 @@ static inline void reduction(uint32_t *n, uint32_t nInv, uint32_t *c, uint32_t *
     uint32_t t12 = res[(uint32_t)4U * i + (uint32_t)3U];
     uint32_t t2 = n[(uint32_t)4U * i + (uint32_t)3U];
     uint32_t *res_i = tmp + (uint32_t)4U * i + (uint32_t)3U;
-    c1 = Lib_IntTypes_Intrinsics_sub_borrow_u32(c1, t12, t2, res_i);
-  }
-  for (uint32_t i = (uint32_t)8U; i < (uint32_t)8U; i++)
-  {
+    c1 = Lib_IntTypes_Intrinsics_sub_borrow_u32(c1, t12, t2, res_i););
+  KRML_MAYBE_FOR0(i,
+    (uint32_t)8U,
+    (uint32_t)8U,
+    (uint32_t)1U,
     uint32_t t1 = res[i];
     uint32_t t2 = n[i];
     uint32_t *res_i = tmp + i;
-    c1 = Lib_IntTypes_Intrinsics_sub_borrow_u32(c1, t1, t2, res_i);
-  }
+    c1 = Lib_IntTypes_Intrinsics_sub_borrow_u32(c1, t1, t2, res_i););
   uint32_t c10 = c1;
   uint32_t c2 = c00 - c10;
-  for (uint32_t i = (uint32_t)0U; i < (uint32_t)8U; i++)
-  {
+  KRML_MAYBE_FOR8(i,
+    (uint32_t)0U,
+    (uint32_t)8U,
+    (uint32_t)1U,
     uint32_t *os = res;
     uint32_t x = (c2 & res[i]) | (~c2 & tmp[i]);
-    os[i] = x;
-  }
+    os[i] = x;);
 }
 
 static inline void areduction(uint32_t *n, uint32_t nInv, uint32_t *c, uint32_t *res)
 {
   uint32_t c0 = (uint32_t)0U;
-  for (uint32_t i0 = (uint32_t)0U; i0 < (uint32_t)8U; i0++)
-  {
+  KRML_MAYBE_FOR8(i0,
+    (uint32_t)0U,
+    (uint32_t)8U,
+    (uint32_t)1U,
     uint32_t qj = nInv * c[i0];
     uint32_t *res_j0 = c + i0;
     uint32_t c1 = (uint32_t)0U;
-    for (uint32_t i = (uint32_t)0U; i < (uint32_t)2U; i++)
-    {
+    KRML_MAYBE_FOR2(i,
+      (uint32_t)0U,
+      (uint32_t)2U,
+      (uint32_t)1U,
       uint32_t a_i = n[(uint32_t)4U * i];
       uint32_t *res_i0 = res_j0 + (uint32_t)4U * i;
       c1 = Hacl_Bignum_Base_mul_wide_add2_u32(a_i, qj, c1, res_i0);
@@ -483,31 +512,31 @@ static inline void areduction(uint32_t *n, uint32_t nInv, uint32_t *c, uint32_t 
       c1 = Hacl_Bignum_Base_mul_wide_add2_u32(a_i1, qj, c1, res_i2);
       uint32_t a_i2 = n[(uint32_t)4U * i + (uint32_t)3U];
       uint32_t *res_i = res_j0 + (uint32_t)4U * i + (uint32_t)3U;
-      c1 = Hacl_Bignum_Base_mul_wide_add2_u32(a_i2, qj, c1, res_i);
-    }
-    for (uint32_t i = (uint32_t)8U; i < (uint32_t)8U; i++)
-    {
+      c1 = Hacl_Bignum_Base_mul_wide_add2_u32(a_i2, qj, c1, res_i););
+    KRML_MAYBE_FOR0(i,
+      (uint32_t)8U,
+      (uint32_t)8U,
+      (uint32_t)1U,
       uint32_t a_i = n[i];
       uint32_t *res_i = res_j0 + i;
-      c1 = Hacl_Bignum_Base_mul_wide_add2_u32(a_i, qj, c1, res_i);
-    }
+      c1 = Hacl_Bignum_Base_mul_wide_add2_u32(a_i, qj, c1, res_i););
     uint32_t r = c1;
     uint32_t c10 = r;
     uint32_t *resb = c + (uint32_t)8U + i0;
     uint32_t res_j = c[(uint32_t)8U + i0];
-    c0 = Lib_IntTypes_Intrinsics_add_carry_u32(c0, c10, res_j, resb);
-  }
+    c0 = Lib_IntTypes_Intrinsics_add_carry_u32(c0, c10, res_j, resb););
   memcpy(res, c + (uint32_t)8U, (uint32_t)8U * sizeof (uint32_t));
   uint32_t c00 = c0;
   uint32_t tmp[8U] = { 0U };
   uint32_t c1 = Hacl_Bignum256_32_sub(res, n, tmp);
   uint32_t m = (uint32_t)0U - c00;
-  for (uint32_t i = (uint32_t)0U; i < (uint32_t)8U; i++)
-  {
+  KRML_MAYBE_FOR8(i,
+    (uint32_t)0U,
+    (uint32_t)8U,
+    (uint32_t)1U,
     uint32_t *os = res;
     uint32_t x = (m & tmp[i]) | (~m & res[i]);
-    os[i] = x;
-  }
+    os[i] = x;);
 }
 
 static inline void
@@ -515,13 +544,17 @@ amont_mul(uint32_t *n, uint32_t nInv_u64, uint32_t *aM, uint32_t *bM, uint32_t *
 {
   uint32_t c[16U] = { 0U };
   memset(c, 0U, (uint32_t)16U * sizeof (uint32_t));
-  for (uint32_t i0 = (uint32_t)0U; i0 < (uint32_t)8U; i0++)
-  {
+  KRML_MAYBE_FOR8(i0,
+    (uint32_t)0U,
+    (uint32_t)8U,
+    (uint32_t)1U,
     uint32_t bj = bM[i0];
     uint32_t *res_j = c + i0;
     uint32_t c1 = (uint32_t)0U;
-    for (uint32_t i = (uint32_t)0U; i < (uint32_t)2U; i++)
-    {
+    KRML_MAYBE_FOR2(i,
+      (uint32_t)0U,
+      (uint32_t)2U,
+      (uint32_t)1U,
       uint32_t a_i = aM[(uint32_t)4U * i];
       uint32_t *res_i0 = res_j + (uint32_t)4U * i;
       c1 = Hacl_Bignum_Base_mul_wide_add2_u32(a_i, bj, c1, res_i0);
@@ -533,17 +566,16 @@ amont_mul(uint32_t *n, uint32_t nInv_u64, uint32_t *aM, uint32_t *bM, uint32_t *
       c1 = Hacl_Bignum_Base_mul_wide_add2_u32(a_i1, bj, c1, res_i2);
       uint32_t a_i2 = aM[(uint32_t)4U * i + (uint32_t)3U];
       uint32_t *res_i = res_j + (uint32_t)4U * i + (uint32_t)3U;
-      c1 = Hacl_Bignum_Base_mul_wide_add2_u32(a_i2, bj, c1, res_i);
-    }
-    for (uint32_t i = (uint32_t)8U; i < (uint32_t)8U; i++)
-    {
+      c1 = Hacl_Bignum_Base_mul_wide_add2_u32(a_i2, bj, c1, res_i););
+    KRML_MAYBE_FOR0(i,
+      (uint32_t)8U,
+      (uint32_t)8U,
+      (uint32_t)1U,
       uint32_t a_i = aM[i];
       uint32_t *res_i = res_j + i;
-      c1 = Hacl_Bignum_Base_mul_wide_add2_u32(a_i, bj, c1, res_i);
-    }
+      c1 = Hacl_Bignum_Base_mul_wide_add2_u32(a_i, bj, c1, res_i););
     uint32_t r = c1;
-    c[(uint32_t)8U + i0] = r;
-  }
+    c[(uint32_t)8U + i0] = r;);
   areduction(n, nInv_u64, c, resM);
 }
 
@@ -551,8 +583,10 @@ static inline void amont_sqr(uint32_t *n, uint32_t nInv_u64, uint32_t *aM, uint3
 {
   uint32_t c[16U] = { 0U };
   memset(c, 0U, (uint32_t)16U * sizeof (uint32_t));
-  for (uint32_t i0 = (uint32_t)0U; i0 < (uint32_t)8U; i0++)
-  {
+  KRML_MAYBE_FOR8(i0,
+    (uint32_t)0U,
+    (uint32_t)8U,
+    (uint32_t)1U,
     uint32_t *ab = aM;
     uint32_t a_j = aM[i0];
     uint32_t *res_j = c + i0;
@@ -579,18 +613,18 @@ static inline void amont_sqr(uint32_t *n, uint32_t nInv_u64, uint32_t *aM, uint3
       c1 = Hacl_Bignum_Base_mul_wide_add2_u32(a_i, a_j, c1, res_i);
     }
     uint32_t r = c1;
-    c[i0 + i0] = r;
-  }
+    c[i0 + i0] = r;);
   uint32_t c0 = Hacl_Bignum_Addition_bn_add_eq_len_u32((uint32_t)16U, c, c, c);
   uint32_t tmp[16U] = { 0U };
-  for (uint32_t i = (uint32_t)0U; i < (uint32_t)8U; i++)
-  {
+  KRML_MAYBE_FOR8(i,
+    (uint32_t)0U,
+    (uint32_t)8U,
+    (uint32_t)1U,
     uint64_t res = (uint64_t)aM[i] * (uint64_t)aM[i];
     uint32_t hi = (uint32_t)(res >> (uint32_t)32U);
     uint32_t lo = (uint32_t)res;
     tmp[(uint32_t)2U * i] = lo;
-    tmp[(uint32_t)2U * i + (uint32_t)1U] = hi;
-  }
+    tmp[(uint32_t)2U * i + (uint32_t)1U] = hi;);
   uint32_t c1 = Hacl_Bignum_Addition_bn_add_eq_len_u32((uint32_t)16U, c, tmp, c);
   areduction(n, nInv_u64, c, resM);
 }
@@ -602,13 +636,17 @@ bn_slow_precomp(uint32_t *n, uint32_t mu, uint32_t *r2, uint32_t *a, uint32_t *r
   uint32_t a1[16U] = { 0U };
   memcpy(a1, a, (uint32_t)16U * sizeof (uint32_t));
   uint32_t c0 = (uint32_t)0U;
-  for (uint32_t i0 = (uint32_t)0U; i0 < (uint32_t)8U; i0++)
-  {
+  KRML_MAYBE_FOR8(i0,
+    (uint32_t)0U,
+    (uint32_t)8U,
+    (uint32_t)1U,
     uint32_t qj = mu * a1[i0];
     uint32_t *res_j0 = a1 + i0;
     uint32_t c = (uint32_t)0U;
-    for (uint32_t i = (uint32_t)0U; i < (uint32_t)2U; i++)
-    {
+    KRML_MAYBE_FOR2(i,
+      (uint32_t)0U,
+      (uint32_t)2U,
+      (uint32_t)1U,
       uint32_t a_i = n[(uint32_t)4U * i];
       uint32_t *res_i0 = res_j0 + (uint32_t)4U * i;
       c = Hacl_Bignum_Base_mul_wide_add2_u32(a_i, qj, c, res_i0);
@@ -620,31 +658,31 @@ bn_slow_precomp(uint32_t *n, uint32_t mu, uint32_t *r2, uint32_t *a, uint32_t *r
       c = Hacl_Bignum_Base_mul_wide_add2_u32(a_i1, qj, c, res_i2);
       uint32_t a_i2 = n[(uint32_t)4U * i + (uint32_t)3U];
       uint32_t *res_i = res_j0 + (uint32_t)4U * i + (uint32_t)3U;
-      c = Hacl_Bignum_Base_mul_wide_add2_u32(a_i2, qj, c, res_i);
-    }
-    for (uint32_t i = (uint32_t)8U; i < (uint32_t)8U; i++)
-    {
+      c = Hacl_Bignum_Base_mul_wide_add2_u32(a_i2, qj, c, res_i););
+    KRML_MAYBE_FOR0(i,
+      (uint32_t)8U,
+      (uint32_t)8U,
+      (uint32_t)1U,
       uint32_t a_i = n[i];
       uint32_t *res_i = res_j0 + i;
-      c = Hacl_Bignum_Base_mul_wide_add2_u32(a_i, qj, c, res_i);
-    }
+      c = Hacl_Bignum_Base_mul_wide_add2_u32(a_i, qj, c, res_i););
     uint32_t r = c;
     uint32_t c1 = r;
     uint32_t *resb = a1 + (uint32_t)8U + i0;
     uint32_t res_j = a1[(uint32_t)8U + i0];
-    c0 = Lib_IntTypes_Intrinsics_add_carry_u32(c0, c1, res_j, resb);
-  }
+    c0 = Lib_IntTypes_Intrinsics_add_carry_u32(c0, c1, res_j, resb););
   memcpy(a_mod, a1 + (uint32_t)8U, (uint32_t)8U * sizeof (uint32_t));
   uint32_t c00 = c0;
   uint32_t tmp[8U] = { 0U };
   uint32_t c1 = Hacl_Bignum256_32_sub(a_mod, n, tmp);
   uint32_t m = (uint32_t)0U - c00;
-  for (uint32_t i = (uint32_t)0U; i < (uint32_t)8U; i++)
-  {
+  KRML_MAYBE_FOR8(i,
+    (uint32_t)0U,
+    (uint32_t)8U,
+    (uint32_t)1U,
     uint32_t *os = a_mod;
     uint32_t x = (m & tmp[i]) | (~m & a_mod[i]);
-    os[i] = x;
-  }
+    os[i] = x;);
   uint32_t c[16U] = { 0U };
   Hacl_Bignum256_32_mul(a_mod, r2, c);
   reduction(n, mu, c, res);
@@ -669,12 +707,13 @@ bool Hacl_Bignum256_32_mod(uint32_t *n, uint32_t *a, uint32_t *res)
   uint32_t bit0 = n[0U] & (uint32_t)1U;
   uint32_t m0 = (uint32_t)0U - bit0;
   uint32_t acc = (uint32_t)0U;
-  for (uint32_t i = (uint32_t)0U; i < (uint32_t)8U; i++)
-  {
+  KRML_MAYBE_FOR8(i,
+    (uint32_t)0U,
+    (uint32_t)8U,
+    (uint32_t)1U,
     uint32_t beq = FStar_UInt32_eq_mask(one[i], n[i]);
     uint32_t blt = ~FStar_UInt32_gte_mask(one[i], n[i]);
-    acc = (beq & acc) | (~beq & ((blt & (uint32_t)0xFFFFFFFFU) | (~blt & (uint32_t)0U)));
-  }
+    acc = (beq & acc) | (~beq & ((blt & (uint32_t)0xFFFFFFFFU) | (~blt & (uint32_t)0U))););
   uint32_t m1 = acc;
   uint32_t is_valid_m = m0 & m1;
   uint32_t nBits = (uint32_t)32U * Hacl_Bignum_Lib_bn_get_top_index_u32((uint32_t)8U, n);
@@ -700,12 +739,13 @@ static uint32_t exp_check(uint32_t *n, uint32_t *a, uint32_t bBits, uint32_t *b)
   uint32_t bit0 = n[0U] & (uint32_t)1U;
   uint32_t m0 = (uint32_t)0U - bit0;
   uint32_t acc0 = (uint32_t)0U;
-  for (uint32_t i = (uint32_t)0U; i < (uint32_t)8U; i++)
-  {
+  KRML_MAYBE_FOR8(i,
+    (uint32_t)0U,
+    (uint32_t)8U,
+    (uint32_t)1U,
     uint32_t beq = FStar_UInt32_eq_mask(one[i], n[i]);
     uint32_t blt = ~FStar_UInt32_gte_mask(one[i], n[i]);
-    acc0 = (beq & acc0) | (~beq & ((blt & (uint32_t)0xFFFFFFFFU) | (~blt & (uint32_t)0U)));
-  }
+    acc0 = (beq & acc0) | (~beq & ((blt & (uint32_t)0xFFFFFFFFU) | (~blt & (uint32_t)0U))););
   uint32_t m10 = acc0;
   uint32_t m00 = m0 & m10;
   uint32_t bLen;
@@ -741,12 +781,13 @@ static uint32_t exp_check(uint32_t *n, uint32_t *a, uint32_t bBits, uint32_t *b)
     m1 = (uint32_t)0xFFFFFFFFU;
   }
   uint32_t acc = (uint32_t)0U;
-  for (uint32_t i = (uint32_t)0U; i < (uint32_t)8U; i++)
-  {
+  KRML_MAYBE_FOR8(i,
+    (uint32_t)0U,
+    (uint32_t)8U,
+    (uint32_t)1U,
     uint32_t beq = FStar_UInt32_eq_mask(a[i], n[i]);
     uint32_t blt = ~FStar_UInt32_gte_mask(a[i], n[i]);
-    acc = (beq & acc) | (~beq & ((blt & (uint32_t)0xFFFFFFFFU) | (~blt & (uint32_t)0U)));
-  }
+    acc = (beq & acc) | (~beq & ((blt & (uint32_t)0xFFFFFFFFU) | (~blt & (uint32_t)0U))););
   uint32_t m2 = acc;
   uint32_t m = m1 & m2;
   return m00 & m;
@@ -811,12 +852,13 @@ exp_vartime_precomp(
   memcpy(table, resM, (uint32_t)8U * sizeof (uint32_t));
   uint32_t *t1 = table + (uint32_t)8U;
   memcpy(t1, aM, (uint32_t)8U * sizeof (uint32_t));
-  for (uint32_t i = (uint32_t)0U; i < (uint32_t)15U; i++)
-  {
+  KRML_MAYBE_FOR15(i,
+    (uint32_t)0U,
+    (uint32_t)15U,
+    (uint32_t)1U,
     uint32_t *t11 = table + i * (uint32_t)8U;
     uint32_t *t2 = table + i * (uint32_t)8U + (uint32_t)8U;
-    amont_mul(n, mu, aM, t11, t2);
-  }
+    amont_mul(n, mu, aM, t11, t2););
   if (bBits % (uint32_t)4U != (uint32_t)0U)
   {
     uint32_t mask_l = (uint32_t)16U - (uint32_t)1U;
@@ -839,10 +881,7 @@ exp_vartime_precomp(
   }
   for (uint32_t i = (uint32_t)0U; i < bBits / (uint32_t)4U; i++)
   {
-    for (uint32_t i0 = (uint32_t)0U; i0 < (uint32_t)4U; i0++)
-    {
-      amont_sqr(n, mu, resM, resM);
-    }
+    KRML_MAYBE_FOR4(i0, (uint32_t)0U, (uint32_t)4U, (uint32_t)1U, amont_sqr(n, mu, resM, resM););
     uint32_t bk = bBits - bBits % (uint32_t)4U;
     uint32_t mask_l = (uint32_t)16U - (uint32_t)1U;
     uint32_t i1 = (bk - (uint32_t)4U * i - (uint32_t)4U) / (uint32_t)32U;
@@ -898,23 +937,25 @@ exp_consttime_precomp(
       uint32_t tmp = b[i1];
       uint32_t bit = tmp >> j & (uint32_t)1U;
       uint32_t sw1 = bit ^ sw;
-      for (uint32_t i = (uint32_t)0U; i < (uint32_t)8U; i++)
-      {
+      KRML_MAYBE_FOR8(i,
+        (uint32_t)0U,
+        (uint32_t)8U,
+        (uint32_t)1U,
         uint32_t dummy = ((uint32_t)0U - sw1) & (resM[i] ^ aM[i]);
         resM[i] = resM[i] ^ dummy;
-        aM[i] = aM[i] ^ dummy;
-      }
+        aM[i] = aM[i] ^ dummy;);
       amont_mul(n, mu, aM, resM, aM);
       amont_sqr(n, mu, resM, resM);
       sw = bit;
     }
     uint32_t sw0 = sw;
-    for (uint32_t i = (uint32_t)0U; i < (uint32_t)8U; i++)
-    {
+    KRML_MAYBE_FOR8(i,
+      (uint32_t)0U,
+      (uint32_t)8U,
+      (uint32_t)1U,
       uint32_t dummy = ((uint32_t)0U - sw0) & (resM[i] ^ aM[i]);
       resM[i] = resM[i] ^ dummy;
-      aM[i] = aM[i] ^ dummy;
-    }
+      aM[i] = aM[i] ^ dummy;);
     uint32_t tmp[16U] = { 0U };
     memcpy(tmp, resM, (uint32_t)8U * sizeof (uint32_t));
     reduction(n, mu, tmp, res);
@@ -941,12 +982,13 @@ exp_consttime_precomp(
   memcpy(table, resM, (uint32_t)8U * sizeof (uint32_t));
   uint32_t *t1 = table + (uint32_t)8U;
   memcpy(t1, aM, (uint32_t)8U * sizeof (uint32_t));
-  for (uint32_t i = (uint32_t)0U; i < (uint32_t)15U; i++)
-  {
+  KRML_MAYBE_FOR15(i,
+    (uint32_t)0U,
+    (uint32_t)15U,
+    (uint32_t)1U,
     uint32_t *t11 = table + i * (uint32_t)8U;
     uint32_t *t2 = table + i * (uint32_t)8U + (uint32_t)8U;
-    amont_mul(n, mu, aM, t11, t2);
-  }
+    amont_mul(n, mu, aM, t11, t2););
   if (bBits % (uint32_t)4U != (uint32_t)0U)
   {
     uint32_t mask_l = (uint32_t)16U - (uint32_t)1U;
@@ -964,24 +1006,23 @@ exp_consttime_precomp(
     }
     uint32_t bits_c = ite & mask_l;
     memcpy(resM, table, (uint32_t)8U * sizeof (uint32_t));
-    for (uint32_t i1 = (uint32_t)0U; i1 < (uint32_t)15U; i1++)
-    {
+    KRML_MAYBE_FOR15(i1,
+      (uint32_t)0U,
+      (uint32_t)15U,
+      (uint32_t)1U,
       uint32_t c = FStar_UInt32_eq_mask(bits_c, i1 + (uint32_t)1U);
       uint32_t *res_j = table + (i1 + (uint32_t)1U) * (uint32_t)8U;
-      for (uint32_t i = (uint32_t)0U; i < (uint32_t)8U; i++)
-      {
+      KRML_MAYBE_FOR8(i,
+        (uint32_t)0U,
+        (uint32_t)8U,
+        (uint32_t)1U,
         uint32_t *os = resM;
         uint32_t x = (c & res_j[i]) | (~c & resM[i]);
-        os[i] = x;
-      }
-    }
+        os[i] = x;););
   }
   for (uint32_t i0 = (uint32_t)0U; i0 < bBits / (uint32_t)4U; i0++)
   {
-    for (uint32_t i = (uint32_t)0U; i < (uint32_t)4U; i++)
-    {
-      amont_sqr(n, mu, resM, resM);
-    }
+    KRML_MAYBE_FOR4(i, (uint32_t)0U, (uint32_t)4U, (uint32_t)1U, amont_sqr(n, mu, resM, resM););
     uint32_t bk = bBits - bBits % (uint32_t)4U;
     uint32_t mask_l = (uint32_t)16U - (uint32_t)1U;
     uint32_t i1 = (bk - (uint32_t)4U * i0 - (uint32_t)4U) / (uint32_t)32U;
@@ -999,17 +1040,19 @@ exp_consttime_precomp(
     uint32_t bits_l = ite & mask_l;
     uint32_t a_bits_l[8U] = { 0U };
     memcpy(a_bits_l, table, (uint32_t)8U * sizeof (uint32_t));
-    for (uint32_t i2 = (uint32_t)0U; i2 < (uint32_t)15U; i2++)
-    {
+    KRML_MAYBE_FOR15(i2,
+      (uint32_t)0U,
+      (uint32_t)15U,
+      (uint32_t)1U,
       uint32_t c = FStar_UInt32_eq_mask(bits_l, i2 + (uint32_t)1U);
       uint32_t *res_j = table + (i2 + (uint32_t)1U) * (uint32_t)8U;
-      for (uint32_t i = (uint32_t)0U; i < (uint32_t)8U; i++)
-      {
+      KRML_MAYBE_FOR8(i,
+        (uint32_t)0U,
+        (uint32_t)8U,
+        (uint32_t)1U,
         uint32_t *os = a_bits_l;
         uint32_t x = (c & res_j[i]) | (~c & a_bits_l[i]);
-        os[i] = x;
-      }
-    }
+        os[i] = x;););
     amont_mul(n, mu, resM, a_bits_l, resM);
   }
   uint32_t tmp0[16U] = { 0U };
@@ -1156,31 +1199,34 @@ bool Hacl_Bignum256_32_mod_inv_prime_vartime(uint32_t *n, uint32_t *a, uint32_t 
   uint32_t bit0 = n[0U] & (uint32_t)1U;
   uint32_t m0 = (uint32_t)0U - bit0;
   uint32_t acc0 = (uint32_t)0U;
-  for (uint32_t i = (uint32_t)0U; i < (uint32_t)8U; i++)
-  {
+  KRML_MAYBE_FOR8(i,
+    (uint32_t)0U,
+    (uint32_t)8U,
+    (uint32_t)1U,
     uint32_t beq = FStar_UInt32_eq_mask(one[i], n[i]);
     uint32_t blt = ~FStar_UInt32_gte_mask(one[i], n[i]);
-    acc0 = (beq & acc0) | (~beq & ((blt & (uint32_t)0xFFFFFFFFU) | (~blt & (uint32_t)0U)));
-  }
+    acc0 = (beq & acc0) | (~beq & ((blt & (uint32_t)0xFFFFFFFFU) | (~blt & (uint32_t)0U))););
   uint32_t m1 = acc0;
   uint32_t m00 = m0 & m1;
   uint32_t bn_zero[8U] = { 0U };
   uint32_t mask = (uint32_t)0xFFFFFFFFU;
-  for (uint32_t i = (uint32_t)0U; i < (uint32_t)8U; i++)
-  {
+  KRML_MAYBE_FOR8(i,
+    (uint32_t)0U,
+    (uint32_t)8U,
+    (uint32_t)1U,
     uint32_t uu____0 = FStar_UInt32_eq_mask(a[i], bn_zero[i]);
-    mask = uu____0 & mask;
-  }
+    mask = uu____0 & mask;);
   uint32_t mask1 = mask;
   uint32_t res10 = mask1;
   uint32_t m10 = res10;
   uint32_t acc = (uint32_t)0U;
-  for (uint32_t i = (uint32_t)0U; i < (uint32_t)8U; i++)
-  {
+  KRML_MAYBE_FOR8(i,
+    (uint32_t)0U,
+    (uint32_t)8U,
+    (uint32_t)1U,
     uint32_t beq = FStar_UInt32_eq_mask(a[i], n[i]);
     uint32_t blt = ~FStar_UInt32_gte_mask(a[i], n[i]);
-    acc = (beq & acc) | (~beq & ((blt & (uint32_t)0xFFFFFFFFU) | (~blt & (uint32_t)0U)));
-  }
+    acc = (beq & acc) | (~beq & ((blt & (uint32_t)0xFFFFFFFFU) | (~blt & (uint32_t)0U))););
   uint32_t m2 = acc;
   uint32_t is_valid_m = (m00 & ~m10) & m2;
   uint32_t nBits = (uint32_t)32U * Hacl_Bignum_Lib_bn_get_top_index_u32((uint32_t)8U, n);
@@ -1584,12 +1630,13 @@ Returns 2^32 - 1 if a < b, otherwise returns 0.
 uint32_t Hacl_Bignum256_32_lt_mask(uint32_t *a, uint32_t *b)
 {
   uint32_t acc = (uint32_t)0U;
-  for (uint32_t i = (uint32_t)0U; i < (uint32_t)8U; i++)
-  {
+  KRML_MAYBE_FOR8(i,
+    (uint32_t)0U,
+    (uint32_t)8U,
+    (uint32_t)1U,
     uint32_t beq = FStar_UInt32_eq_mask(a[i], b[i]);
     uint32_t blt = ~FStar_UInt32_gte_mask(a[i], b[i]);
-    acc = (beq & acc) | (~beq & ((blt & (uint32_t)0xFFFFFFFFU) | (~blt & (uint32_t)0U)));
-  }
+    acc = (beq & acc) | (~beq & ((blt & (uint32_t)0xFFFFFFFFU) | (~blt & (uint32_t)0U))););
   return acc;
 }
 
@@ -1601,11 +1648,12 @@ Returns 2^32 - 1 if a = b, otherwise returns 0.
 uint32_t Hacl_Bignum256_32_eq_mask(uint32_t *a, uint32_t *b)
 {
   uint32_t mask = (uint32_t)0xFFFFFFFFU;
-  for (uint32_t i = (uint32_t)0U; i < (uint32_t)8U; i++)
-  {
+  KRML_MAYBE_FOR8(i,
+    (uint32_t)0U,
+    (uint32_t)8U,
+    (uint32_t)1U,
     uint32_t uu____0 = FStar_UInt32_eq_mask(a[i], b[i]);
-    mask = uu____0 & mask;
-  }
+    mask = uu____0 & mask;);
   uint32_t mask1 = mask;
   return mask1;
 }

--- a/dist/gcc-compatible/Hacl_Bignum4096.c
+++ b/dist/gcc-compatible/Hacl_Bignum4096.c
@@ -63,8 +63,10 @@ Write `a + b mod 2^4096` in `res`.
 uint64_t Hacl_Bignum4096_add(uint64_t *a, uint64_t *b, uint64_t *res)
 {
   uint64_t c = (uint64_t)0U;
-  for (uint32_t i = (uint32_t)0U; i < (uint32_t)16U; i++)
-  {
+  KRML_MAYBE_FOR16(i,
+    (uint32_t)0U,
+    (uint32_t)16U,
+    (uint32_t)1U,
     uint64_t t1 = a[(uint32_t)4U * i];
     uint64_t t20 = b[(uint32_t)4U * i];
     uint64_t *res_i0 = res + (uint32_t)4U * i;
@@ -80,15 +82,15 @@ uint64_t Hacl_Bignum4096_add(uint64_t *a, uint64_t *b, uint64_t *res)
     uint64_t t12 = a[(uint32_t)4U * i + (uint32_t)3U];
     uint64_t t2 = b[(uint32_t)4U * i + (uint32_t)3U];
     uint64_t *res_i = res + (uint32_t)4U * i + (uint32_t)3U;
-    c = Lib_IntTypes_Intrinsics_add_carry_u64(c, t12, t2, res_i);
-  }
-  for (uint32_t i = (uint32_t)64U; i < (uint32_t)64U; i++)
-  {
+    c = Lib_IntTypes_Intrinsics_add_carry_u64(c, t12, t2, res_i););
+  KRML_MAYBE_FOR0(i,
+    (uint32_t)64U,
+    (uint32_t)64U,
+    (uint32_t)1U,
     uint64_t t1 = a[i];
     uint64_t t2 = b[i];
     uint64_t *res_i = res + i;
-    c = Lib_IntTypes_Intrinsics_add_carry_u64(c, t1, t2, res_i);
-  }
+    c = Lib_IntTypes_Intrinsics_add_carry_u64(c, t1, t2, res_i););
   return c;
 }
 
@@ -102,8 +104,10 @@ Write `a - b mod 2^4096` in `res`.
 uint64_t Hacl_Bignum4096_sub(uint64_t *a, uint64_t *b, uint64_t *res)
 {
   uint64_t c = (uint64_t)0U;
-  for (uint32_t i = (uint32_t)0U; i < (uint32_t)16U; i++)
-  {
+  KRML_MAYBE_FOR16(i,
+    (uint32_t)0U,
+    (uint32_t)16U,
+    (uint32_t)1U,
     uint64_t t1 = a[(uint32_t)4U * i];
     uint64_t t20 = b[(uint32_t)4U * i];
     uint64_t *res_i0 = res + (uint32_t)4U * i;
@@ -119,15 +123,15 @@ uint64_t Hacl_Bignum4096_sub(uint64_t *a, uint64_t *b, uint64_t *res)
     uint64_t t12 = a[(uint32_t)4U * i + (uint32_t)3U];
     uint64_t t2 = b[(uint32_t)4U * i + (uint32_t)3U];
     uint64_t *res_i = res + (uint32_t)4U * i + (uint32_t)3U;
-    c = Lib_IntTypes_Intrinsics_sub_borrow_u64(c, t12, t2, res_i);
-  }
-  for (uint32_t i = (uint32_t)64U; i < (uint32_t)64U; i++)
-  {
+    c = Lib_IntTypes_Intrinsics_sub_borrow_u64(c, t12, t2, res_i););
+  KRML_MAYBE_FOR0(i,
+    (uint32_t)64U,
+    (uint32_t)64U,
+    (uint32_t)1U,
     uint64_t t1 = a[i];
     uint64_t t2 = b[i];
     uint64_t *res_i = res + i;
-    c = Lib_IntTypes_Intrinsics_sub_borrow_u64(c, t1, t2, res_i);
-  }
+    c = Lib_IntTypes_Intrinsics_sub_borrow_u64(c, t1, t2, res_i););
   return c;
 }
 
@@ -144,8 +148,10 @@ Write `(a + b) mod n` in `res`.
 void Hacl_Bignum4096_add_mod(uint64_t *n, uint64_t *a, uint64_t *b, uint64_t *res)
 {
   uint64_t c0 = (uint64_t)0U;
-  for (uint32_t i = (uint32_t)0U; i < (uint32_t)16U; i++)
-  {
+  KRML_MAYBE_FOR16(i,
+    (uint32_t)0U,
+    (uint32_t)16U,
+    (uint32_t)1U,
     uint64_t t1 = a[(uint32_t)4U * i];
     uint64_t t20 = b[(uint32_t)4U * i];
     uint64_t *res_i0 = res + (uint32_t)4U * i;
@@ -161,20 +167,22 @@ void Hacl_Bignum4096_add_mod(uint64_t *n, uint64_t *a, uint64_t *b, uint64_t *re
     uint64_t t12 = a[(uint32_t)4U * i + (uint32_t)3U];
     uint64_t t2 = b[(uint32_t)4U * i + (uint32_t)3U];
     uint64_t *res_i = res + (uint32_t)4U * i + (uint32_t)3U;
-    c0 = Lib_IntTypes_Intrinsics_add_carry_u64(c0, t12, t2, res_i);
-  }
-  for (uint32_t i = (uint32_t)64U; i < (uint32_t)64U; i++)
-  {
+    c0 = Lib_IntTypes_Intrinsics_add_carry_u64(c0, t12, t2, res_i););
+  KRML_MAYBE_FOR0(i,
+    (uint32_t)64U,
+    (uint32_t)64U,
+    (uint32_t)1U,
     uint64_t t1 = a[i];
     uint64_t t2 = b[i];
     uint64_t *res_i = res + i;
-    c0 = Lib_IntTypes_Intrinsics_add_carry_u64(c0, t1, t2, res_i);
-  }
+    c0 = Lib_IntTypes_Intrinsics_add_carry_u64(c0, t1, t2, res_i););
   uint64_t c00 = c0;
   uint64_t tmp[64U] = { 0U };
   uint64_t c = (uint64_t)0U;
-  for (uint32_t i = (uint32_t)0U; i < (uint32_t)16U; i++)
-  {
+  KRML_MAYBE_FOR16(i,
+    (uint32_t)0U,
+    (uint32_t)16U,
+    (uint32_t)1U,
     uint64_t t1 = res[(uint32_t)4U * i];
     uint64_t t20 = n[(uint32_t)4U * i];
     uint64_t *res_i0 = tmp + (uint32_t)4U * i;
@@ -190,15 +198,15 @@ void Hacl_Bignum4096_add_mod(uint64_t *n, uint64_t *a, uint64_t *b, uint64_t *re
     uint64_t t12 = res[(uint32_t)4U * i + (uint32_t)3U];
     uint64_t t2 = n[(uint32_t)4U * i + (uint32_t)3U];
     uint64_t *res_i = tmp + (uint32_t)4U * i + (uint32_t)3U;
-    c = Lib_IntTypes_Intrinsics_sub_borrow_u64(c, t12, t2, res_i);
-  }
-  for (uint32_t i = (uint32_t)64U; i < (uint32_t)64U; i++)
-  {
+    c = Lib_IntTypes_Intrinsics_sub_borrow_u64(c, t12, t2, res_i););
+  KRML_MAYBE_FOR0(i,
+    (uint32_t)64U,
+    (uint32_t)64U,
+    (uint32_t)1U,
     uint64_t t1 = res[i];
     uint64_t t2 = n[i];
     uint64_t *res_i = tmp + i;
-    c = Lib_IntTypes_Intrinsics_sub_borrow_u64(c, t1, t2, res_i);
-  }
+    c = Lib_IntTypes_Intrinsics_sub_borrow_u64(c, t1, t2, res_i););
   uint64_t c1 = c;
   uint64_t c2 = c00 - c1;
   for (uint32_t i = (uint32_t)0U; i < (uint32_t)64U; i++)
@@ -222,8 +230,10 @@ Write `(a - b) mod n` in `res`.
 void Hacl_Bignum4096_sub_mod(uint64_t *n, uint64_t *a, uint64_t *b, uint64_t *res)
 {
   uint64_t c0 = (uint64_t)0U;
-  for (uint32_t i = (uint32_t)0U; i < (uint32_t)16U; i++)
-  {
+  KRML_MAYBE_FOR16(i,
+    (uint32_t)0U,
+    (uint32_t)16U,
+    (uint32_t)1U,
     uint64_t t1 = a[(uint32_t)4U * i];
     uint64_t t20 = b[(uint32_t)4U * i];
     uint64_t *res_i0 = res + (uint32_t)4U * i;
@@ -239,20 +249,22 @@ void Hacl_Bignum4096_sub_mod(uint64_t *n, uint64_t *a, uint64_t *b, uint64_t *re
     uint64_t t12 = a[(uint32_t)4U * i + (uint32_t)3U];
     uint64_t t2 = b[(uint32_t)4U * i + (uint32_t)3U];
     uint64_t *res_i = res + (uint32_t)4U * i + (uint32_t)3U;
-    c0 = Lib_IntTypes_Intrinsics_sub_borrow_u64(c0, t12, t2, res_i);
-  }
-  for (uint32_t i = (uint32_t)64U; i < (uint32_t)64U; i++)
-  {
+    c0 = Lib_IntTypes_Intrinsics_sub_borrow_u64(c0, t12, t2, res_i););
+  KRML_MAYBE_FOR0(i,
+    (uint32_t)64U,
+    (uint32_t)64U,
+    (uint32_t)1U,
     uint64_t t1 = a[i];
     uint64_t t2 = b[i];
     uint64_t *res_i = res + i;
-    c0 = Lib_IntTypes_Intrinsics_sub_borrow_u64(c0, t1, t2, res_i);
-  }
+    c0 = Lib_IntTypes_Intrinsics_sub_borrow_u64(c0, t1, t2, res_i););
   uint64_t c00 = c0;
   uint64_t tmp[64U] = { 0U };
   uint64_t c = (uint64_t)0U;
-  for (uint32_t i = (uint32_t)0U; i < (uint32_t)16U; i++)
-  {
+  KRML_MAYBE_FOR16(i,
+    (uint32_t)0U,
+    (uint32_t)16U,
+    (uint32_t)1U,
     uint64_t t1 = res[(uint32_t)4U * i];
     uint64_t t20 = n[(uint32_t)4U * i];
     uint64_t *res_i0 = tmp + (uint32_t)4U * i;
@@ -268,15 +280,15 @@ void Hacl_Bignum4096_sub_mod(uint64_t *n, uint64_t *a, uint64_t *b, uint64_t *re
     uint64_t t12 = res[(uint32_t)4U * i + (uint32_t)3U];
     uint64_t t2 = n[(uint32_t)4U * i + (uint32_t)3U];
     uint64_t *res_i = tmp + (uint32_t)4U * i + (uint32_t)3U;
-    c = Lib_IntTypes_Intrinsics_add_carry_u64(c, t12, t2, res_i);
-  }
-  for (uint32_t i = (uint32_t)64U; i < (uint32_t)64U; i++)
-  {
+    c = Lib_IntTypes_Intrinsics_add_carry_u64(c, t12, t2, res_i););
+  KRML_MAYBE_FOR0(i,
+    (uint32_t)64U,
+    (uint32_t)64U,
+    (uint32_t)1U,
     uint64_t t1 = res[i];
     uint64_t t2 = n[i];
     uint64_t *res_i = tmp + i;
-    c = Lib_IntTypes_Intrinsics_add_carry_u64(c, t1, t2, res_i);
-  }
+    c = Lib_IntTypes_Intrinsics_add_carry_u64(c, t1, t2, res_i););
   uint64_t c1 = c;
   uint64_t c2 = (uint64_t)0U - c00;
   for (uint32_t i = (uint32_t)0U; i < (uint32_t)64U; i++)
@@ -331,8 +343,10 @@ static inline void reduction(uint64_t *n, uint64_t nInv, uint64_t *c, uint64_t *
     uint64_t qj = nInv * c[i0];
     uint64_t *res_j0 = c + i0;
     uint64_t c1 = (uint64_t)0U;
-    for (uint32_t i = (uint32_t)0U; i < (uint32_t)16U; i++)
-    {
+    KRML_MAYBE_FOR16(i,
+      (uint32_t)0U,
+      (uint32_t)16U,
+      (uint32_t)1U,
       uint64_t a_i = n[(uint32_t)4U * i];
       uint64_t *res_i0 = res_j0 + (uint32_t)4U * i;
       c1 = Hacl_Bignum_Base_mul_wide_add2_u64(a_i, qj, c1, res_i0);
@@ -344,14 +358,14 @@ static inline void reduction(uint64_t *n, uint64_t nInv, uint64_t *c, uint64_t *
       c1 = Hacl_Bignum_Base_mul_wide_add2_u64(a_i1, qj, c1, res_i2);
       uint64_t a_i2 = n[(uint32_t)4U * i + (uint32_t)3U];
       uint64_t *res_i = res_j0 + (uint32_t)4U * i + (uint32_t)3U;
-      c1 = Hacl_Bignum_Base_mul_wide_add2_u64(a_i2, qj, c1, res_i);
-    }
-    for (uint32_t i = (uint32_t)64U; i < (uint32_t)64U; i++)
-    {
+      c1 = Hacl_Bignum_Base_mul_wide_add2_u64(a_i2, qj, c1, res_i););
+    KRML_MAYBE_FOR0(i,
+      (uint32_t)64U,
+      (uint32_t)64U,
+      (uint32_t)1U,
       uint64_t a_i = n[i];
       uint64_t *res_i = res_j0 + i;
-      c1 = Hacl_Bignum_Base_mul_wide_add2_u64(a_i, qj, c1, res_i);
-    }
+      c1 = Hacl_Bignum_Base_mul_wide_add2_u64(a_i, qj, c1, res_i););
     uint64_t r = c1;
     uint64_t c10 = r;
     uint64_t *resb = c + (uint32_t)64U + i0;
@@ -362,8 +376,10 @@ static inline void reduction(uint64_t *n, uint64_t nInv, uint64_t *c, uint64_t *
   uint64_t c00 = c0;
   uint64_t tmp[64U] = { 0U };
   uint64_t c1 = (uint64_t)0U;
-  for (uint32_t i = (uint32_t)0U; i < (uint32_t)16U; i++)
-  {
+  KRML_MAYBE_FOR16(i,
+    (uint32_t)0U,
+    (uint32_t)16U,
+    (uint32_t)1U,
     uint64_t t1 = res[(uint32_t)4U * i];
     uint64_t t20 = n[(uint32_t)4U * i];
     uint64_t *res_i0 = tmp + (uint32_t)4U * i;
@@ -379,15 +395,15 @@ static inline void reduction(uint64_t *n, uint64_t nInv, uint64_t *c, uint64_t *
     uint64_t t12 = res[(uint32_t)4U * i + (uint32_t)3U];
     uint64_t t2 = n[(uint32_t)4U * i + (uint32_t)3U];
     uint64_t *res_i = tmp + (uint32_t)4U * i + (uint32_t)3U;
-    c1 = Lib_IntTypes_Intrinsics_sub_borrow_u64(c1, t12, t2, res_i);
-  }
-  for (uint32_t i = (uint32_t)64U; i < (uint32_t)64U; i++)
-  {
+    c1 = Lib_IntTypes_Intrinsics_sub_borrow_u64(c1, t12, t2, res_i););
+  KRML_MAYBE_FOR0(i,
+    (uint32_t)64U,
+    (uint32_t)64U,
+    (uint32_t)1U,
     uint64_t t1 = res[i];
     uint64_t t2 = n[i];
     uint64_t *res_i = tmp + i;
-    c1 = Lib_IntTypes_Intrinsics_sub_borrow_u64(c1, t1, t2, res_i);
-  }
+    c1 = Lib_IntTypes_Intrinsics_sub_borrow_u64(c1, t1, t2, res_i););
   uint64_t c10 = c1;
   uint64_t c2 = c00 - c10;
   for (uint32_t i = (uint32_t)0U; i < (uint32_t)64U; i++)
@@ -406,8 +422,10 @@ static inline void areduction(uint64_t *n, uint64_t nInv, uint64_t *c, uint64_t 
     uint64_t qj = nInv * c[i0];
     uint64_t *res_j0 = c + i0;
     uint64_t c1 = (uint64_t)0U;
-    for (uint32_t i = (uint32_t)0U; i < (uint32_t)16U; i++)
-    {
+    KRML_MAYBE_FOR16(i,
+      (uint32_t)0U,
+      (uint32_t)16U,
+      (uint32_t)1U,
       uint64_t a_i = n[(uint32_t)4U * i];
       uint64_t *res_i0 = res_j0 + (uint32_t)4U * i;
       c1 = Hacl_Bignum_Base_mul_wide_add2_u64(a_i, qj, c1, res_i0);
@@ -419,14 +437,14 @@ static inline void areduction(uint64_t *n, uint64_t nInv, uint64_t *c, uint64_t 
       c1 = Hacl_Bignum_Base_mul_wide_add2_u64(a_i1, qj, c1, res_i2);
       uint64_t a_i2 = n[(uint32_t)4U * i + (uint32_t)3U];
       uint64_t *res_i = res_j0 + (uint32_t)4U * i + (uint32_t)3U;
-      c1 = Hacl_Bignum_Base_mul_wide_add2_u64(a_i2, qj, c1, res_i);
-    }
-    for (uint32_t i = (uint32_t)64U; i < (uint32_t)64U; i++)
-    {
+      c1 = Hacl_Bignum_Base_mul_wide_add2_u64(a_i2, qj, c1, res_i););
+    KRML_MAYBE_FOR0(i,
+      (uint32_t)64U,
+      (uint32_t)64U,
+      (uint32_t)1U,
       uint64_t a_i = n[i];
       uint64_t *res_i = res_j0 + i;
-      c1 = Hacl_Bignum_Base_mul_wide_add2_u64(a_i, qj, c1, res_i);
-    }
+      c1 = Hacl_Bignum_Base_mul_wide_add2_u64(a_i, qj, c1, res_i););
     uint64_t r = c1;
     uint64_t c10 = r;
     uint64_t *resb = c + (uint32_t)64U + i0;
@@ -475,8 +493,10 @@ bn_slow_precomp(uint64_t *n, uint64_t mu, uint64_t *r2, uint64_t *a, uint64_t *r
     uint64_t qj = mu * a1[i0];
     uint64_t *res_j0 = a1 + i0;
     uint64_t c = (uint64_t)0U;
-    for (uint32_t i = (uint32_t)0U; i < (uint32_t)16U; i++)
-    {
+    KRML_MAYBE_FOR16(i,
+      (uint32_t)0U,
+      (uint32_t)16U,
+      (uint32_t)1U,
       uint64_t a_i = n[(uint32_t)4U * i];
       uint64_t *res_i0 = res_j0 + (uint32_t)4U * i;
       c = Hacl_Bignum_Base_mul_wide_add2_u64(a_i, qj, c, res_i0);
@@ -488,14 +508,14 @@ bn_slow_precomp(uint64_t *n, uint64_t mu, uint64_t *r2, uint64_t *a, uint64_t *r
       c = Hacl_Bignum_Base_mul_wide_add2_u64(a_i1, qj, c, res_i2);
       uint64_t a_i2 = n[(uint32_t)4U * i + (uint32_t)3U];
       uint64_t *res_i = res_j0 + (uint32_t)4U * i + (uint32_t)3U;
-      c = Hacl_Bignum_Base_mul_wide_add2_u64(a_i2, qj, c, res_i);
-    }
-    for (uint32_t i = (uint32_t)64U; i < (uint32_t)64U; i++)
-    {
+      c = Hacl_Bignum_Base_mul_wide_add2_u64(a_i2, qj, c, res_i););
+    KRML_MAYBE_FOR0(i,
+      (uint32_t)64U,
+      (uint32_t)64U,
+      (uint32_t)1U,
       uint64_t a_i = n[i];
       uint64_t *res_i = res_j0 + i;
-      c = Hacl_Bignum_Base_mul_wide_add2_u64(a_i, qj, c, res_i);
-    }
+      c = Hacl_Bignum_Base_mul_wide_add2_u64(a_i, qj, c, res_i););
     uint64_t r = c;
     uint64_t c1 = r;
     uint64_t *resb = a1 + (uint32_t)64U + i0;
@@ -680,12 +700,13 @@ exp_vartime_precomp(
   memcpy(table, resM, (uint32_t)64U * sizeof (uint64_t));
   uint64_t *t1 = table + (uint32_t)64U;
   memcpy(t1, aM, (uint32_t)64U * sizeof (uint64_t));
-  for (uint32_t i = (uint32_t)0U; i < (uint32_t)15U; i++)
-  {
+  KRML_MAYBE_FOR15(i,
+    (uint32_t)0U,
+    (uint32_t)15U,
+    (uint32_t)1U,
     uint64_t *t11 = table + i * (uint32_t)64U;
     uint64_t *t2 = table + i * (uint32_t)64U + (uint32_t)64U;
-    amont_mul(n, mu, aM, t11, t2);
-  }
+    amont_mul(n, mu, aM, t11, t2););
   if (bBits % (uint32_t)4U != (uint32_t)0U)
   {
     uint64_t mask_l = (uint64_t)16U - (uint64_t)1U;
@@ -708,10 +729,7 @@ exp_vartime_precomp(
   }
   for (uint32_t i = (uint32_t)0U; i < bBits / (uint32_t)4U; i++)
   {
-    for (uint32_t i0 = (uint32_t)0U; i0 < (uint32_t)4U; i0++)
-    {
-      amont_sqr(n, mu, resM, resM);
-    }
+    KRML_MAYBE_FOR4(i0, (uint32_t)0U, (uint32_t)4U, (uint32_t)1U, amont_sqr(n, mu, resM, resM););
     uint32_t bk = bBits - bBits % (uint32_t)4U;
     uint64_t mask_l = (uint64_t)16U - (uint64_t)1U;
     uint32_t i1 = (bk - (uint32_t)4U * i - (uint32_t)4U) / (uint32_t)64U;
@@ -810,12 +828,13 @@ exp_consttime_precomp(
   memcpy(table, resM, (uint32_t)64U * sizeof (uint64_t));
   uint64_t *t1 = table + (uint32_t)64U;
   memcpy(t1, aM, (uint32_t)64U * sizeof (uint64_t));
-  for (uint32_t i = (uint32_t)0U; i < (uint32_t)15U; i++)
-  {
+  KRML_MAYBE_FOR15(i,
+    (uint32_t)0U,
+    (uint32_t)15U,
+    (uint32_t)1U,
     uint64_t *t11 = table + i * (uint32_t)64U;
     uint64_t *t2 = table + i * (uint32_t)64U + (uint32_t)64U;
-    amont_mul(n, mu, aM, t11, t2);
-  }
+    amont_mul(n, mu, aM, t11, t2););
   if (bBits % (uint32_t)4U != (uint32_t)0U)
   {
     uint64_t mask_l = (uint64_t)16U - (uint64_t)1U;
@@ -833,8 +852,10 @@ exp_consttime_precomp(
     }
     uint64_t bits_c = ite & mask_l;
     memcpy(resM, table, (uint32_t)64U * sizeof (uint64_t));
-    for (uint32_t i1 = (uint32_t)0U; i1 < (uint32_t)15U; i1++)
-    {
+    KRML_MAYBE_FOR15(i1,
+      (uint32_t)0U,
+      (uint32_t)15U,
+      (uint32_t)1U,
       uint64_t c = FStar_UInt64_eq_mask(bits_c, (uint64_t)(i1 + (uint32_t)1U));
       uint64_t *res_j = table + (i1 + (uint32_t)1U) * (uint32_t)64U;
       for (uint32_t i = (uint32_t)0U; i < (uint32_t)64U; i++)
@@ -842,15 +863,11 @@ exp_consttime_precomp(
         uint64_t *os = resM;
         uint64_t x = (c & res_j[i]) | (~c & resM[i]);
         os[i] = x;
-      }
-    }
+      });
   }
   for (uint32_t i0 = (uint32_t)0U; i0 < bBits / (uint32_t)4U; i0++)
   {
-    for (uint32_t i = (uint32_t)0U; i < (uint32_t)4U; i++)
-    {
-      amont_sqr(n, mu, resM, resM);
-    }
+    KRML_MAYBE_FOR4(i, (uint32_t)0U, (uint32_t)4U, (uint32_t)1U, amont_sqr(n, mu, resM, resM););
     uint32_t bk = bBits - bBits % (uint32_t)4U;
     uint64_t mask_l = (uint64_t)16U - (uint64_t)1U;
     uint32_t i1 = (bk - (uint32_t)4U * i0 - (uint32_t)4U) / (uint32_t)64U;
@@ -868,8 +885,10 @@ exp_consttime_precomp(
     uint64_t bits_l = ite & mask_l;
     uint64_t a_bits_l[64U] = { 0U };
     memcpy(a_bits_l, table, (uint32_t)64U * sizeof (uint64_t));
-    for (uint32_t i2 = (uint32_t)0U; i2 < (uint32_t)15U; i2++)
-    {
+    KRML_MAYBE_FOR15(i2,
+      (uint32_t)0U,
+      (uint32_t)15U,
+      (uint32_t)1U,
       uint64_t c = FStar_UInt64_eq_mask(bits_l, (uint64_t)(i2 + (uint32_t)1U));
       uint64_t *res_j = table + (i2 + (uint32_t)1U) * (uint32_t)64U;
       for (uint32_t i = (uint32_t)0U; i < (uint32_t)64U; i++)
@@ -877,8 +896,7 @@ exp_consttime_precomp(
         uint64_t *os = a_bits_l;
         uint64_t x = (c & res_j[i]) | (~c & a_bits_l[i]);
         os[i] = x;
-      }
-    }
+      });
     amont_mul(n, mu, resM, a_bits_l, resM);
   }
   uint64_t tmp0[128U] = { 0U };

--- a/dist/gcc-compatible/Hacl_Bignum4096.c
+++ b/dist/gcc-compatible/Hacl_Bignum4096.c
@@ -83,14 +83,6 @@ uint64_t Hacl_Bignum4096_add(uint64_t *a, uint64_t *b, uint64_t *res)
     uint64_t t2 = b[(uint32_t)4U * i + (uint32_t)3U];
     uint64_t *res_i = res + (uint32_t)4U * i + (uint32_t)3U;
     c = Lib_IntTypes_Intrinsics_add_carry_u64(c, t12, t2, res_i););
-  KRML_MAYBE_FOR0(i,
-    (uint32_t)64U,
-    (uint32_t)64U,
-    (uint32_t)1U,
-    uint64_t t1 = a[i];
-    uint64_t t2 = b[i];
-    uint64_t *res_i = res + i;
-    c = Lib_IntTypes_Intrinsics_add_carry_u64(c, t1, t2, res_i););
   return c;
 }
 
@@ -124,14 +116,6 @@ uint64_t Hacl_Bignum4096_sub(uint64_t *a, uint64_t *b, uint64_t *res)
     uint64_t t2 = b[(uint32_t)4U * i + (uint32_t)3U];
     uint64_t *res_i = res + (uint32_t)4U * i + (uint32_t)3U;
     c = Lib_IntTypes_Intrinsics_sub_borrow_u64(c, t12, t2, res_i););
-  KRML_MAYBE_FOR0(i,
-    (uint32_t)64U,
-    (uint32_t)64U,
-    (uint32_t)1U,
-    uint64_t t1 = a[i];
-    uint64_t t2 = b[i];
-    uint64_t *res_i = res + i;
-    c = Lib_IntTypes_Intrinsics_sub_borrow_u64(c, t1, t2, res_i););
   return c;
 }
 
@@ -168,14 +152,6 @@ void Hacl_Bignum4096_add_mod(uint64_t *n, uint64_t *a, uint64_t *b, uint64_t *re
     uint64_t t2 = b[(uint32_t)4U * i + (uint32_t)3U];
     uint64_t *res_i = res + (uint32_t)4U * i + (uint32_t)3U;
     c0 = Lib_IntTypes_Intrinsics_add_carry_u64(c0, t12, t2, res_i););
-  KRML_MAYBE_FOR0(i,
-    (uint32_t)64U,
-    (uint32_t)64U,
-    (uint32_t)1U,
-    uint64_t t1 = a[i];
-    uint64_t t2 = b[i];
-    uint64_t *res_i = res + i;
-    c0 = Lib_IntTypes_Intrinsics_add_carry_u64(c0, t1, t2, res_i););
   uint64_t c00 = c0;
   uint64_t tmp[64U] = { 0U };
   uint64_t c = (uint64_t)0U;
@@ -199,14 +175,6 @@ void Hacl_Bignum4096_add_mod(uint64_t *n, uint64_t *a, uint64_t *b, uint64_t *re
     uint64_t t2 = n[(uint32_t)4U * i + (uint32_t)3U];
     uint64_t *res_i = tmp + (uint32_t)4U * i + (uint32_t)3U;
     c = Lib_IntTypes_Intrinsics_sub_borrow_u64(c, t12, t2, res_i););
-  KRML_MAYBE_FOR0(i,
-    (uint32_t)64U,
-    (uint32_t)64U,
-    (uint32_t)1U,
-    uint64_t t1 = res[i];
-    uint64_t t2 = n[i];
-    uint64_t *res_i = tmp + i;
-    c = Lib_IntTypes_Intrinsics_sub_borrow_u64(c, t1, t2, res_i););
   uint64_t c1 = c;
   uint64_t c2 = c00 - c1;
   for (uint32_t i = (uint32_t)0U; i < (uint32_t)64U; i++)
@@ -250,14 +218,6 @@ void Hacl_Bignum4096_sub_mod(uint64_t *n, uint64_t *a, uint64_t *b, uint64_t *re
     uint64_t t2 = b[(uint32_t)4U * i + (uint32_t)3U];
     uint64_t *res_i = res + (uint32_t)4U * i + (uint32_t)3U;
     c0 = Lib_IntTypes_Intrinsics_sub_borrow_u64(c0, t12, t2, res_i););
-  KRML_MAYBE_FOR0(i,
-    (uint32_t)64U,
-    (uint32_t)64U,
-    (uint32_t)1U,
-    uint64_t t1 = a[i];
-    uint64_t t2 = b[i];
-    uint64_t *res_i = res + i;
-    c0 = Lib_IntTypes_Intrinsics_sub_borrow_u64(c0, t1, t2, res_i););
   uint64_t c00 = c0;
   uint64_t tmp[64U] = { 0U };
   uint64_t c = (uint64_t)0U;
@@ -281,14 +241,6 @@ void Hacl_Bignum4096_sub_mod(uint64_t *n, uint64_t *a, uint64_t *b, uint64_t *re
     uint64_t t2 = n[(uint32_t)4U * i + (uint32_t)3U];
     uint64_t *res_i = tmp + (uint32_t)4U * i + (uint32_t)3U;
     c = Lib_IntTypes_Intrinsics_add_carry_u64(c, t12, t2, res_i););
-  KRML_MAYBE_FOR0(i,
-    (uint32_t)64U,
-    (uint32_t)64U,
-    (uint32_t)1U,
-    uint64_t t1 = res[i];
-    uint64_t t2 = n[i];
-    uint64_t *res_i = tmp + i;
-    c = Lib_IntTypes_Intrinsics_add_carry_u64(c, t1, t2, res_i););
   uint64_t c1 = c;
   uint64_t c2 = (uint64_t)0U - c00;
   for (uint32_t i = (uint32_t)0U; i < (uint32_t)64U; i++)
@@ -359,13 +311,6 @@ static inline void reduction(uint64_t *n, uint64_t nInv, uint64_t *c, uint64_t *
       uint64_t a_i2 = n[(uint32_t)4U * i + (uint32_t)3U];
       uint64_t *res_i = res_j0 + (uint32_t)4U * i + (uint32_t)3U;
       c1 = Hacl_Bignum_Base_mul_wide_add2_u64(a_i2, qj, c1, res_i););
-    KRML_MAYBE_FOR0(i,
-      (uint32_t)64U,
-      (uint32_t)64U,
-      (uint32_t)1U,
-      uint64_t a_i = n[i];
-      uint64_t *res_i = res_j0 + i;
-      c1 = Hacl_Bignum_Base_mul_wide_add2_u64(a_i, qj, c1, res_i););
     uint64_t r = c1;
     uint64_t c10 = r;
     uint64_t *resb = c + (uint32_t)64U + i0;
@@ -396,14 +341,6 @@ static inline void reduction(uint64_t *n, uint64_t nInv, uint64_t *c, uint64_t *
     uint64_t t2 = n[(uint32_t)4U * i + (uint32_t)3U];
     uint64_t *res_i = tmp + (uint32_t)4U * i + (uint32_t)3U;
     c1 = Lib_IntTypes_Intrinsics_sub_borrow_u64(c1, t12, t2, res_i););
-  KRML_MAYBE_FOR0(i,
-    (uint32_t)64U,
-    (uint32_t)64U,
-    (uint32_t)1U,
-    uint64_t t1 = res[i];
-    uint64_t t2 = n[i];
-    uint64_t *res_i = tmp + i;
-    c1 = Lib_IntTypes_Intrinsics_sub_borrow_u64(c1, t1, t2, res_i););
   uint64_t c10 = c1;
   uint64_t c2 = c00 - c10;
   for (uint32_t i = (uint32_t)0U; i < (uint32_t)64U; i++)
@@ -438,13 +375,6 @@ static inline void areduction(uint64_t *n, uint64_t nInv, uint64_t *c, uint64_t 
       uint64_t a_i2 = n[(uint32_t)4U * i + (uint32_t)3U];
       uint64_t *res_i = res_j0 + (uint32_t)4U * i + (uint32_t)3U;
       c1 = Hacl_Bignum_Base_mul_wide_add2_u64(a_i2, qj, c1, res_i););
-    KRML_MAYBE_FOR0(i,
-      (uint32_t)64U,
-      (uint32_t)64U,
-      (uint32_t)1U,
-      uint64_t a_i = n[i];
-      uint64_t *res_i = res_j0 + i;
-      c1 = Hacl_Bignum_Base_mul_wide_add2_u64(a_i, qj, c1, res_i););
     uint64_t r = c1;
     uint64_t c10 = r;
     uint64_t *resb = c + (uint32_t)64U + i0;
@@ -509,13 +439,6 @@ bn_slow_precomp(uint64_t *n, uint64_t mu, uint64_t *r2, uint64_t *a, uint64_t *r
       uint64_t a_i2 = n[(uint32_t)4U * i + (uint32_t)3U];
       uint64_t *res_i = res_j0 + (uint32_t)4U * i + (uint32_t)3U;
       c = Hacl_Bignum_Base_mul_wide_add2_u64(a_i2, qj, c, res_i););
-    KRML_MAYBE_FOR0(i,
-      (uint32_t)64U,
-      (uint32_t)64U,
-      (uint32_t)1U,
-      uint64_t a_i = n[i];
-      uint64_t *res_i = res_j0 + i;
-      c = Hacl_Bignum_Base_mul_wide_add2_u64(a_i, qj, c, res_i););
     uint64_t r = c;
     uint64_t c1 = r;
     uint64_t *resb = a1 + (uint32_t)64U + i0;

--- a/dist/gcc-compatible/Hacl_Bignum4096_32.c
+++ b/dist/gcc-compatible/Hacl_Bignum4096_32.c
@@ -82,13 +82,14 @@ uint32_t Hacl_Bignum4096_32_add(uint32_t *a, uint32_t *b, uint32_t *res)
     uint32_t *res_i = res + (uint32_t)4U * i + (uint32_t)3U;
     c = Lib_IntTypes_Intrinsics_add_carry_u32(c, t12, t2, res_i);
   }
-  for (uint32_t i = (uint32_t)128U; i < (uint32_t)128U; i++)
-  {
+  KRML_MAYBE_FOR0(i,
+    (uint32_t)128U,
+    (uint32_t)128U,
+    (uint32_t)1U,
     uint32_t t1 = a[i];
     uint32_t t2 = b[i];
     uint32_t *res_i = res + i;
-    c = Lib_IntTypes_Intrinsics_add_carry_u32(c, t1, t2, res_i);
-  }
+    c = Lib_IntTypes_Intrinsics_add_carry_u32(c, t1, t2, res_i););
   return c;
 }
 
@@ -121,13 +122,14 @@ uint32_t Hacl_Bignum4096_32_sub(uint32_t *a, uint32_t *b, uint32_t *res)
     uint32_t *res_i = res + (uint32_t)4U * i + (uint32_t)3U;
     c = Lib_IntTypes_Intrinsics_sub_borrow_u32(c, t12, t2, res_i);
   }
-  for (uint32_t i = (uint32_t)128U; i < (uint32_t)128U; i++)
-  {
+  KRML_MAYBE_FOR0(i,
+    (uint32_t)128U,
+    (uint32_t)128U,
+    (uint32_t)1U,
     uint32_t t1 = a[i];
     uint32_t t2 = b[i];
     uint32_t *res_i = res + i;
-    c = Lib_IntTypes_Intrinsics_sub_borrow_u32(c, t1, t2, res_i);
-  }
+    c = Lib_IntTypes_Intrinsics_sub_borrow_u32(c, t1, t2, res_i););
   return c;
 }
 
@@ -163,13 +165,14 @@ void Hacl_Bignum4096_32_add_mod(uint32_t *n, uint32_t *a, uint32_t *b, uint32_t 
     uint32_t *res_i = res + (uint32_t)4U * i + (uint32_t)3U;
     c0 = Lib_IntTypes_Intrinsics_add_carry_u32(c0, t12, t2, res_i);
   }
-  for (uint32_t i = (uint32_t)128U; i < (uint32_t)128U; i++)
-  {
+  KRML_MAYBE_FOR0(i,
+    (uint32_t)128U,
+    (uint32_t)128U,
+    (uint32_t)1U,
     uint32_t t1 = a[i];
     uint32_t t2 = b[i];
     uint32_t *res_i = res + i;
-    c0 = Lib_IntTypes_Intrinsics_add_carry_u32(c0, t1, t2, res_i);
-  }
+    c0 = Lib_IntTypes_Intrinsics_add_carry_u32(c0, t1, t2, res_i););
   uint32_t c00 = c0;
   uint32_t tmp[128U] = { 0U };
   uint32_t c = (uint32_t)0U;
@@ -192,13 +195,14 @@ void Hacl_Bignum4096_32_add_mod(uint32_t *n, uint32_t *a, uint32_t *b, uint32_t 
     uint32_t *res_i = tmp + (uint32_t)4U * i + (uint32_t)3U;
     c = Lib_IntTypes_Intrinsics_sub_borrow_u32(c, t12, t2, res_i);
   }
-  for (uint32_t i = (uint32_t)128U; i < (uint32_t)128U; i++)
-  {
+  KRML_MAYBE_FOR0(i,
+    (uint32_t)128U,
+    (uint32_t)128U,
+    (uint32_t)1U,
     uint32_t t1 = res[i];
     uint32_t t2 = n[i];
     uint32_t *res_i = tmp + i;
-    c = Lib_IntTypes_Intrinsics_sub_borrow_u32(c, t1, t2, res_i);
-  }
+    c = Lib_IntTypes_Intrinsics_sub_borrow_u32(c, t1, t2, res_i););
   uint32_t c1 = c;
   uint32_t c2 = c00 - c1;
   for (uint32_t i = (uint32_t)0U; i < (uint32_t)128U; i++)
@@ -241,13 +245,14 @@ void Hacl_Bignum4096_32_sub_mod(uint32_t *n, uint32_t *a, uint32_t *b, uint32_t 
     uint32_t *res_i = res + (uint32_t)4U * i + (uint32_t)3U;
     c0 = Lib_IntTypes_Intrinsics_sub_borrow_u32(c0, t12, t2, res_i);
   }
-  for (uint32_t i = (uint32_t)128U; i < (uint32_t)128U; i++)
-  {
+  KRML_MAYBE_FOR0(i,
+    (uint32_t)128U,
+    (uint32_t)128U,
+    (uint32_t)1U,
     uint32_t t1 = a[i];
     uint32_t t2 = b[i];
     uint32_t *res_i = res + i;
-    c0 = Lib_IntTypes_Intrinsics_sub_borrow_u32(c0, t1, t2, res_i);
-  }
+    c0 = Lib_IntTypes_Intrinsics_sub_borrow_u32(c0, t1, t2, res_i););
   uint32_t c00 = c0;
   uint32_t tmp[128U] = { 0U };
   uint32_t c = (uint32_t)0U;
@@ -270,13 +275,14 @@ void Hacl_Bignum4096_32_sub_mod(uint32_t *n, uint32_t *a, uint32_t *b, uint32_t 
     uint32_t *res_i = tmp + (uint32_t)4U * i + (uint32_t)3U;
     c = Lib_IntTypes_Intrinsics_add_carry_u32(c, t12, t2, res_i);
   }
-  for (uint32_t i = (uint32_t)128U; i < (uint32_t)128U; i++)
-  {
+  KRML_MAYBE_FOR0(i,
+    (uint32_t)128U,
+    (uint32_t)128U,
+    (uint32_t)1U,
     uint32_t t1 = res[i];
     uint32_t t2 = n[i];
     uint32_t *res_i = tmp + i;
-    c = Lib_IntTypes_Intrinsics_add_carry_u32(c, t1, t2, res_i);
-  }
+    c = Lib_IntTypes_Intrinsics_add_carry_u32(c, t1, t2, res_i););
   uint32_t c1 = c;
   uint32_t c2 = (uint32_t)0U - c00;
   for (uint32_t i = (uint32_t)0U; i < (uint32_t)128U; i++)
@@ -346,12 +352,13 @@ static inline void reduction(uint32_t *n, uint32_t nInv, uint32_t *c, uint32_t *
       uint32_t *res_i = res_j0 + (uint32_t)4U * i + (uint32_t)3U;
       c1 = Hacl_Bignum_Base_mul_wide_add2_u32(a_i2, qj, c1, res_i);
     }
-    for (uint32_t i = (uint32_t)128U; i < (uint32_t)128U; i++)
-    {
+    KRML_MAYBE_FOR0(i,
+      (uint32_t)128U,
+      (uint32_t)128U,
+      (uint32_t)1U,
       uint32_t a_i = n[i];
       uint32_t *res_i = res_j0 + i;
-      c1 = Hacl_Bignum_Base_mul_wide_add2_u32(a_i, qj, c1, res_i);
-    }
+      c1 = Hacl_Bignum_Base_mul_wide_add2_u32(a_i, qj, c1, res_i););
     uint32_t r = c1;
     uint32_t c10 = r;
     uint32_t *resb = c + (uint32_t)128U + i0;
@@ -381,13 +388,14 @@ static inline void reduction(uint32_t *n, uint32_t nInv, uint32_t *c, uint32_t *
     uint32_t *res_i = tmp + (uint32_t)4U * i + (uint32_t)3U;
     c1 = Lib_IntTypes_Intrinsics_sub_borrow_u32(c1, t12, t2, res_i);
   }
-  for (uint32_t i = (uint32_t)128U; i < (uint32_t)128U; i++)
-  {
+  KRML_MAYBE_FOR0(i,
+    (uint32_t)128U,
+    (uint32_t)128U,
+    (uint32_t)1U,
     uint32_t t1 = res[i];
     uint32_t t2 = n[i];
     uint32_t *res_i = tmp + i;
-    c1 = Lib_IntTypes_Intrinsics_sub_borrow_u32(c1, t1, t2, res_i);
-  }
+    c1 = Lib_IntTypes_Intrinsics_sub_borrow_u32(c1, t1, t2, res_i););
   uint32_t c10 = c1;
   uint32_t c2 = c00 - c10;
   for (uint32_t i = (uint32_t)0U; i < (uint32_t)128U; i++)
@@ -421,12 +429,13 @@ static inline void areduction(uint32_t *n, uint32_t nInv, uint32_t *c, uint32_t 
       uint32_t *res_i = res_j0 + (uint32_t)4U * i + (uint32_t)3U;
       c1 = Hacl_Bignum_Base_mul_wide_add2_u32(a_i2, qj, c1, res_i);
     }
-    for (uint32_t i = (uint32_t)128U; i < (uint32_t)128U; i++)
-    {
+    KRML_MAYBE_FOR0(i,
+      (uint32_t)128U,
+      (uint32_t)128U,
+      (uint32_t)1U,
       uint32_t a_i = n[i];
       uint32_t *res_i = res_j0 + i;
-      c1 = Hacl_Bignum_Base_mul_wide_add2_u32(a_i, qj, c1, res_i);
-    }
+      c1 = Hacl_Bignum_Base_mul_wide_add2_u32(a_i, qj, c1, res_i););
     uint32_t r = c1;
     uint32_t c10 = r;
     uint32_t *resb = c + (uint32_t)128U + i0;
@@ -490,12 +499,13 @@ bn_slow_precomp(uint32_t *n, uint32_t mu, uint32_t *r2, uint32_t *a, uint32_t *r
       uint32_t *res_i = res_j0 + (uint32_t)4U * i + (uint32_t)3U;
       c = Hacl_Bignum_Base_mul_wide_add2_u32(a_i2, qj, c, res_i);
     }
-    for (uint32_t i = (uint32_t)128U; i < (uint32_t)128U; i++)
-    {
+    KRML_MAYBE_FOR0(i,
+      (uint32_t)128U,
+      (uint32_t)128U,
+      (uint32_t)1U,
       uint32_t a_i = n[i];
       uint32_t *res_i = res_j0 + i;
-      c = Hacl_Bignum_Base_mul_wide_add2_u32(a_i, qj, c, res_i);
-    }
+      c = Hacl_Bignum_Base_mul_wide_add2_u32(a_i, qj, c, res_i););
     uint32_t r = c;
     uint32_t c1 = r;
     uint32_t *resb = a1 + (uint32_t)128U + i0;
@@ -679,12 +689,13 @@ exp_vartime_precomp(
   memcpy(table, resM, (uint32_t)128U * sizeof (uint32_t));
   uint32_t *t1 = table + (uint32_t)128U;
   memcpy(t1, aM, (uint32_t)128U * sizeof (uint32_t));
-  for (uint32_t i = (uint32_t)0U; i < (uint32_t)15U; i++)
-  {
+  KRML_MAYBE_FOR15(i,
+    (uint32_t)0U,
+    (uint32_t)15U,
+    (uint32_t)1U,
     uint32_t *t11 = table + i * (uint32_t)128U;
     uint32_t *t2 = table + i * (uint32_t)128U + (uint32_t)128U;
-    amont_mul(n, mu, aM, t11, t2);
-  }
+    amont_mul(n, mu, aM, t11, t2););
   if (bBits % (uint32_t)4U != (uint32_t)0U)
   {
     uint32_t mask_l = (uint32_t)16U - (uint32_t)1U;
@@ -707,10 +718,7 @@ exp_vartime_precomp(
   }
   for (uint32_t i = (uint32_t)0U; i < bBits / (uint32_t)4U; i++)
   {
-    for (uint32_t i0 = (uint32_t)0U; i0 < (uint32_t)4U; i0++)
-    {
-      amont_sqr(n, mu, resM, resM);
-    }
+    KRML_MAYBE_FOR4(i0, (uint32_t)0U, (uint32_t)4U, (uint32_t)1U, amont_sqr(n, mu, resM, resM););
     uint32_t bk = bBits - bBits % (uint32_t)4U;
     uint32_t mask_l = (uint32_t)16U - (uint32_t)1U;
     uint32_t i1 = (bk - (uint32_t)4U * i - (uint32_t)4U) / (uint32_t)32U;
@@ -809,12 +817,13 @@ exp_consttime_precomp(
   memcpy(table, resM, (uint32_t)128U * sizeof (uint32_t));
   uint32_t *t1 = table + (uint32_t)128U;
   memcpy(t1, aM, (uint32_t)128U * sizeof (uint32_t));
-  for (uint32_t i = (uint32_t)0U; i < (uint32_t)15U; i++)
-  {
+  KRML_MAYBE_FOR15(i,
+    (uint32_t)0U,
+    (uint32_t)15U,
+    (uint32_t)1U,
     uint32_t *t11 = table + i * (uint32_t)128U;
     uint32_t *t2 = table + i * (uint32_t)128U + (uint32_t)128U;
-    amont_mul(n, mu, aM, t11, t2);
-  }
+    amont_mul(n, mu, aM, t11, t2););
   if (bBits % (uint32_t)4U != (uint32_t)0U)
   {
     uint32_t mask_l = (uint32_t)16U - (uint32_t)1U;
@@ -832,8 +841,10 @@ exp_consttime_precomp(
     }
     uint32_t bits_c = ite & mask_l;
     memcpy(resM, table, (uint32_t)128U * sizeof (uint32_t));
-    for (uint32_t i1 = (uint32_t)0U; i1 < (uint32_t)15U; i1++)
-    {
+    KRML_MAYBE_FOR15(i1,
+      (uint32_t)0U,
+      (uint32_t)15U,
+      (uint32_t)1U,
       uint32_t c = FStar_UInt32_eq_mask(bits_c, i1 + (uint32_t)1U);
       uint32_t *res_j = table + (i1 + (uint32_t)1U) * (uint32_t)128U;
       for (uint32_t i = (uint32_t)0U; i < (uint32_t)128U; i++)
@@ -841,15 +852,11 @@ exp_consttime_precomp(
         uint32_t *os = resM;
         uint32_t x = (c & res_j[i]) | (~c & resM[i]);
         os[i] = x;
-      }
-    }
+      });
   }
   for (uint32_t i0 = (uint32_t)0U; i0 < bBits / (uint32_t)4U; i0++)
   {
-    for (uint32_t i = (uint32_t)0U; i < (uint32_t)4U; i++)
-    {
-      amont_sqr(n, mu, resM, resM);
-    }
+    KRML_MAYBE_FOR4(i, (uint32_t)0U, (uint32_t)4U, (uint32_t)1U, amont_sqr(n, mu, resM, resM););
     uint32_t bk = bBits - bBits % (uint32_t)4U;
     uint32_t mask_l = (uint32_t)16U - (uint32_t)1U;
     uint32_t i1 = (bk - (uint32_t)4U * i0 - (uint32_t)4U) / (uint32_t)32U;
@@ -867,8 +874,10 @@ exp_consttime_precomp(
     uint32_t bits_l = ite & mask_l;
     uint32_t a_bits_l[128U] = { 0U };
     memcpy(a_bits_l, table, (uint32_t)128U * sizeof (uint32_t));
-    for (uint32_t i2 = (uint32_t)0U; i2 < (uint32_t)15U; i2++)
-    {
+    KRML_MAYBE_FOR15(i2,
+      (uint32_t)0U,
+      (uint32_t)15U,
+      (uint32_t)1U,
       uint32_t c = FStar_UInt32_eq_mask(bits_l, i2 + (uint32_t)1U);
       uint32_t *res_j = table + (i2 + (uint32_t)1U) * (uint32_t)128U;
       for (uint32_t i = (uint32_t)0U; i < (uint32_t)128U; i++)
@@ -876,8 +885,7 @@ exp_consttime_precomp(
         uint32_t *os = a_bits_l;
         uint32_t x = (c & res_j[i]) | (~c & a_bits_l[i]);
         os[i] = x;
-      }
-    }
+      });
     amont_mul(n, mu, resM, a_bits_l, resM);
   }
   uint32_t tmp0[256U] = { 0U };

--- a/dist/gcc-compatible/Hacl_Bignum4096_32.c
+++ b/dist/gcc-compatible/Hacl_Bignum4096_32.c
@@ -82,14 +82,6 @@ uint32_t Hacl_Bignum4096_32_add(uint32_t *a, uint32_t *b, uint32_t *res)
     uint32_t *res_i = res + (uint32_t)4U * i + (uint32_t)3U;
     c = Lib_IntTypes_Intrinsics_add_carry_u32(c, t12, t2, res_i);
   }
-  KRML_MAYBE_FOR0(i,
-    (uint32_t)128U,
-    (uint32_t)128U,
-    (uint32_t)1U,
-    uint32_t t1 = a[i];
-    uint32_t t2 = b[i];
-    uint32_t *res_i = res + i;
-    c = Lib_IntTypes_Intrinsics_add_carry_u32(c, t1, t2, res_i););
   return c;
 }
 
@@ -122,14 +114,6 @@ uint32_t Hacl_Bignum4096_32_sub(uint32_t *a, uint32_t *b, uint32_t *res)
     uint32_t *res_i = res + (uint32_t)4U * i + (uint32_t)3U;
     c = Lib_IntTypes_Intrinsics_sub_borrow_u32(c, t12, t2, res_i);
   }
-  KRML_MAYBE_FOR0(i,
-    (uint32_t)128U,
-    (uint32_t)128U,
-    (uint32_t)1U,
-    uint32_t t1 = a[i];
-    uint32_t t2 = b[i];
-    uint32_t *res_i = res + i;
-    c = Lib_IntTypes_Intrinsics_sub_borrow_u32(c, t1, t2, res_i););
   return c;
 }
 
@@ -165,14 +149,6 @@ void Hacl_Bignum4096_32_add_mod(uint32_t *n, uint32_t *a, uint32_t *b, uint32_t 
     uint32_t *res_i = res + (uint32_t)4U * i + (uint32_t)3U;
     c0 = Lib_IntTypes_Intrinsics_add_carry_u32(c0, t12, t2, res_i);
   }
-  KRML_MAYBE_FOR0(i,
-    (uint32_t)128U,
-    (uint32_t)128U,
-    (uint32_t)1U,
-    uint32_t t1 = a[i];
-    uint32_t t2 = b[i];
-    uint32_t *res_i = res + i;
-    c0 = Lib_IntTypes_Intrinsics_add_carry_u32(c0, t1, t2, res_i););
   uint32_t c00 = c0;
   uint32_t tmp[128U] = { 0U };
   uint32_t c = (uint32_t)0U;
@@ -195,14 +171,6 @@ void Hacl_Bignum4096_32_add_mod(uint32_t *n, uint32_t *a, uint32_t *b, uint32_t 
     uint32_t *res_i = tmp + (uint32_t)4U * i + (uint32_t)3U;
     c = Lib_IntTypes_Intrinsics_sub_borrow_u32(c, t12, t2, res_i);
   }
-  KRML_MAYBE_FOR0(i,
-    (uint32_t)128U,
-    (uint32_t)128U,
-    (uint32_t)1U,
-    uint32_t t1 = res[i];
-    uint32_t t2 = n[i];
-    uint32_t *res_i = tmp + i;
-    c = Lib_IntTypes_Intrinsics_sub_borrow_u32(c, t1, t2, res_i););
   uint32_t c1 = c;
   uint32_t c2 = c00 - c1;
   for (uint32_t i = (uint32_t)0U; i < (uint32_t)128U; i++)
@@ -245,14 +213,6 @@ void Hacl_Bignum4096_32_sub_mod(uint32_t *n, uint32_t *a, uint32_t *b, uint32_t 
     uint32_t *res_i = res + (uint32_t)4U * i + (uint32_t)3U;
     c0 = Lib_IntTypes_Intrinsics_sub_borrow_u32(c0, t12, t2, res_i);
   }
-  KRML_MAYBE_FOR0(i,
-    (uint32_t)128U,
-    (uint32_t)128U,
-    (uint32_t)1U,
-    uint32_t t1 = a[i];
-    uint32_t t2 = b[i];
-    uint32_t *res_i = res + i;
-    c0 = Lib_IntTypes_Intrinsics_sub_borrow_u32(c0, t1, t2, res_i););
   uint32_t c00 = c0;
   uint32_t tmp[128U] = { 0U };
   uint32_t c = (uint32_t)0U;
@@ -275,14 +235,6 @@ void Hacl_Bignum4096_32_sub_mod(uint32_t *n, uint32_t *a, uint32_t *b, uint32_t 
     uint32_t *res_i = tmp + (uint32_t)4U * i + (uint32_t)3U;
     c = Lib_IntTypes_Intrinsics_add_carry_u32(c, t12, t2, res_i);
   }
-  KRML_MAYBE_FOR0(i,
-    (uint32_t)128U,
-    (uint32_t)128U,
-    (uint32_t)1U,
-    uint32_t t1 = res[i];
-    uint32_t t2 = n[i];
-    uint32_t *res_i = tmp + i;
-    c = Lib_IntTypes_Intrinsics_add_carry_u32(c, t1, t2, res_i););
   uint32_t c1 = c;
   uint32_t c2 = (uint32_t)0U - c00;
   for (uint32_t i = (uint32_t)0U; i < (uint32_t)128U; i++)
@@ -352,13 +304,6 @@ static inline void reduction(uint32_t *n, uint32_t nInv, uint32_t *c, uint32_t *
       uint32_t *res_i = res_j0 + (uint32_t)4U * i + (uint32_t)3U;
       c1 = Hacl_Bignum_Base_mul_wide_add2_u32(a_i2, qj, c1, res_i);
     }
-    KRML_MAYBE_FOR0(i,
-      (uint32_t)128U,
-      (uint32_t)128U,
-      (uint32_t)1U,
-      uint32_t a_i = n[i];
-      uint32_t *res_i = res_j0 + i;
-      c1 = Hacl_Bignum_Base_mul_wide_add2_u32(a_i, qj, c1, res_i););
     uint32_t r = c1;
     uint32_t c10 = r;
     uint32_t *resb = c + (uint32_t)128U + i0;
@@ -388,14 +333,6 @@ static inline void reduction(uint32_t *n, uint32_t nInv, uint32_t *c, uint32_t *
     uint32_t *res_i = tmp + (uint32_t)4U * i + (uint32_t)3U;
     c1 = Lib_IntTypes_Intrinsics_sub_borrow_u32(c1, t12, t2, res_i);
   }
-  KRML_MAYBE_FOR0(i,
-    (uint32_t)128U,
-    (uint32_t)128U,
-    (uint32_t)1U,
-    uint32_t t1 = res[i];
-    uint32_t t2 = n[i];
-    uint32_t *res_i = tmp + i;
-    c1 = Lib_IntTypes_Intrinsics_sub_borrow_u32(c1, t1, t2, res_i););
   uint32_t c10 = c1;
   uint32_t c2 = c00 - c10;
   for (uint32_t i = (uint32_t)0U; i < (uint32_t)128U; i++)
@@ -429,13 +366,6 @@ static inline void areduction(uint32_t *n, uint32_t nInv, uint32_t *c, uint32_t 
       uint32_t *res_i = res_j0 + (uint32_t)4U * i + (uint32_t)3U;
       c1 = Hacl_Bignum_Base_mul_wide_add2_u32(a_i2, qj, c1, res_i);
     }
-    KRML_MAYBE_FOR0(i,
-      (uint32_t)128U,
-      (uint32_t)128U,
-      (uint32_t)1U,
-      uint32_t a_i = n[i];
-      uint32_t *res_i = res_j0 + i;
-      c1 = Hacl_Bignum_Base_mul_wide_add2_u32(a_i, qj, c1, res_i););
     uint32_t r = c1;
     uint32_t c10 = r;
     uint32_t *resb = c + (uint32_t)128U + i0;
@@ -499,13 +429,6 @@ bn_slow_precomp(uint32_t *n, uint32_t mu, uint32_t *r2, uint32_t *a, uint32_t *r
       uint32_t *res_i = res_j0 + (uint32_t)4U * i + (uint32_t)3U;
       c = Hacl_Bignum_Base_mul_wide_add2_u32(a_i2, qj, c, res_i);
     }
-    KRML_MAYBE_FOR0(i,
-      (uint32_t)128U,
-      (uint32_t)128U,
-      (uint32_t)1U,
-      uint32_t a_i = n[i];
-      uint32_t *res_i = res_j0 + i;
-      c = Hacl_Bignum_Base_mul_wide_add2_u32(a_i, qj, c, res_i););
     uint32_t r = c;
     uint32_t c1 = r;
     uint32_t *resb = a1 + (uint32_t)128U + i0;

--- a/dist/gcc-compatible/Hacl_Bignum_K256.h
+++ b/dist/gcc-compatible/Hacl_Bignum_K256.h
@@ -105,15 +105,16 @@ static inline bool Hacl_K256_Field_is_felem_lt_prime_minus_order_vartime(uint64_
 static inline void Hacl_K256_Field_load_felem(uint64_t *f, uint8_t *b)
 {
   uint64_t tmp[4U] = { 0U };
-  for (uint32_t i = (uint32_t)0U; i < (uint32_t)4U; i++)
-  {
+  KRML_MAYBE_FOR4(i,
+    (uint32_t)0U,
+    (uint32_t)4U,
+    (uint32_t)1U,
     uint64_t *os = tmp;
     uint8_t *bj = b + i * (uint32_t)8U;
     uint64_t u = load64_be(bj);
     uint64_t r = u;
     uint64_t x = r;
-    os[i] = x;
-  }
+    os[i] = x;);
   uint64_t s0 = tmp[3U];
   uint64_t s1 = tmp[2U];
   uint64_t s2 = tmp[1U];
@@ -178,10 +179,11 @@ static inline void Hacl_K256_Field_store_felem(uint8_t *b, uint64_t *f)
   tmp[1U] = f2;
   tmp[2U] = f1;
   tmp[3U] = f0;
-  for (uint32_t i = (uint32_t)0U; i < (uint32_t)4U; i++)
-  {
-    store64_be(b + i * (uint32_t)8U, tmp[i]);
-  }
+  KRML_MAYBE_FOR4(i,
+    (uint32_t)0U,
+    (uint32_t)4U,
+    (uint32_t)1U,
+    store64_be(b + i * (uint32_t)8U, tmp[i]););
 }
 
 static inline void Hacl_K256_Field_fmul_small_num(uint64_t *out, uint64_t *f, uint64_t num)

--- a/dist/gcc-compatible/Hacl_Chacha20.c
+++ b/dist/gcc-compatible/Hacl_Chacha20.c
@@ -99,12 +99,13 @@ static inline void chacha20_core(uint32_t *k, uint32_t *ctx, uint32_t ctr)
   uint32_t ctr_u32 = ctr;
   k[12U] = k[12U] + ctr_u32;
   rounds(k);
-  for (uint32_t i = (uint32_t)0U; i < (uint32_t)16U; i++)
-  {
+  KRML_MAYBE_FOR16(i,
+    (uint32_t)0U,
+    (uint32_t)16U,
+    (uint32_t)1U,
     uint32_t *os = k;
     uint32_t x = k[i] + ctx[i];
-    os[i] = x;
-  }
+    os[i] = x;);
   k[12U] = k[12U] + ctr_u32;
 }
 
@@ -116,31 +117,34 @@ chacha20_constants[4U] =
 inline void
 Hacl_Impl_Chacha20_chacha20_init(uint32_t *ctx, uint8_t *k, uint8_t *n, uint32_t ctr)
 {
-  for (uint32_t i = (uint32_t)0U; i < (uint32_t)4U; i++)
-  {
+  KRML_MAYBE_FOR4(i,
+    (uint32_t)0U,
+    (uint32_t)4U,
+    (uint32_t)1U,
     uint32_t *os = ctx;
     uint32_t x = chacha20_constants[i];
-    os[i] = x;
-  }
-  for (uint32_t i = (uint32_t)0U; i < (uint32_t)8U; i++)
-  {
+    os[i] = x;);
+  KRML_MAYBE_FOR8(i,
+    (uint32_t)0U,
+    (uint32_t)8U,
+    (uint32_t)1U,
     uint32_t *os = ctx + (uint32_t)4U;
     uint8_t *bj = k + i * (uint32_t)4U;
     uint32_t u = load32_le(bj);
     uint32_t r = u;
     uint32_t x = r;
-    os[i] = x;
-  }
+    os[i] = x;);
   ctx[12U] = ctr;
-  for (uint32_t i = (uint32_t)0U; i < (uint32_t)3U; i++)
-  {
+  KRML_MAYBE_FOR3(i,
+    (uint32_t)0U,
+    (uint32_t)3U,
+    (uint32_t)1U,
     uint32_t *os = ctx + (uint32_t)13U;
     uint8_t *bj = n + i * (uint32_t)4U;
     uint32_t u = load32_le(bj);
     uint32_t r = u;
     uint32_t x = r;
-    os[i] = x;
-  }
+    os[i] = x;);
 }
 
 inline void
@@ -154,25 +158,28 @@ Hacl_Impl_Chacha20_chacha20_encrypt_block(
   uint32_t k[16U] = { 0U };
   chacha20_core(k, ctx, incr);
   uint32_t bl[16U] = { 0U };
-  for (uint32_t i = (uint32_t)0U; i < (uint32_t)16U; i++)
-  {
+  KRML_MAYBE_FOR16(i,
+    (uint32_t)0U,
+    (uint32_t)16U,
+    (uint32_t)1U,
     uint32_t *os = bl;
     uint8_t *bj = text + i * (uint32_t)4U;
     uint32_t u = load32_le(bj);
     uint32_t r = u;
     uint32_t x = r;
-    os[i] = x;
-  }
-  for (uint32_t i = (uint32_t)0U; i < (uint32_t)16U; i++)
-  {
+    os[i] = x;);
+  KRML_MAYBE_FOR16(i,
+    (uint32_t)0U,
+    (uint32_t)16U,
+    (uint32_t)1U,
     uint32_t *os = bl;
     uint32_t x = bl[i] ^ k[i];
-    os[i] = x;
-  }
-  for (uint32_t i = (uint32_t)0U; i < (uint32_t)16U; i++)
-  {
-    store32_le(out + i * (uint32_t)4U, bl[i]);
-  }
+    os[i] = x;);
+  KRML_MAYBE_FOR16(i,
+    (uint32_t)0U,
+    (uint32_t)16U,
+    (uint32_t)1U,
+    store32_le(out + i * (uint32_t)4U, bl[i]););
 }
 
 static inline void

--- a/dist/gcc-compatible/Hacl_Chacha20Poly1305_128.c
+++ b/dist/gcc-compatible/Hacl_Chacha20Poly1305_128.c
@@ -1167,11 +1167,12 @@ Hacl_Chacha20Poly1305_128_aead_decrypt(
   uint8_t *key = tmp;
   poly1305_do_128(key, aadlen, aad, mlen, cipher, computed_mac);
   uint8_t res = (uint8_t)255U;
-  for (uint32_t i = (uint32_t)0U; i < (uint32_t)16U; i++)
-  {
+  KRML_MAYBE_FOR16(i,
+    (uint32_t)0U,
+    (uint32_t)16U,
+    (uint32_t)1U,
     uint8_t uu____0 = FStar_UInt8_eq_mask(computed_mac[i], mac[i]);
-    res = uu____0 & res;
-  }
+    res = uu____0 & res;);
   uint8_t z = res;
   if (z == (uint8_t)255U)
   {

--- a/dist/gcc-compatible/Hacl_Chacha20Poly1305_256.c
+++ b/dist/gcc-compatible/Hacl_Chacha20Poly1305_256.c
@@ -1169,11 +1169,12 @@ Hacl_Chacha20Poly1305_256_aead_decrypt(
   uint8_t *key = tmp;
   poly1305_do_256(key, aadlen, aad, mlen, cipher, computed_mac);
   uint8_t res = (uint8_t)255U;
-  for (uint32_t i = (uint32_t)0U; i < (uint32_t)16U; i++)
-  {
+  KRML_MAYBE_FOR16(i,
+    (uint32_t)0U,
+    (uint32_t)16U,
+    (uint32_t)1U,
     uint8_t uu____0 = FStar_UInt8_eq_mask(computed_mac[i], mac[i]);
-    res = uu____0 & res;
-  }
+    res = uu____0 & res;);
   uint8_t z = res;
   if (z == (uint8_t)255U)
   {

--- a/dist/gcc-compatible/Hacl_Chacha20Poly1305_32.c
+++ b/dist/gcc-compatible/Hacl_Chacha20Poly1305_32.c
@@ -585,11 +585,12 @@ Hacl_Chacha20Poly1305_32_aead_decrypt(
   uint8_t *key = tmp;
   poly1305_do_32(key, aadlen, aad, mlen, cipher, computed_mac);
   uint8_t res = (uint8_t)255U;
-  for (uint32_t i = (uint32_t)0U; i < (uint32_t)16U; i++)
-  {
+  KRML_MAYBE_FOR16(i,
+    (uint32_t)0U,
+    (uint32_t)16U,
+    (uint32_t)1U,
     uint8_t uu____0 = FStar_UInt8_eq_mask(computed_mac[i], mac[i]);
-    res = uu____0 & res;
-  }
+    res = uu____0 & res;);
   uint8_t z = res;
   if (z == (uint8_t)255U)
   {

--- a/dist/gcc-compatible/Hacl_Chacha20_Vec128.c
+++ b/dist/gcc-compatible/Hacl_Chacha20_Vec128.c
@@ -147,12 +147,13 @@ chacha20_core_128(
   double_round_128(k);
   double_round_128(k);
   double_round_128(k);
-  for (uint32_t i = (uint32_t)0U; i < (uint32_t)16U; i++)
-  {
+  KRML_MAYBE_FOR16(i,
+    (uint32_t)0U,
+    (uint32_t)16U,
+    (uint32_t)1U,
     Lib_IntVector_Intrinsics_vec128 *os = k;
     Lib_IntVector_Intrinsics_vec128 x = Lib_IntVector_Intrinsics_vec128_add32(k[i], ctx[i]);
-    os[i] = x;
-  }
+    os[i] = x;);
   k[12U] = Lib_IntVector_Intrinsics_vec128_add32(k[12U], cv);
 }
 
@@ -160,38 +161,42 @@ static inline void
 chacha20_init_128(Lib_IntVector_Intrinsics_vec128 *ctx, uint8_t *k, uint8_t *n, uint32_t ctr)
 {
   uint32_t ctx1[16U] = { 0U };
-  for (uint32_t i = (uint32_t)0U; i < (uint32_t)4U; i++)
-  {
+  KRML_MAYBE_FOR4(i,
+    (uint32_t)0U,
+    (uint32_t)4U,
+    (uint32_t)1U,
     uint32_t *os = ctx1;
     uint32_t x = Hacl_Impl_Chacha20_Vec_chacha20_constants[i];
-    os[i] = x;
-  }
-  for (uint32_t i = (uint32_t)0U; i < (uint32_t)8U; i++)
-  {
+    os[i] = x;);
+  KRML_MAYBE_FOR8(i,
+    (uint32_t)0U,
+    (uint32_t)8U,
+    (uint32_t)1U,
     uint32_t *os = ctx1 + (uint32_t)4U;
     uint8_t *bj = k + i * (uint32_t)4U;
     uint32_t u = load32_le(bj);
     uint32_t r = u;
     uint32_t x = r;
-    os[i] = x;
-  }
+    os[i] = x;);
   ctx1[12U] = ctr;
-  for (uint32_t i = (uint32_t)0U; i < (uint32_t)3U; i++)
-  {
+  KRML_MAYBE_FOR3(i,
+    (uint32_t)0U,
+    (uint32_t)3U,
+    (uint32_t)1U,
     uint32_t *os = ctx1 + (uint32_t)13U;
     uint8_t *bj = n + i * (uint32_t)4U;
     uint32_t u = load32_le(bj);
     uint32_t r = u;
     uint32_t x = r;
-    os[i] = x;
-  }
-  for (uint32_t i = (uint32_t)0U; i < (uint32_t)16U; i++)
-  {
+    os[i] = x;);
+  KRML_MAYBE_FOR16(i,
+    (uint32_t)0U,
+    (uint32_t)16U,
+    (uint32_t)1U,
     Lib_IntVector_Intrinsics_vec128 *os = ctx;
     uint32_t x = ctx1[i];
     Lib_IntVector_Intrinsics_vec128 x0 = Lib_IntVector_Intrinsics_vec128_load32(x);
-    os[i] = x0;
-  }
+    os[i] = x0;);
   Lib_IntVector_Intrinsics_vec128
   ctr1 =
     Lib_IntVector_Intrinsics_vec128_load32s((uint32_t)0U,
@@ -351,13 +356,14 @@ Hacl_Chacha20_Vec128_chacha20_encrypt_128(
     k[13U] = v7;
     k[14U] = v11;
     k[15U] = v15;
-    for (uint32_t i0 = (uint32_t)0U; i0 < (uint32_t)16U; i0++)
-    {
+    KRML_MAYBE_FOR16(i0,
+      (uint32_t)0U,
+      (uint32_t)16U,
+      (uint32_t)1U,
       Lib_IntVector_Intrinsics_vec128
       x = Lib_IntVector_Intrinsics_vec128_load32_le(uu____1 + i0 * (uint32_t)16U);
       Lib_IntVector_Intrinsics_vec128 y = Lib_IntVector_Intrinsics_vec128_xor(x, k[i0]);
-      Lib_IntVector_Intrinsics_vec128_store32_le(uu____0 + i0 * (uint32_t)16U, y);
-    }
+      Lib_IntVector_Intrinsics_vec128_store32_le(uu____0 + i0 * (uint32_t)16U, y););
   }
   if (rem1 > (uint32_t)0U)
   {
@@ -495,13 +501,14 @@ Hacl_Chacha20_Vec128_chacha20_encrypt_128(
     k[13U] = v7;
     k[14U] = v11;
     k[15U] = v15;
-    for (uint32_t i = (uint32_t)0U; i < (uint32_t)16U; i++)
-    {
+    KRML_MAYBE_FOR16(i,
+      (uint32_t)0U,
+      (uint32_t)16U,
+      (uint32_t)1U,
       Lib_IntVector_Intrinsics_vec128
       x = Lib_IntVector_Intrinsics_vec128_load32_le(plain + i * (uint32_t)16U);
       Lib_IntVector_Intrinsics_vec128 y = Lib_IntVector_Intrinsics_vec128_xor(x, k[i]);
-      Lib_IntVector_Intrinsics_vec128_store32_le(plain + i * (uint32_t)16U, y);
-    }
+      Lib_IntVector_Intrinsics_vec128_store32_le(plain + i * (uint32_t)16U, y););
     memcpy(uu____2, plain, rem * sizeof (uint8_t));
   }
 }
@@ -655,13 +662,14 @@ Hacl_Chacha20_Vec128_chacha20_decrypt_128(
     k[13U] = v7;
     k[14U] = v11;
     k[15U] = v15;
-    for (uint32_t i0 = (uint32_t)0U; i0 < (uint32_t)16U; i0++)
-    {
+    KRML_MAYBE_FOR16(i0,
+      (uint32_t)0U,
+      (uint32_t)16U,
+      (uint32_t)1U,
       Lib_IntVector_Intrinsics_vec128
       x = Lib_IntVector_Intrinsics_vec128_load32_le(uu____1 + i0 * (uint32_t)16U);
       Lib_IntVector_Intrinsics_vec128 y = Lib_IntVector_Intrinsics_vec128_xor(x, k[i0]);
-      Lib_IntVector_Intrinsics_vec128_store32_le(uu____0 + i0 * (uint32_t)16U, y);
-    }
+      Lib_IntVector_Intrinsics_vec128_store32_le(uu____0 + i0 * (uint32_t)16U, y););
   }
   if (rem1 > (uint32_t)0U)
   {
@@ -799,13 +807,14 @@ Hacl_Chacha20_Vec128_chacha20_decrypt_128(
     k[13U] = v7;
     k[14U] = v11;
     k[15U] = v15;
-    for (uint32_t i = (uint32_t)0U; i < (uint32_t)16U; i++)
-    {
+    KRML_MAYBE_FOR16(i,
+      (uint32_t)0U,
+      (uint32_t)16U,
+      (uint32_t)1U,
       Lib_IntVector_Intrinsics_vec128
       x = Lib_IntVector_Intrinsics_vec128_load32_le(plain + i * (uint32_t)16U);
       Lib_IntVector_Intrinsics_vec128 y = Lib_IntVector_Intrinsics_vec128_xor(x, k[i]);
-      Lib_IntVector_Intrinsics_vec128_store32_le(plain + i * (uint32_t)16U, y);
-    }
+      Lib_IntVector_Intrinsics_vec128_store32_le(plain + i * (uint32_t)16U, y););
     memcpy(uu____2, plain, rem * sizeof (uint8_t));
   }
 }

--- a/dist/gcc-compatible/Hacl_Chacha20_Vec256.c
+++ b/dist/gcc-compatible/Hacl_Chacha20_Vec256.c
@@ -147,12 +147,13 @@ chacha20_core_256(
   double_round_256(k);
   double_round_256(k);
   double_round_256(k);
-  for (uint32_t i = (uint32_t)0U; i < (uint32_t)16U; i++)
-  {
+  KRML_MAYBE_FOR16(i,
+    (uint32_t)0U,
+    (uint32_t)16U,
+    (uint32_t)1U,
     Lib_IntVector_Intrinsics_vec256 *os = k;
     Lib_IntVector_Intrinsics_vec256 x = Lib_IntVector_Intrinsics_vec256_add32(k[i], ctx[i]);
-    os[i] = x;
-  }
+    os[i] = x;);
   k[12U] = Lib_IntVector_Intrinsics_vec256_add32(k[12U], cv);
 }
 
@@ -160,38 +161,42 @@ static inline void
 chacha20_init_256(Lib_IntVector_Intrinsics_vec256 *ctx, uint8_t *k, uint8_t *n, uint32_t ctr)
 {
   uint32_t ctx1[16U] = { 0U };
-  for (uint32_t i = (uint32_t)0U; i < (uint32_t)4U; i++)
-  {
+  KRML_MAYBE_FOR4(i,
+    (uint32_t)0U,
+    (uint32_t)4U,
+    (uint32_t)1U,
     uint32_t *os = ctx1;
     uint32_t x = Hacl_Impl_Chacha20_Vec_chacha20_constants[i];
-    os[i] = x;
-  }
-  for (uint32_t i = (uint32_t)0U; i < (uint32_t)8U; i++)
-  {
+    os[i] = x;);
+  KRML_MAYBE_FOR8(i,
+    (uint32_t)0U,
+    (uint32_t)8U,
+    (uint32_t)1U,
     uint32_t *os = ctx1 + (uint32_t)4U;
     uint8_t *bj = k + i * (uint32_t)4U;
     uint32_t u = load32_le(bj);
     uint32_t r = u;
     uint32_t x = r;
-    os[i] = x;
-  }
+    os[i] = x;);
   ctx1[12U] = ctr;
-  for (uint32_t i = (uint32_t)0U; i < (uint32_t)3U; i++)
-  {
+  KRML_MAYBE_FOR3(i,
+    (uint32_t)0U,
+    (uint32_t)3U,
+    (uint32_t)1U,
     uint32_t *os = ctx1 + (uint32_t)13U;
     uint8_t *bj = n + i * (uint32_t)4U;
     uint32_t u = load32_le(bj);
     uint32_t r = u;
     uint32_t x = r;
-    os[i] = x;
-  }
-  for (uint32_t i = (uint32_t)0U; i < (uint32_t)16U; i++)
-  {
+    os[i] = x;);
+  KRML_MAYBE_FOR16(i,
+    (uint32_t)0U,
+    (uint32_t)16U,
+    (uint32_t)1U,
     Lib_IntVector_Intrinsics_vec256 *os = ctx;
     uint32_t x = ctx1[i];
     Lib_IntVector_Intrinsics_vec256 x0 = Lib_IntVector_Intrinsics_vec256_load32(x);
-    os[i] = x0;
-  }
+    os[i] = x0;);
   Lib_IntVector_Intrinsics_vec256
   ctr1 =
     Lib_IntVector_Intrinsics_vec256_load32s((uint32_t)0U,
@@ -451,13 +456,14 @@ Hacl_Chacha20_Vec256_chacha20_encrypt_256(
     k[13U] = v14;
     k[14U] = v7;
     k[15U] = v15;
-    for (uint32_t i0 = (uint32_t)0U; i0 < (uint32_t)16U; i0++)
-    {
+    KRML_MAYBE_FOR16(i0,
+      (uint32_t)0U,
+      (uint32_t)16U,
+      (uint32_t)1U,
       Lib_IntVector_Intrinsics_vec256
       x = Lib_IntVector_Intrinsics_vec256_load32_le(uu____1 + i0 * (uint32_t)32U);
       Lib_IntVector_Intrinsics_vec256 y = Lib_IntVector_Intrinsics_vec256_xor(x, k[i0]);
-      Lib_IntVector_Intrinsics_vec256_store32_le(uu____0 + i0 * (uint32_t)32U, y);
-    }
+      Lib_IntVector_Intrinsics_vec256_store32_le(uu____0 + i0 * (uint32_t)32U, y););
   }
   if (rem1 > (uint32_t)0U)
   {
@@ -691,13 +697,14 @@ Hacl_Chacha20_Vec256_chacha20_encrypt_256(
     k[13U] = v14;
     k[14U] = v7;
     k[15U] = v15;
-    for (uint32_t i = (uint32_t)0U; i < (uint32_t)16U; i++)
-    {
+    KRML_MAYBE_FOR16(i,
+      (uint32_t)0U,
+      (uint32_t)16U,
+      (uint32_t)1U,
       Lib_IntVector_Intrinsics_vec256
       x = Lib_IntVector_Intrinsics_vec256_load32_le(plain + i * (uint32_t)32U);
       Lib_IntVector_Intrinsics_vec256 y = Lib_IntVector_Intrinsics_vec256_xor(x, k[i]);
-      Lib_IntVector_Intrinsics_vec256_store32_le(plain + i * (uint32_t)32U, y);
-    }
+      Lib_IntVector_Intrinsics_vec256_store32_le(plain + i * (uint32_t)32U, y););
     memcpy(uu____2, plain, rem * sizeof (uint8_t));
   }
 }
@@ -947,13 +954,14 @@ Hacl_Chacha20_Vec256_chacha20_decrypt_256(
     k[13U] = v14;
     k[14U] = v7;
     k[15U] = v15;
-    for (uint32_t i0 = (uint32_t)0U; i0 < (uint32_t)16U; i0++)
-    {
+    KRML_MAYBE_FOR16(i0,
+      (uint32_t)0U,
+      (uint32_t)16U,
+      (uint32_t)1U,
       Lib_IntVector_Intrinsics_vec256
       x = Lib_IntVector_Intrinsics_vec256_load32_le(uu____1 + i0 * (uint32_t)32U);
       Lib_IntVector_Intrinsics_vec256 y = Lib_IntVector_Intrinsics_vec256_xor(x, k[i0]);
-      Lib_IntVector_Intrinsics_vec256_store32_le(uu____0 + i0 * (uint32_t)32U, y);
-    }
+      Lib_IntVector_Intrinsics_vec256_store32_le(uu____0 + i0 * (uint32_t)32U, y););
   }
   if (rem1 > (uint32_t)0U)
   {
@@ -1187,13 +1195,14 @@ Hacl_Chacha20_Vec256_chacha20_decrypt_256(
     k[13U] = v14;
     k[14U] = v7;
     k[15U] = v15;
-    for (uint32_t i = (uint32_t)0U; i < (uint32_t)16U; i++)
-    {
+    KRML_MAYBE_FOR16(i,
+      (uint32_t)0U,
+      (uint32_t)16U,
+      (uint32_t)1U,
       Lib_IntVector_Intrinsics_vec256
       x = Lib_IntVector_Intrinsics_vec256_load32_le(plain + i * (uint32_t)32U);
       Lib_IntVector_Intrinsics_vec256 y = Lib_IntVector_Intrinsics_vec256_xor(x, k[i]);
-      Lib_IntVector_Intrinsics_vec256_store32_le(plain + i * (uint32_t)32U, y);
-    }
+      Lib_IntVector_Intrinsics_vec256_store32_le(plain + i * (uint32_t)32U, y););
     memcpy(uu____2, plain, rem * sizeof (uint8_t));
   }
 }

--- a/dist/gcc-compatible/Hacl_Chacha20_Vec32.c
+++ b/dist/gcc-compatible/Hacl_Chacha20_Vec32.c
@@ -142,49 +142,54 @@ static inline void chacha20_core_32(uint32_t *k, uint32_t *ctx, uint32_t ctr)
   double_round_32(k);
   double_round_32(k);
   double_round_32(k);
-  for (uint32_t i = (uint32_t)0U; i < (uint32_t)16U; i++)
-  {
+  KRML_MAYBE_FOR16(i,
+    (uint32_t)0U,
+    (uint32_t)16U,
+    (uint32_t)1U,
     uint32_t *os = k;
     uint32_t x = k[i] + ctx[i];
-    os[i] = x;
-  }
+    os[i] = x;);
   k[12U] = k[12U] + cv;
 }
 
 static inline void chacha20_init_32(uint32_t *ctx, uint8_t *k, uint8_t *n, uint32_t ctr)
 {
   uint32_t ctx1[16U] = { 0U };
-  for (uint32_t i = (uint32_t)0U; i < (uint32_t)4U; i++)
-  {
+  KRML_MAYBE_FOR4(i,
+    (uint32_t)0U,
+    (uint32_t)4U,
+    (uint32_t)1U,
     uint32_t *os = ctx1;
     uint32_t x = Hacl_Impl_Chacha20_Vec_chacha20_constants[i];
-    os[i] = x;
-  }
-  for (uint32_t i = (uint32_t)0U; i < (uint32_t)8U; i++)
-  {
+    os[i] = x;);
+  KRML_MAYBE_FOR8(i,
+    (uint32_t)0U,
+    (uint32_t)8U,
+    (uint32_t)1U,
     uint32_t *os = ctx1 + (uint32_t)4U;
     uint8_t *bj = k + i * (uint32_t)4U;
     uint32_t u = load32_le(bj);
     uint32_t r = u;
     uint32_t x = r;
-    os[i] = x;
-  }
+    os[i] = x;);
   ctx1[12U] = ctr;
-  for (uint32_t i = (uint32_t)0U; i < (uint32_t)3U; i++)
-  {
+  KRML_MAYBE_FOR3(i,
+    (uint32_t)0U,
+    (uint32_t)3U,
+    (uint32_t)1U,
     uint32_t *os = ctx1 + (uint32_t)13U;
     uint8_t *bj = n + i * (uint32_t)4U;
     uint32_t u = load32_le(bj);
     uint32_t r = u;
     uint32_t x = r;
-    os[i] = x;
-  }
-  for (uint32_t i = (uint32_t)0U; i < (uint32_t)16U; i++)
-  {
+    os[i] = x;);
+  KRML_MAYBE_FOR16(i,
+    (uint32_t)0U,
+    (uint32_t)16U,
+    (uint32_t)1U,
     uint32_t *os = ctx;
     uint32_t x = ctx1[i];
-    os[i] = x;
-  }
+    os[i] = x;);
   uint32_t ctr1 = (uint32_t)0U;
   uint32_t c12 = ctx[12U];
   ctx[12U] = c12 + ctr1;
@@ -211,13 +216,14 @@ Hacl_Chacha20_Vec32_chacha20_encrypt_32(
     uint8_t *uu____1 = text + i0 * (uint32_t)64U;
     uint32_t k[16U] = { 0U };
     chacha20_core_32(k, ctx, i0);
-    for (uint32_t i = (uint32_t)0U; i < (uint32_t)16U; i++)
-    {
+    KRML_MAYBE_FOR16(i,
+      (uint32_t)0U,
+      (uint32_t)16U,
+      (uint32_t)1U,
       uint32_t u = load32_le(uu____1 + i * (uint32_t)4U);
       uint32_t x = u;
       uint32_t y = x ^ k[i];
-      store32_le(uu____0 + i * (uint32_t)4U, y);
-    }
+      store32_le(uu____0 + i * (uint32_t)4U, y););
   }
   if (rem1 > (uint32_t)0U)
   {
@@ -227,13 +233,14 @@ Hacl_Chacha20_Vec32_chacha20_encrypt_32(
     memcpy(plain, uu____3, rem * sizeof (uint8_t));
     uint32_t k[16U] = { 0U };
     chacha20_core_32(k, ctx, nb);
-    for (uint32_t i = (uint32_t)0U; i < (uint32_t)16U; i++)
-    {
+    KRML_MAYBE_FOR16(i,
+      (uint32_t)0U,
+      (uint32_t)16U,
+      (uint32_t)1U,
       uint32_t u = load32_le(plain + i * (uint32_t)4U);
       uint32_t x = u;
       uint32_t y = x ^ k[i];
-      store32_le(plain + i * (uint32_t)4U, y);
-    }
+      store32_le(plain + i * (uint32_t)4U, y););
     memcpy(uu____2, plain, rem * sizeof (uint8_t));
   }
 }
@@ -259,13 +266,14 @@ Hacl_Chacha20_Vec32_chacha20_decrypt_32(
     uint8_t *uu____1 = cipher + i0 * (uint32_t)64U;
     uint32_t k[16U] = { 0U };
     chacha20_core_32(k, ctx, i0);
-    for (uint32_t i = (uint32_t)0U; i < (uint32_t)16U; i++)
-    {
+    KRML_MAYBE_FOR16(i,
+      (uint32_t)0U,
+      (uint32_t)16U,
+      (uint32_t)1U,
       uint32_t u = load32_le(uu____1 + i * (uint32_t)4U);
       uint32_t x = u;
       uint32_t y = x ^ k[i];
-      store32_le(uu____0 + i * (uint32_t)4U, y);
-    }
+      store32_le(uu____0 + i * (uint32_t)4U, y););
   }
   if (rem1 > (uint32_t)0U)
   {
@@ -275,13 +283,14 @@ Hacl_Chacha20_Vec32_chacha20_decrypt_32(
     memcpy(plain, uu____3, rem * sizeof (uint8_t));
     uint32_t k[16U] = { 0U };
     chacha20_core_32(k, ctx, nb);
-    for (uint32_t i = (uint32_t)0U; i < (uint32_t)16U; i++)
-    {
+    KRML_MAYBE_FOR16(i,
+      (uint32_t)0U,
+      (uint32_t)16U,
+      (uint32_t)1U,
       uint32_t u = load32_le(plain + i * (uint32_t)4U);
       uint32_t x = u;
       uint32_t y = x ^ k[i];
-      store32_le(plain + i * (uint32_t)4U, y);
-    }
+      store32_le(plain + i * (uint32_t)4U, y););
     memcpy(uu____2, plain, rem * sizeof (uint8_t));
   }
 }

--- a/dist/gcc-compatible/Hacl_Curve25519_51.c
+++ b/dist/gcc-compatible/Hacl_Curve25519_51.c
@@ -222,25 +222,27 @@ static void encode_point(uint8_t *o, uint64_t *i)
   Hacl_Curve25519_51_finv(tmp, z, tmp_w);
   Hacl_Impl_Curve25519_Field51_fmul(tmp, tmp, x, tmp_w);
   Hacl_Impl_Curve25519_Field51_store_felem(u64s, tmp);
-  for (uint32_t i0 = (uint32_t)0U; i0 < (uint32_t)4U; i0++)
-  {
-    store64_le(o + i0 * (uint32_t)8U, u64s[i0]);
-  }
+  KRML_MAYBE_FOR4(i0,
+    (uint32_t)0U,
+    (uint32_t)4U,
+    (uint32_t)1U,
+    store64_le(o + i0 * (uint32_t)8U, u64s[i0]););
 }
 
 void Hacl_Curve25519_51_scalarmult(uint8_t *out, uint8_t *priv, uint8_t *pub)
 {
   uint64_t init[10U] = { 0U };
   uint64_t tmp[4U] = { 0U };
-  for (uint32_t i = (uint32_t)0U; i < (uint32_t)4U; i++)
-  {
+  KRML_MAYBE_FOR4(i,
+    (uint32_t)0U,
+    (uint32_t)4U,
+    (uint32_t)1U,
     uint64_t *os = tmp;
     uint8_t *bj = pub + i * (uint32_t)8U;
     uint64_t u = load64_le(bj);
     uint64_t r = u;
     uint64_t x = r;
-    os[i] = x;
-  }
+    os[i] = x;);
   uint64_t tmp3 = tmp[3U];
   tmp[3U] = tmp3 & (uint64_t)0x7fffffffffffffffU;
   uint64_t *x = init;

--- a/dist/gcc-compatible/Hacl_Curve25519_64.c
+++ b/dist/gcc-compatible/Hacl_Curve25519_64.c
@@ -324,25 +324,27 @@ static void encode_point(uint8_t *o, uint64_t *i)
   finv(tmp, z, tmp_w);
   fmul0(tmp, tmp, x, tmp_w);
   store_felem(u64s, tmp);
-  for (uint32_t i0 = (uint32_t)0U; i0 < (uint32_t)4U; i0++)
-  {
-    store64_le(o + i0 * (uint32_t)8U, u64s[i0]);
-  }
+  KRML_MAYBE_FOR4(i0,
+    (uint32_t)0U,
+    (uint32_t)4U,
+    (uint32_t)1U,
+    store64_le(o + i0 * (uint32_t)8U, u64s[i0]););
 }
 
 void Hacl_Curve25519_64_scalarmult(uint8_t *out, uint8_t *priv, uint8_t *pub)
 {
   uint64_t init[8U] = { 0U };
   uint64_t tmp[4U] = { 0U };
-  for (uint32_t i = (uint32_t)0U; i < (uint32_t)4U; i++)
-  {
+  KRML_MAYBE_FOR4(i,
+    (uint32_t)0U,
+    (uint32_t)4U,
+    (uint32_t)1U,
     uint64_t *os = tmp;
     uint8_t *bj = pub + i * (uint32_t)8U;
     uint64_t u = load64_le(bj);
     uint64_t r = u;
     uint64_t x = r;
-    os[i] = x;
-  }
+    os[i] = x;);
   uint64_t tmp3 = tmp[3U];
   tmp[3U] = tmp3 & (uint64_t)0x7fffffffffffffffU;
   uint64_t *x = init;

--- a/dist/gcc-compatible/Hacl_Curve25519_64_Slow.c
+++ b/dist/gcc-compatible/Hacl_Curve25519_64_Slow.c
@@ -66,34 +66,24 @@ static inline uint64_t add1_(uint64_t *out, uint64_t *f1, uint64_t f2)
 static inline void fadd_(uint64_t *out, uint64_t *f1, uint64_t *f2)
 {
   uint64_t c0 = (uint64_t)0U;
-  KRML_MAYBE_FOR1(i,
-    (uint32_t)0U,
-    (uint32_t)1U,
-    (uint32_t)1U,
-    uint64_t t1 = f1[(uint32_t)4U * i];
-    uint64_t t20 = f2[(uint32_t)4U * i];
-    uint64_t *res_i0 = out + (uint32_t)4U * i;
+  {
+    uint64_t t1 = f1[(uint32_t)4U * (uint32_t)0U];
+    uint64_t t20 = f2[(uint32_t)4U * (uint32_t)0U];
+    uint64_t *res_i0 = out + (uint32_t)4U * (uint32_t)0U;
     c0 = Lib_IntTypes_Intrinsics_add_carry_u64(c0, t1, t20, res_i0);
-    uint64_t t10 = f1[(uint32_t)4U * i + (uint32_t)1U];
-    uint64_t t21 = f2[(uint32_t)4U * i + (uint32_t)1U];
-    uint64_t *res_i1 = out + (uint32_t)4U * i + (uint32_t)1U;
+    uint64_t t10 = f1[(uint32_t)4U * (uint32_t)0U + (uint32_t)1U];
+    uint64_t t21 = f2[(uint32_t)4U * (uint32_t)0U + (uint32_t)1U];
+    uint64_t *res_i1 = out + (uint32_t)4U * (uint32_t)0U + (uint32_t)1U;
     c0 = Lib_IntTypes_Intrinsics_add_carry_u64(c0, t10, t21, res_i1);
-    uint64_t t11 = f1[(uint32_t)4U * i + (uint32_t)2U];
-    uint64_t t22 = f2[(uint32_t)4U * i + (uint32_t)2U];
-    uint64_t *res_i2 = out + (uint32_t)4U * i + (uint32_t)2U;
+    uint64_t t11 = f1[(uint32_t)4U * (uint32_t)0U + (uint32_t)2U];
+    uint64_t t22 = f2[(uint32_t)4U * (uint32_t)0U + (uint32_t)2U];
+    uint64_t *res_i2 = out + (uint32_t)4U * (uint32_t)0U + (uint32_t)2U;
     c0 = Lib_IntTypes_Intrinsics_add_carry_u64(c0, t11, t22, res_i2);
-    uint64_t t12 = f1[(uint32_t)4U * i + (uint32_t)3U];
-    uint64_t t2 = f2[(uint32_t)4U * i + (uint32_t)3U];
-    uint64_t *res_i = out + (uint32_t)4U * i + (uint32_t)3U;
-    c0 = Lib_IntTypes_Intrinsics_add_carry_u64(c0, t12, t2, res_i););
-  KRML_MAYBE_FOR0(i,
-    (uint32_t)4U,
-    (uint32_t)4U,
-    (uint32_t)1U,
-    uint64_t t1 = f1[i];
-    uint64_t t2 = f2[i];
-    uint64_t *res_i = out + i;
-    c0 = Lib_IntTypes_Intrinsics_add_carry_u64(c0, t1, t2, res_i););
+    uint64_t t12 = f1[(uint32_t)4U * (uint32_t)0U + (uint32_t)3U];
+    uint64_t t2 = f2[(uint32_t)4U * (uint32_t)0U + (uint32_t)3U];
+    uint64_t *res_i = out + (uint32_t)4U * (uint32_t)0U + (uint32_t)3U;
+    c0 = Lib_IntTypes_Intrinsics_add_carry_u64(c0, t12, t2, res_i);
+  }
   uint64_t c00 = c0;
   uint64_t
   c01 = Lib_IntTypes_Intrinsics_add_carry_u64((uint64_t)0U, out[0U], c00 * (uint64_t)38U, out);
@@ -138,34 +128,24 @@ static inline void fadd_(uint64_t *out, uint64_t *f1, uint64_t *f2)
 static inline void fsub_(uint64_t *out, uint64_t *f1, uint64_t *f2)
 {
   uint64_t c0 = (uint64_t)0U;
-  KRML_MAYBE_FOR1(i,
-    (uint32_t)0U,
-    (uint32_t)1U,
-    (uint32_t)1U,
-    uint64_t t1 = f1[(uint32_t)4U * i];
-    uint64_t t20 = f2[(uint32_t)4U * i];
-    uint64_t *res_i0 = out + (uint32_t)4U * i;
+  {
+    uint64_t t1 = f1[(uint32_t)4U * (uint32_t)0U];
+    uint64_t t20 = f2[(uint32_t)4U * (uint32_t)0U];
+    uint64_t *res_i0 = out + (uint32_t)4U * (uint32_t)0U;
     c0 = Lib_IntTypes_Intrinsics_sub_borrow_u64(c0, t1, t20, res_i0);
-    uint64_t t10 = f1[(uint32_t)4U * i + (uint32_t)1U];
-    uint64_t t21 = f2[(uint32_t)4U * i + (uint32_t)1U];
-    uint64_t *res_i1 = out + (uint32_t)4U * i + (uint32_t)1U;
+    uint64_t t10 = f1[(uint32_t)4U * (uint32_t)0U + (uint32_t)1U];
+    uint64_t t21 = f2[(uint32_t)4U * (uint32_t)0U + (uint32_t)1U];
+    uint64_t *res_i1 = out + (uint32_t)4U * (uint32_t)0U + (uint32_t)1U;
     c0 = Lib_IntTypes_Intrinsics_sub_borrow_u64(c0, t10, t21, res_i1);
-    uint64_t t11 = f1[(uint32_t)4U * i + (uint32_t)2U];
-    uint64_t t22 = f2[(uint32_t)4U * i + (uint32_t)2U];
-    uint64_t *res_i2 = out + (uint32_t)4U * i + (uint32_t)2U;
+    uint64_t t11 = f1[(uint32_t)4U * (uint32_t)0U + (uint32_t)2U];
+    uint64_t t22 = f2[(uint32_t)4U * (uint32_t)0U + (uint32_t)2U];
+    uint64_t *res_i2 = out + (uint32_t)4U * (uint32_t)0U + (uint32_t)2U;
     c0 = Lib_IntTypes_Intrinsics_sub_borrow_u64(c0, t11, t22, res_i2);
-    uint64_t t12 = f1[(uint32_t)4U * i + (uint32_t)3U];
-    uint64_t t2 = f2[(uint32_t)4U * i + (uint32_t)3U];
-    uint64_t *res_i = out + (uint32_t)4U * i + (uint32_t)3U;
-    c0 = Lib_IntTypes_Intrinsics_sub_borrow_u64(c0, t12, t2, res_i););
-  KRML_MAYBE_FOR0(i,
-    (uint32_t)4U,
-    (uint32_t)4U,
-    (uint32_t)1U,
-    uint64_t t1 = f1[i];
-    uint64_t t2 = f2[i];
-    uint64_t *res_i = out + i;
-    c0 = Lib_IntTypes_Intrinsics_sub_borrow_u64(c0, t1, t2, res_i););
+    uint64_t t12 = f1[(uint32_t)4U * (uint32_t)0U + (uint32_t)3U];
+    uint64_t t2 = f2[(uint32_t)4U * (uint32_t)0U + (uint32_t)3U];
+    uint64_t *res_i = out + (uint32_t)4U * (uint32_t)0U + (uint32_t)3U;
+    c0 = Lib_IntTypes_Intrinsics_sub_borrow_u64(c0, t12, t2, res_i);
+  }
   uint64_t c00 = c0;
   uint64_t
   c01 = Lib_IntTypes_Intrinsics_sub_borrow_u64((uint64_t)0U, out[0U], c00 * (uint64_t)38U, out);
@@ -218,58 +198,40 @@ static inline void fmul_(uint64_t *out, uint64_t *f1, uint64_t *f2, uint64_t *tm
     uint64_t bj = f2[i0];
     uint64_t *res_j = tmp0 + i0;
     uint64_t c = (uint64_t)0U;
-    KRML_MAYBE_FOR1(i,
-      (uint32_t)0U,
-      (uint32_t)1U,
-      (uint32_t)1U,
-      uint64_t a_i = f1[(uint32_t)4U * i];
-      uint64_t *res_i0 = res_j + (uint32_t)4U * i;
+    {
+      uint64_t a_i = f1[(uint32_t)4U * (uint32_t)0U];
+      uint64_t *res_i0 = res_j + (uint32_t)4U * (uint32_t)0U;
       c = Hacl_Bignum_Base_mul_wide_add2_u64(a_i, bj, c, res_i0);
-      uint64_t a_i0 = f1[(uint32_t)4U * i + (uint32_t)1U];
-      uint64_t *res_i1 = res_j + (uint32_t)4U * i + (uint32_t)1U;
+      uint64_t a_i0 = f1[(uint32_t)4U * (uint32_t)0U + (uint32_t)1U];
+      uint64_t *res_i1 = res_j + (uint32_t)4U * (uint32_t)0U + (uint32_t)1U;
       c = Hacl_Bignum_Base_mul_wide_add2_u64(a_i0, bj, c, res_i1);
-      uint64_t a_i1 = f1[(uint32_t)4U * i + (uint32_t)2U];
-      uint64_t *res_i2 = res_j + (uint32_t)4U * i + (uint32_t)2U;
+      uint64_t a_i1 = f1[(uint32_t)4U * (uint32_t)0U + (uint32_t)2U];
+      uint64_t *res_i2 = res_j + (uint32_t)4U * (uint32_t)0U + (uint32_t)2U;
       c = Hacl_Bignum_Base_mul_wide_add2_u64(a_i1, bj, c, res_i2);
-      uint64_t a_i2 = f1[(uint32_t)4U * i + (uint32_t)3U];
-      uint64_t *res_i = res_j + (uint32_t)4U * i + (uint32_t)3U;
-      c = Hacl_Bignum_Base_mul_wide_add2_u64(a_i2, bj, c, res_i););
-    KRML_MAYBE_FOR0(i,
-      (uint32_t)4U,
-      (uint32_t)4U,
-      (uint32_t)1U,
-      uint64_t a_i = f1[i];
-      uint64_t *res_i = res_j + i;
-      c = Hacl_Bignum_Base_mul_wide_add2_u64(a_i, bj, c, res_i););
+      uint64_t a_i2 = f1[(uint32_t)4U * (uint32_t)0U + (uint32_t)3U];
+      uint64_t *res_i = res_j + (uint32_t)4U * (uint32_t)0U + (uint32_t)3U;
+      c = Hacl_Bignum_Base_mul_wide_add2_u64(a_i2, bj, c, res_i);
+    }
     uint64_t r = c;
     tmp0[(uint32_t)4U + i0] = r;);
   uint64_t *uu____0 = tmp0 + (uint32_t)4U;
   uint64_t *uu____1 = tmp0;
   uint64_t *res_j = uu____1;
   uint64_t c0 = (uint64_t)0U;
-  KRML_MAYBE_FOR1(i,
-    (uint32_t)0U,
-    (uint32_t)1U,
-    (uint32_t)1U,
-    uint64_t a_i = uu____0[(uint32_t)4U * i];
-    uint64_t *res_i0 = res_j + (uint32_t)4U * i;
+  {
+    uint64_t a_i = uu____0[(uint32_t)4U * (uint32_t)0U];
+    uint64_t *res_i0 = res_j + (uint32_t)4U * (uint32_t)0U;
     c0 = Hacl_Bignum_Base_mul_wide_add2_u64(a_i, (uint64_t)38U, c0, res_i0);
-    uint64_t a_i0 = uu____0[(uint32_t)4U * i + (uint32_t)1U];
-    uint64_t *res_i1 = res_j + (uint32_t)4U * i + (uint32_t)1U;
+    uint64_t a_i0 = uu____0[(uint32_t)4U * (uint32_t)0U + (uint32_t)1U];
+    uint64_t *res_i1 = res_j + (uint32_t)4U * (uint32_t)0U + (uint32_t)1U;
     c0 = Hacl_Bignum_Base_mul_wide_add2_u64(a_i0, (uint64_t)38U, c0, res_i1);
-    uint64_t a_i1 = uu____0[(uint32_t)4U * i + (uint32_t)2U];
-    uint64_t *res_i2 = res_j + (uint32_t)4U * i + (uint32_t)2U;
+    uint64_t a_i1 = uu____0[(uint32_t)4U * (uint32_t)0U + (uint32_t)2U];
+    uint64_t *res_i2 = res_j + (uint32_t)4U * (uint32_t)0U + (uint32_t)2U;
     c0 = Hacl_Bignum_Base_mul_wide_add2_u64(a_i1, (uint64_t)38U, c0, res_i2);
-    uint64_t a_i2 = uu____0[(uint32_t)4U * i + (uint32_t)3U];
-    uint64_t *res_i = res_j + (uint32_t)4U * i + (uint32_t)3U;
-    c0 = Hacl_Bignum_Base_mul_wide_add2_u64(a_i2, (uint64_t)38U, c0, res_i););
-  KRML_MAYBE_FOR0(i,
-    (uint32_t)4U,
-    (uint32_t)4U,
-    (uint32_t)1U,
-    uint64_t a_i = uu____0[i];
-    uint64_t *res_i = res_j + i;
-    c0 = Hacl_Bignum_Base_mul_wide_add2_u64(a_i, (uint64_t)38U, c0, res_i););
+    uint64_t a_i2 = uu____0[(uint32_t)4U * (uint32_t)0U + (uint32_t)3U];
+    uint64_t *res_i = res_j + (uint32_t)4U * (uint32_t)0U + (uint32_t)3U;
+    c0 = Hacl_Bignum_Base_mul_wide_add2_u64(a_i2, (uint64_t)38U, c0, res_i);
+  }
   uint64_t r = c0;
   uint64_t c00 = r;
   uint64_t *uu____2 = tmp0;
@@ -332,29 +294,20 @@ static inline void fmul2_(uint64_t *out, uint64_t *f1, uint64_t *f2, uint64_t *t
 static inline void fmul1_(uint64_t *out, uint64_t *f1, uint64_t f2)
 {
   uint64_t c0 = (uint64_t)0U;
-  KRML_MAYBE_FOR1(i,
-    (uint32_t)0U,
-    (uint32_t)1U,
-    (uint32_t)1U,
-    uint64_t a_i = f1[(uint32_t)4U * i];
-    uint64_t *res_i0 = out + (uint32_t)4U * i;
+  {
+    uint64_t a_i = f1[(uint32_t)4U * (uint32_t)0U];
+    uint64_t *res_i0 = out + (uint32_t)4U * (uint32_t)0U;
     c0 = Hacl_Bignum_Base_mul_wide_add_u64(a_i, f2, c0, res_i0);
-    uint64_t a_i0 = f1[(uint32_t)4U * i + (uint32_t)1U];
-    uint64_t *res_i1 = out + (uint32_t)4U * i + (uint32_t)1U;
+    uint64_t a_i0 = f1[(uint32_t)4U * (uint32_t)0U + (uint32_t)1U];
+    uint64_t *res_i1 = out + (uint32_t)4U * (uint32_t)0U + (uint32_t)1U;
     c0 = Hacl_Bignum_Base_mul_wide_add_u64(a_i0, f2, c0, res_i1);
-    uint64_t a_i1 = f1[(uint32_t)4U * i + (uint32_t)2U];
-    uint64_t *res_i2 = out + (uint32_t)4U * i + (uint32_t)2U;
+    uint64_t a_i1 = f1[(uint32_t)4U * (uint32_t)0U + (uint32_t)2U];
+    uint64_t *res_i2 = out + (uint32_t)4U * (uint32_t)0U + (uint32_t)2U;
     c0 = Hacl_Bignum_Base_mul_wide_add_u64(a_i1, f2, c0, res_i2);
-    uint64_t a_i2 = f1[(uint32_t)4U * i + (uint32_t)3U];
-    uint64_t *res_i = out + (uint32_t)4U * i + (uint32_t)3U;
-    c0 = Hacl_Bignum_Base_mul_wide_add_u64(a_i2, f2, c0, res_i););
-  KRML_MAYBE_FOR0(i,
-    (uint32_t)4U,
-    (uint32_t)4U,
-    (uint32_t)1U,
-    uint64_t a_i = f1[i];
-    uint64_t *res_i = out + i;
-    c0 = Hacl_Bignum_Base_mul_wide_add_u64(a_i, f2, c0, res_i););
+    uint64_t a_i2 = f1[(uint32_t)4U * (uint32_t)0U + (uint32_t)3U];
+    uint64_t *res_i = out + (uint32_t)4U * (uint32_t)0U + (uint32_t)3U;
+    c0 = Hacl_Bignum_Base_mul_wide_add_u64(a_i2, f2, c0, res_i);
+  }
   uint64_t c00 = c0;
   uint64_t
   c01 = Lib_IntTypes_Intrinsics_add_carry_u64((uint64_t)0U, out[0U], c00 * (uint64_t)38U, out);
@@ -446,29 +399,20 @@ static inline void fsqr_(uint64_t *out, uint64_t *f1, uint64_t *tmp)
   uint64_t *uu____1 = tmp;
   uint64_t *res_j = uu____1;
   uint64_t c2 = (uint64_t)0U;
-  KRML_MAYBE_FOR1(i,
-    (uint32_t)0U,
-    (uint32_t)1U,
-    (uint32_t)1U,
-    uint64_t a_i = uu____0[(uint32_t)4U * i];
-    uint64_t *res_i0 = res_j + (uint32_t)4U * i;
+  {
+    uint64_t a_i = uu____0[(uint32_t)4U * (uint32_t)0U];
+    uint64_t *res_i0 = res_j + (uint32_t)4U * (uint32_t)0U;
     c2 = Hacl_Bignum_Base_mul_wide_add2_u64(a_i, (uint64_t)38U, c2, res_i0);
-    uint64_t a_i0 = uu____0[(uint32_t)4U * i + (uint32_t)1U];
-    uint64_t *res_i1 = res_j + (uint32_t)4U * i + (uint32_t)1U;
+    uint64_t a_i0 = uu____0[(uint32_t)4U * (uint32_t)0U + (uint32_t)1U];
+    uint64_t *res_i1 = res_j + (uint32_t)4U * (uint32_t)0U + (uint32_t)1U;
     c2 = Hacl_Bignum_Base_mul_wide_add2_u64(a_i0, (uint64_t)38U, c2, res_i1);
-    uint64_t a_i1 = uu____0[(uint32_t)4U * i + (uint32_t)2U];
-    uint64_t *res_i2 = res_j + (uint32_t)4U * i + (uint32_t)2U;
+    uint64_t a_i1 = uu____0[(uint32_t)4U * (uint32_t)0U + (uint32_t)2U];
+    uint64_t *res_i2 = res_j + (uint32_t)4U * (uint32_t)0U + (uint32_t)2U;
     c2 = Hacl_Bignum_Base_mul_wide_add2_u64(a_i1, (uint64_t)38U, c2, res_i2);
-    uint64_t a_i2 = uu____0[(uint32_t)4U * i + (uint32_t)3U];
-    uint64_t *res_i = res_j + (uint32_t)4U * i + (uint32_t)3U;
-    c2 = Hacl_Bignum_Base_mul_wide_add2_u64(a_i2, (uint64_t)38U, c2, res_i););
-  KRML_MAYBE_FOR0(i,
-    (uint32_t)4U,
-    (uint32_t)4U,
-    (uint32_t)1U,
-    uint64_t a_i = uu____0[i];
-    uint64_t *res_i = res_j + i;
-    c2 = Hacl_Bignum_Base_mul_wide_add2_u64(a_i, (uint64_t)38U, c2, res_i););
+    uint64_t a_i2 = uu____0[(uint32_t)4U * (uint32_t)0U + (uint32_t)3U];
+    uint64_t *res_i = res_j + (uint32_t)4U * (uint32_t)0U + (uint32_t)3U;
+    c2 = Hacl_Bignum_Base_mul_wide_add2_u64(a_i2, (uint64_t)38U, c2, res_i);
+  }
   uint64_t r = c2;
   uint64_t c00 = r;
   uint64_t *uu____2 = tmp;

--- a/dist/gcc-compatible/Hacl_Curve25519_64_Slow.c
+++ b/dist/gcc-compatible/Hacl_Curve25519_64_Slow.c
@@ -66,8 +66,10 @@ static inline uint64_t add1_(uint64_t *out, uint64_t *f1, uint64_t f2)
 static inline void fadd_(uint64_t *out, uint64_t *f1, uint64_t *f2)
 {
   uint64_t c0 = (uint64_t)0U;
-  for (uint32_t i = (uint32_t)0U; i < (uint32_t)1U; i++)
-  {
+  KRML_MAYBE_FOR1(i,
+    (uint32_t)0U,
+    (uint32_t)1U,
+    (uint32_t)1U,
     uint64_t t1 = f1[(uint32_t)4U * i];
     uint64_t t20 = f2[(uint32_t)4U * i];
     uint64_t *res_i0 = out + (uint32_t)4U * i;
@@ -83,15 +85,15 @@ static inline void fadd_(uint64_t *out, uint64_t *f1, uint64_t *f2)
     uint64_t t12 = f1[(uint32_t)4U * i + (uint32_t)3U];
     uint64_t t2 = f2[(uint32_t)4U * i + (uint32_t)3U];
     uint64_t *res_i = out + (uint32_t)4U * i + (uint32_t)3U;
-    c0 = Lib_IntTypes_Intrinsics_add_carry_u64(c0, t12, t2, res_i);
-  }
-  for (uint32_t i = (uint32_t)4U; i < (uint32_t)4U; i++)
-  {
+    c0 = Lib_IntTypes_Intrinsics_add_carry_u64(c0, t12, t2, res_i););
+  KRML_MAYBE_FOR0(i,
+    (uint32_t)4U,
+    (uint32_t)4U,
+    (uint32_t)1U,
     uint64_t t1 = f1[i];
     uint64_t t2 = f2[i];
     uint64_t *res_i = out + i;
-    c0 = Lib_IntTypes_Intrinsics_add_carry_u64(c0, t1, t2, res_i);
-  }
+    c0 = Lib_IntTypes_Intrinsics_add_carry_u64(c0, t1, t2, res_i););
   uint64_t c00 = c0;
   uint64_t
   c01 = Lib_IntTypes_Intrinsics_add_carry_u64((uint64_t)0U, out[0U], c00 * (uint64_t)38U, out);
@@ -136,8 +138,10 @@ static inline void fadd_(uint64_t *out, uint64_t *f1, uint64_t *f2)
 static inline void fsub_(uint64_t *out, uint64_t *f1, uint64_t *f2)
 {
   uint64_t c0 = (uint64_t)0U;
-  for (uint32_t i = (uint32_t)0U; i < (uint32_t)1U; i++)
-  {
+  KRML_MAYBE_FOR1(i,
+    (uint32_t)0U,
+    (uint32_t)1U,
+    (uint32_t)1U,
     uint64_t t1 = f1[(uint32_t)4U * i];
     uint64_t t20 = f2[(uint32_t)4U * i];
     uint64_t *res_i0 = out + (uint32_t)4U * i;
@@ -153,15 +157,15 @@ static inline void fsub_(uint64_t *out, uint64_t *f1, uint64_t *f2)
     uint64_t t12 = f1[(uint32_t)4U * i + (uint32_t)3U];
     uint64_t t2 = f2[(uint32_t)4U * i + (uint32_t)3U];
     uint64_t *res_i = out + (uint32_t)4U * i + (uint32_t)3U;
-    c0 = Lib_IntTypes_Intrinsics_sub_borrow_u64(c0, t12, t2, res_i);
-  }
-  for (uint32_t i = (uint32_t)4U; i < (uint32_t)4U; i++)
-  {
+    c0 = Lib_IntTypes_Intrinsics_sub_borrow_u64(c0, t12, t2, res_i););
+  KRML_MAYBE_FOR0(i,
+    (uint32_t)4U,
+    (uint32_t)4U,
+    (uint32_t)1U,
     uint64_t t1 = f1[i];
     uint64_t t2 = f2[i];
     uint64_t *res_i = out + i;
-    c0 = Lib_IntTypes_Intrinsics_sub_borrow_u64(c0, t1, t2, res_i);
-  }
+    c0 = Lib_IntTypes_Intrinsics_sub_borrow_u64(c0, t1, t2, res_i););
   uint64_t c00 = c0;
   uint64_t
   c01 = Lib_IntTypes_Intrinsics_sub_borrow_u64((uint64_t)0U, out[0U], c00 * (uint64_t)38U, out);
@@ -207,13 +211,17 @@ static inline void fmul_(uint64_t *out, uint64_t *f1, uint64_t *f2, uint64_t *tm
 {
   uint64_t *tmp0 = tmp;
   memset(tmp0, 0U, (uint32_t)8U * sizeof (uint64_t));
-  for (uint32_t i0 = (uint32_t)0U; i0 < (uint32_t)4U; i0++)
-  {
+  KRML_MAYBE_FOR4(i0,
+    (uint32_t)0U,
+    (uint32_t)4U,
+    (uint32_t)1U,
     uint64_t bj = f2[i0];
     uint64_t *res_j = tmp0 + i0;
     uint64_t c = (uint64_t)0U;
-    for (uint32_t i = (uint32_t)0U; i < (uint32_t)1U; i++)
-    {
+    KRML_MAYBE_FOR1(i,
+      (uint32_t)0U,
+      (uint32_t)1U,
+      (uint32_t)1U,
       uint64_t a_i = f1[(uint32_t)4U * i];
       uint64_t *res_i0 = res_j + (uint32_t)4U * i;
       c = Hacl_Bignum_Base_mul_wide_add2_u64(a_i, bj, c, res_i0);
@@ -225,23 +233,24 @@ static inline void fmul_(uint64_t *out, uint64_t *f1, uint64_t *f2, uint64_t *tm
       c = Hacl_Bignum_Base_mul_wide_add2_u64(a_i1, bj, c, res_i2);
       uint64_t a_i2 = f1[(uint32_t)4U * i + (uint32_t)3U];
       uint64_t *res_i = res_j + (uint32_t)4U * i + (uint32_t)3U;
-      c = Hacl_Bignum_Base_mul_wide_add2_u64(a_i2, bj, c, res_i);
-    }
-    for (uint32_t i = (uint32_t)4U; i < (uint32_t)4U; i++)
-    {
+      c = Hacl_Bignum_Base_mul_wide_add2_u64(a_i2, bj, c, res_i););
+    KRML_MAYBE_FOR0(i,
+      (uint32_t)4U,
+      (uint32_t)4U,
+      (uint32_t)1U,
       uint64_t a_i = f1[i];
       uint64_t *res_i = res_j + i;
-      c = Hacl_Bignum_Base_mul_wide_add2_u64(a_i, bj, c, res_i);
-    }
+      c = Hacl_Bignum_Base_mul_wide_add2_u64(a_i, bj, c, res_i););
     uint64_t r = c;
-    tmp0[(uint32_t)4U + i0] = r;
-  }
+    tmp0[(uint32_t)4U + i0] = r;);
   uint64_t *uu____0 = tmp0 + (uint32_t)4U;
   uint64_t *uu____1 = tmp0;
   uint64_t *res_j = uu____1;
   uint64_t c0 = (uint64_t)0U;
-  for (uint32_t i = (uint32_t)0U; i < (uint32_t)1U; i++)
-  {
+  KRML_MAYBE_FOR1(i,
+    (uint32_t)0U,
+    (uint32_t)1U,
+    (uint32_t)1U,
     uint64_t a_i = uu____0[(uint32_t)4U * i];
     uint64_t *res_i0 = res_j + (uint32_t)4U * i;
     c0 = Hacl_Bignum_Base_mul_wide_add2_u64(a_i, (uint64_t)38U, c0, res_i0);
@@ -253,14 +262,14 @@ static inline void fmul_(uint64_t *out, uint64_t *f1, uint64_t *f2, uint64_t *tm
     c0 = Hacl_Bignum_Base_mul_wide_add2_u64(a_i1, (uint64_t)38U, c0, res_i2);
     uint64_t a_i2 = uu____0[(uint32_t)4U * i + (uint32_t)3U];
     uint64_t *res_i = res_j + (uint32_t)4U * i + (uint32_t)3U;
-    c0 = Hacl_Bignum_Base_mul_wide_add2_u64(a_i2, (uint64_t)38U, c0, res_i);
-  }
-  for (uint32_t i = (uint32_t)4U; i < (uint32_t)4U; i++)
-  {
+    c0 = Hacl_Bignum_Base_mul_wide_add2_u64(a_i2, (uint64_t)38U, c0, res_i););
+  KRML_MAYBE_FOR0(i,
+    (uint32_t)4U,
+    (uint32_t)4U,
+    (uint32_t)1U,
     uint64_t a_i = uu____0[i];
     uint64_t *res_i = res_j + i;
-    c0 = Hacl_Bignum_Base_mul_wide_add2_u64(a_i, (uint64_t)38U, c0, res_i);
-  }
+    c0 = Hacl_Bignum_Base_mul_wide_add2_u64(a_i, (uint64_t)38U, c0, res_i););
   uint64_t r = c0;
   uint64_t c00 = r;
   uint64_t *uu____2 = tmp0;
@@ -323,8 +332,10 @@ static inline void fmul2_(uint64_t *out, uint64_t *f1, uint64_t *f2, uint64_t *t
 static inline void fmul1_(uint64_t *out, uint64_t *f1, uint64_t f2)
 {
   uint64_t c0 = (uint64_t)0U;
-  for (uint32_t i = (uint32_t)0U; i < (uint32_t)1U; i++)
-  {
+  KRML_MAYBE_FOR1(i,
+    (uint32_t)0U,
+    (uint32_t)1U,
+    (uint32_t)1U,
     uint64_t a_i = f1[(uint32_t)4U * i];
     uint64_t *res_i0 = out + (uint32_t)4U * i;
     c0 = Hacl_Bignum_Base_mul_wide_add_u64(a_i, f2, c0, res_i0);
@@ -336,14 +347,14 @@ static inline void fmul1_(uint64_t *out, uint64_t *f1, uint64_t f2)
     c0 = Hacl_Bignum_Base_mul_wide_add_u64(a_i1, f2, c0, res_i2);
     uint64_t a_i2 = f1[(uint32_t)4U * i + (uint32_t)3U];
     uint64_t *res_i = out + (uint32_t)4U * i + (uint32_t)3U;
-    c0 = Hacl_Bignum_Base_mul_wide_add_u64(a_i2, f2, c0, res_i);
-  }
-  for (uint32_t i = (uint32_t)4U; i < (uint32_t)4U; i++)
-  {
+    c0 = Hacl_Bignum_Base_mul_wide_add_u64(a_i2, f2, c0, res_i););
+  KRML_MAYBE_FOR0(i,
+    (uint32_t)4U,
+    (uint32_t)4U,
+    (uint32_t)1U,
     uint64_t a_i = f1[i];
     uint64_t *res_i = out + i;
-    c0 = Hacl_Bignum_Base_mul_wide_add_u64(a_i, f2, c0, res_i);
-  }
+    c0 = Hacl_Bignum_Base_mul_wide_add_u64(a_i, f2, c0, res_i););
   uint64_t c00 = c0;
   uint64_t
   c01 = Lib_IntTypes_Intrinsics_add_carry_u64((uint64_t)0U, out[0U], c00 * (uint64_t)38U, out);
@@ -388,8 +399,10 @@ static inline void fmul1_(uint64_t *out, uint64_t *f1, uint64_t f2)
 static inline void fsqr_(uint64_t *out, uint64_t *f1, uint64_t *tmp)
 {
   memset(tmp, 0U, (uint32_t)8U * sizeof (uint64_t));
-  for (uint32_t i0 = (uint32_t)0U; i0 < (uint32_t)4U; i0++)
-  {
+  KRML_MAYBE_FOR4(i0,
+    (uint32_t)0U,
+    (uint32_t)4U,
+    (uint32_t)1U,
     uint64_t *ab = f1;
     uint64_t a_j = f1[i0];
     uint64_t *res_j = tmp + i0;
@@ -416,25 +429,27 @@ static inline void fsqr_(uint64_t *out, uint64_t *f1, uint64_t *tmp)
       c = Hacl_Bignum_Base_mul_wide_add2_u64(a_i, a_j, c, res_i);
     }
     uint64_t r = c;
-    tmp[i0 + i0] = r;
-  }
+    tmp[i0 + i0] = r;);
   uint64_t c0 = Hacl_Bignum_Addition_bn_add_eq_len_u64((uint32_t)8U, tmp, tmp, tmp);
   uint64_t tmp1[8U] = { 0U };
-  for (uint32_t i = (uint32_t)0U; i < (uint32_t)4U; i++)
-  {
+  KRML_MAYBE_FOR4(i,
+    (uint32_t)0U,
+    (uint32_t)4U,
+    (uint32_t)1U,
     FStar_UInt128_uint128 res = FStar_UInt128_mul_wide(f1[i], f1[i]);
     uint64_t hi = FStar_UInt128_uint128_to_uint64(FStar_UInt128_shift_right(res, (uint32_t)64U));
     uint64_t lo = FStar_UInt128_uint128_to_uint64(res);
     tmp1[(uint32_t)2U * i] = lo;
-    tmp1[(uint32_t)2U * i + (uint32_t)1U] = hi;
-  }
+    tmp1[(uint32_t)2U * i + (uint32_t)1U] = hi;);
   uint64_t c1 = Hacl_Bignum_Addition_bn_add_eq_len_u64((uint32_t)8U, tmp, tmp1, tmp);
   uint64_t *uu____0 = tmp + (uint32_t)4U;
   uint64_t *uu____1 = tmp;
   uint64_t *res_j = uu____1;
   uint64_t c2 = (uint64_t)0U;
-  for (uint32_t i = (uint32_t)0U; i < (uint32_t)1U; i++)
-  {
+  KRML_MAYBE_FOR1(i,
+    (uint32_t)0U,
+    (uint32_t)1U,
+    (uint32_t)1U,
     uint64_t a_i = uu____0[(uint32_t)4U * i];
     uint64_t *res_i0 = res_j + (uint32_t)4U * i;
     c2 = Hacl_Bignum_Base_mul_wide_add2_u64(a_i, (uint64_t)38U, c2, res_i0);
@@ -446,14 +461,14 @@ static inline void fsqr_(uint64_t *out, uint64_t *f1, uint64_t *tmp)
     c2 = Hacl_Bignum_Base_mul_wide_add2_u64(a_i1, (uint64_t)38U, c2, res_i2);
     uint64_t a_i2 = uu____0[(uint32_t)4U * i + (uint32_t)3U];
     uint64_t *res_i = res_j + (uint32_t)4U * i + (uint32_t)3U;
-    c2 = Hacl_Bignum_Base_mul_wide_add2_u64(a_i2, (uint64_t)38U, c2, res_i);
-  }
-  for (uint32_t i = (uint32_t)4U; i < (uint32_t)4U; i++)
-  {
+    c2 = Hacl_Bignum_Base_mul_wide_add2_u64(a_i2, (uint64_t)38U, c2, res_i););
+  KRML_MAYBE_FOR0(i,
+    (uint32_t)4U,
+    (uint32_t)4U,
+    (uint32_t)1U,
     uint64_t a_i = uu____0[i];
     uint64_t *res_i = res_j + i;
-    c2 = Hacl_Bignum_Base_mul_wide_add2_u64(a_i, (uint64_t)38U, c2, res_i);
-  }
+    c2 = Hacl_Bignum_Base_mul_wide_add2_u64(a_i, (uint64_t)38U, c2, res_i););
   uint64_t r = c2;
   uint64_t c00 = r;
   uint64_t *uu____2 = tmp;
@@ -514,12 +529,13 @@ static inline void fsqr2_(uint64_t *out, uint64_t *f, uint64_t *tmp)
 static inline void cswap2_(uint64_t bit, uint64_t *p1, uint64_t *p2)
 {
   uint64_t mask = (uint64_t)0U - bit;
-  for (uint32_t i = (uint32_t)0U; i < (uint32_t)8U; i++)
-  {
+  KRML_MAYBE_FOR8(i,
+    (uint32_t)0U,
+    (uint32_t)8U,
+    (uint32_t)1U,
     uint64_t dummy = mask & (p1[i] ^ p2[i]);
     p1[i] = p1[i] ^ dummy;
-    p2[i] = p2[i] ^ dummy;
-  }
+    p2[i] = p2[i] ^ dummy;);
 }
 
 static const uint8_t g25519[32U] = { (uint8_t)9U };
@@ -737,25 +753,27 @@ static void encode_point(uint8_t *o, uint64_t *i)
   finv(tmp, z, tmp_w);
   fmul_(tmp, tmp, x, tmp_w);
   store_felem(u64s, tmp);
-  for (uint32_t i0 = (uint32_t)0U; i0 < (uint32_t)4U; i0++)
-  {
-    store64_le(o + i0 * (uint32_t)8U, u64s[i0]);
-  }
+  KRML_MAYBE_FOR4(i0,
+    (uint32_t)0U,
+    (uint32_t)4U,
+    (uint32_t)1U,
+    store64_le(o + i0 * (uint32_t)8U, u64s[i0]););
 }
 
 void Hacl_Curve25519_64_Slow_scalarmult(uint8_t *out, uint8_t *priv, uint8_t *pub)
 {
   uint64_t init[8U] = { 0U };
   uint64_t tmp[4U] = { 0U };
-  for (uint32_t i = (uint32_t)0U; i < (uint32_t)4U; i++)
-  {
+  KRML_MAYBE_FOR4(i,
+    (uint32_t)0U,
+    (uint32_t)4U,
+    (uint32_t)1U,
     uint64_t *os = tmp;
     uint8_t *bj = pub + i * (uint32_t)8U;
     uint64_t u = load64_le(bj);
     uint64_t r = u;
     uint64_t x = r;
-    os[i] = x;
-  }
+    os[i] = x;);
   uint64_t tmp3 = tmp[3U];
   tmp[3U] = tmp3 & (uint64_t)0x7fffffffffffffffU;
   uint64_t *x = init;

--- a/dist/gcc-compatible/Hacl_Ed25519.c
+++ b/dist/gcc-compatible/Hacl_Ed25519.c
@@ -207,15 +207,16 @@ static inline void reduce(uint64_t *out)
 void Hacl_Bignum25519_load_51(uint64_t *output, uint8_t *input)
 {
   uint64_t u64s[4U] = { 0U };
-  for (uint32_t i = (uint32_t)0U; i < (uint32_t)4U; i++)
-  {
+  KRML_MAYBE_FOR4(i,
+    (uint32_t)0U,
+    (uint32_t)4U,
+    (uint32_t)1U,
     uint64_t *os = u64s;
     uint8_t *bj = input + i * (uint32_t)8U;
     uint64_t u = load64_le(bj);
     uint64_t r = u;
     uint64_t x = r;
-    os[i] = x;
-  }
+    os[i] = x;);
   uint64_t u64s3 = u64s[3U];
   u64s[3U] = u64s3 & (uint64_t)0x7fffffffffffffffU;
   output[0U] = u64s[0U] & (uint64_t)0x7ffffffffffffU;
@@ -229,10 +230,11 @@ void Hacl_Bignum25519_store_51(uint8_t *output, uint64_t *input)
 {
   uint64_t u64s[4U] = { 0U };
   Hacl_Impl_Curve25519_Field51_store_felem(u64s, input);
-  for (uint32_t i = (uint32_t)0U; i < (uint32_t)4U; i++)
-  {
-    store64_le(output + i * (uint32_t)8U, u64s[i]);
-  }
+  KRML_MAYBE_FOR4(i,
+    (uint32_t)0U,
+    (uint32_t)4U,
+    (uint32_t)1U,
+    store64_le(output + i * (uint32_t)8U, u64s[i]););
 }
 
 void Hacl_Impl_Ed25519_PointDouble_point_double(uint64_t *out, uint64_t *p)
@@ -1289,15 +1291,16 @@ void Hacl_Impl_Ed25519_PointNegate_point_negate(uint64_t *p, uint64_t *out)
 void Hacl_Impl_Ed25519_Ladder_point_mul(uint64_t *result, uint8_t *scalar, uint64_t *q)
 {
   uint64_t bscalar[4U] = { 0U };
-  for (uint32_t i = (uint32_t)0U; i < (uint32_t)4U; i++)
-  {
+  KRML_MAYBE_FOR4(i,
+    (uint32_t)0U,
+    (uint32_t)4U,
+    (uint32_t)1U,
     uint64_t *os = bscalar;
     uint8_t *bj = scalar + i * (uint32_t)8U;
     uint64_t u = load64_le(bj);
     uint64_t r = u;
     uint64_t x = r;
-    os[i] = x;
-  }
+    os[i] = x;);
   uint64_t *x0 = result;
   uint64_t *y = result + (uint32_t)5U;
   uint64_t *z = result + (uint32_t)10U;
@@ -1326,18 +1329,20 @@ void Hacl_Impl_Ed25519_Ladder_point_mul(uint64_t *result, uint8_t *scalar, uint6
   memcpy(table, result, (uint32_t)20U * sizeof (uint64_t));
   uint64_t *t1 = table + (uint32_t)20U;
   memcpy(t1, q, (uint32_t)20U * sizeof (uint64_t));
-  for (uint32_t i = (uint32_t)0U; i < (uint32_t)15U; i++)
-  {
+  KRML_MAYBE_FOR15(i,
+    (uint32_t)0U,
+    (uint32_t)15U,
+    (uint32_t)1U,
     uint64_t *t11 = table + i * (uint32_t)20U;
     uint64_t *t2 = table + i * (uint32_t)20U + (uint32_t)20U;
-    Hacl_Impl_Ed25519_PointAdd_point_add(t2, q, t11);
-  }
+    Hacl_Impl_Ed25519_PointAdd_point_add(t2, q, t11););
   for (uint32_t i0 = (uint32_t)0U; i0 < (uint32_t)64U; i0++)
   {
-    for (uint32_t i = (uint32_t)0U; i < (uint32_t)4U; i++)
-    {
-      Hacl_Impl_Ed25519_PointDouble_point_double(result, result);
-    }
+    KRML_MAYBE_FOR4(i,
+      (uint32_t)0U,
+      (uint32_t)4U,
+      (uint32_t)1U,
+      Hacl_Impl_Ed25519_PointDouble_point_double(result, result););
     uint32_t bk = (uint32_t)256U;
     uint64_t mask_l = (uint64_t)16U - (uint64_t)1U;
     uint32_t i1 = (bk - (uint32_t)4U * i0 - (uint32_t)4U) / (uint32_t)64U;
@@ -1355,8 +1360,10 @@ void Hacl_Impl_Ed25519_Ladder_point_mul(uint64_t *result, uint8_t *scalar, uint6
     uint64_t bits_l = ite & mask_l;
     uint64_t a_bits_l[20U] = { 0U };
     memcpy(a_bits_l, table, (uint32_t)20U * sizeof (uint64_t));
-    for (uint32_t i2 = (uint32_t)0U; i2 < (uint32_t)15U; i2++)
-    {
+    KRML_MAYBE_FOR15(i2,
+      (uint32_t)0U,
+      (uint32_t)15U,
+      (uint32_t)1U,
       uint64_t c = FStar_UInt64_eq_mask(bits_l, (uint64_t)(i2 + (uint32_t)1U));
       uint64_t *res_j = table + (i2 + (uint32_t)1U) * (uint32_t)20U;
       for (uint32_t i = (uint32_t)0U; i < (uint32_t)20U; i++)
@@ -1364,8 +1371,7 @@ void Hacl_Impl_Ed25519_Ladder_point_mul(uint64_t *result, uint8_t *scalar, uint6
         uint64_t *os = a_bits_l;
         uint64_t x = (c & res_j[i]) | (~c & a_bits_l[i]);
         os[i] = x;
-      }
-    }
+      });
     Hacl_Impl_Ed25519_PointAdd_point_add(result, result, a_bits_l);
   }
 }
@@ -1410,25 +1416,27 @@ point_mul_double_vartime(
 )
 {
   uint64_t bscalar1[4U] = { 0U };
-  for (uint32_t i = (uint32_t)0U; i < (uint32_t)4U; i++)
-  {
+  KRML_MAYBE_FOR4(i,
+    (uint32_t)0U,
+    (uint32_t)4U,
+    (uint32_t)1U,
     uint64_t *os = bscalar1;
     uint8_t *bj = scalar1 + i * (uint32_t)8U;
     uint64_t u = load64_le(bj);
     uint64_t r = u;
     uint64_t x = r;
-    os[i] = x;
-  }
+    os[i] = x;);
   uint64_t bscalar2[4U] = { 0U };
-  for (uint32_t i = (uint32_t)0U; i < (uint32_t)4U; i++)
-  {
+  KRML_MAYBE_FOR4(i,
+    (uint32_t)0U,
+    (uint32_t)4U,
+    (uint32_t)1U,
     uint64_t *os = bscalar2;
     uint8_t *bj = scalar2 + i * (uint32_t)8U;
     uint64_t u = load64_le(bj);
     uint64_t r = u;
     uint64_t x = r;
-    os[i] = x;
-  }
+    os[i] = x;);
   uint64_t *x = result;
   uint64_t *y = result + (uint32_t)5U;
   uint64_t *z = result + (uint32_t)10U;
@@ -1457,28 +1465,31 @@ point_mul_double_vartime(
   memcpy(table1, result, (uint32_t)20U * sizeof (uint64_t));
   uint64_t *t10 = table1 + (uint32_t)20U;
   memcpy(t10, q1, (uint32_t)20U * sizeof (uint64_t));
-  for (uint32_t i = (uint32_t)0U; i < (uint32_t)15U; i++)
-  {
+  KRML_MAYBE_FOR15(i,
+    (uint32_t)0U,
+    (uint32_t)15U,
+    (uint32_t)1U,
     uint64_t *t11 = table1 + i * (uint32_t)20U;
     uint64_t *t2 = table1 + i * (uint32_t)20U + (uint32_t)20U;
-    Hacl_Impl_Ed25519_PointAdd_point_add(t2, q1, t11);
-  }
+    Hacl_Impl_Ed25519_PointAdd_point_add(t2, q1, t11););
   uint64_t table2[320U] = { 0U };
   memcpy(table2, result, (uint32_t)20U * sizeof (uint64_t));
   uint64_t *t1 = table2 + (uint32_t)20U;
   memcpy(t1, q2, (uint32_t)20U * sizeof (uint64_t));
-  for (uint32_t i = (uint32_t)0U; i < (uint32_t)15U; i++)
-  {
+  KRML_MAYBE_FOR15(i,
+    (uint32_t)0U,
+    (uint32_t)15U,
+    (uint32_t)1U,
     uint64_t *t11 = table2 + i * (uint32_t)20U;
     uint64_t *t2 = table2 + i * (uint32_t)20U + (uint32_t)20U;
-    Hacl_Impl_Ed25519_PointAdd_point_add(t2, q2, t11);
-  }
+    Hacl_Impl_Ed25519_PointAdd_point_add(t2, q2, t11););
   for (uint32_t i = (uint32_t)0U; i < (uint32_t)64U; i++)
   {
-    for (uint32_t i0 = (uint32_t)0U; i0 < (uint32_t)4U; i0++)
-    {
-      Hacl_Impl_Ed25519_PointDouble_point_double(result, result);
-    }
+    KRML_MAYBE_FOR4(i0,
+      (uint32_t)0U,
+      (uint32_t)4U,
+      (uint32_t)1U,
+      Hacl_Impl_Ed25519_PointDouble_point_double(result, result););
     uint32_t bk = (uint32_t)256U;
     uint64_t mask_l0 = (uint64_t)16U - (uint64_t)1U;
     uint32_t i10 = (bk - (uint32_t)4U * i - (uint32_t)4U) / (uint32_t)64U;

--- a/dist/gcc-compatible/Hacl_FFDHE.c
+++ b/dist/gcc-compatible/Hacl_FFDHE.c
@@ -249,12 +249,13 @@ Hacl_FFDHE_ffdhe_secret_to_public_precomp(
   uint64_t g_n[nLen];
   memset(g_n, 0U, nLen * sizeof (uint64_t));
   uint8_t g = (uint8_t)0U;
-  for (uint32_t i = (uint32_t)0U; i < (uint32_t)1U; i++)
-  {
+  KRML_MAYBE_FOR1(i,
+    (uint32_t)0U,
+    (uint32_t)1U,
+    (uint32_t)1U,
     uint8_t *os = &g;
     uint8_t x = Hacl_Impl_FFDHE_Constants_ffdhe_g2[i];
-    os[i] = x;
-  }
+    os[i] = x;);
   Hacl_Bignum_Convert_bn_from_bytes_be_uint64((uint32_t)1U, &g, g_n);
   KRML_CHECK_SIZE(sizeof (uint64_t), nLen);
   uint64_t sk_n[nLen];

--- a/dist/gcc-compatible/Hacl_FFDHE.c
+++ b/dist/gcc-compatible/Hacl_FFDHE.c
@@ -249,13 +249,11 @@ Hacl_FFDHE_ffdhe_secret_to_public_precomp(
   uint64_t g_n[nLen];
   memset(g_n, 0U, nLen * sizeof (uint64_t));
   uint8_t g = (uint8_t)0U;
-  KRML_MAYBE_FOR1(i,
-    (uint32_t)0U,
-    (uint32_t)1U,
-    (uint32_t)1U,
+  {
     uint8_t *os = &g;
-    uint8_t x = Hacl_Impl_FFDHE_Constants_ffdhe_g2[i];
-    os[i] = x;);
+    uint8_t x = Hacl_Impl_FFDHE_Constants_ffdhe_g2[0U];
+    os[0U] = x;
+  }
   Hacl_Bignum_Convert_bn_from_bytes_be_uint64((uint32_t)1U, &g, g_n);
   KRML_CHECK_SIZE(sizeof (uint64_t), nLen);
   uint64_t sk_n[nLen];

--- a/dist/gcc-compatible/Hacl_Frodo64.c
+++ b/dist/gcc-compatible/Hacl_Frodo64.c
@@ -273,13 +273,14 @@ uint32_t Hacl_Frodo64_crypto_kem_dec(uint8_t *ss, uint8_t *ct, uint8_t *sk)
   uint16_t mask = b1 & b2;
   uint16_t mask0 = mask;
   uint8_t kp_s[16U] = { 0U };
-  for (uint32_t i = (uint32_t)0U; i < (uint32_t)16U; i++)
-  {
+  KRML_MAYBE_FOR16(i,
+    (uint32_t)0U,
+    (uint32_t)16U,
+    (uint32_t)1U,
     uint8_t *os = kp_s;
     uint8_t uu____0 = s[i];
     uint8_t x = uu____0 ^ ((uint8_t)mask0 & (kp[i] ^ uu____0));
-    os[i] = x;
-  }
+    os[i] = x;);
   uint32_t ss_init_len = (uint32_t)1096U;
   KRML_CHECK_SIZE(sizeof (uint8_t), ss_init_len);
   uint8_t ss_init[ss_init_len];

--- a/dist/gcc-compatible/Hacl_Frodo640.c
+++ b/dist/gcc-compatible/Hacl_Frodo640.c
@@ -272,13 +272,14 @@ uint32_t Hacl_Frodo640_crypto_kem_dec(uint8_t *ss, uint8_t *ct, uint8_t *sk)
   uint16_t mask = b1 & b2;
   uint16_t mask0 = mask;
   uint8_t kp_s[16U] = { 0U };
-  for (uint32_t i = (uint32_t)0U; i < (uint32_t)16U; i++)
-  {
+  KRML_MAYBE_FOR16(i,
+    (uint32_t)0U,
+    (uint32_t)16U,
+    (uint32_t)1U,
     uint8_t *os = kp_s;
     uint8_t uu____0 = s[i];
     uint8_t x = uu____0 ^ ((uint8_t)mask0 & (kp[i] ^ uu____0));
-    os[i] = x;
-  }
+    os[i] = x;);
   uint32_t ss_init_len = (uint32_t)9736U;
   KRML_CHECK_SIZE(sizeof (uint8_t), ss_init_len);
   uint8_t ss_init[ss_init_len];

--- a/dist/gcc-compatible/Hacl_Frodo_KEM.h
+++ b/dist/gcc-compatible/Hacl_Frodo_KEM.h
@@ -540,11 +540,12 @@ Hacl_Impl_Frodo_Encode_frodo_key_encode(
     uint64_t u = load64_le(v8);
     uint64_t x = u;
     uint64_t x0 = x;
-    for (uint32_t i = (uint32_t)0U; i < (uint32_t)8U; i++)
-    {
+    KRML_MAYBE_FOR8(i,
+      (uint32_t)0U,
+      (uint32_t)8U,
+      (uint32_t)1U,
       uint64_t rk = x0 >> b * i & (((uint64_t)1U << b) - (uint64_t)1U);
-      res[i0 * n + i] = (uint16_t)rk << (logq - b);
-    }
+      res[i0 * n + i] = (uint16_t)rk << (logq - b););
   }
 }
 
@@ -560,12 +561,13 @@ Hacl_Impl_Frodo_Encode_frodo_key_decode(
   for (uint32_t i0 = (uint32_t)0U; i0 < n; i0++)
   {
     uint64_t templong = (uint64_t)0U;
-    for (uint32_t i = (uint32_t)0U; i < (uint32_t)8U; i++)
-    {
+    KRML_MAYBE_FOR8(i,
+      (uint32_t)0U,
+      (uint32_t)8U,
+      (uint32_t)1U,
       uint16_t aik = a[i0 * n + i];
       uint16_t res1 = (aik + ((uint16_t)1U << (logq - b - (uint32_t)1U))) >> (logq - b);
-      templong = templong | (uint64_t)(res1 & (((uint16_t)1U << b) - (uint16_t)1U)) << b * i;
-    }
+      templong = templong | (uint64_t)(res1 & (((uint16_t)1U << b) - (uint16_t)1U)) << b * i;);
     uint64_t templong0 = templong;
     uint8_t v8[8U] = { 0U };
     store64_le(v8, templong0);

--- a/dist/gcc-compatible/Hacl_GenericField32.c
+++ b/dist/gcc-compatible/Hacl_GenericField32.c
@@ -326,12 +326,13 @@ Hacl_GenericField32_exp_consttime(
     memcpy(table, resM, len1 * sizeof (uint32_t));
     uint32_t *t1 = table + len1;
     memcpy(t1, aMc, len1 * sizeof (uint32_t));
-    for (uint32_t i = (uint32_t)0U; i < (uint32_t)15U; i++)
-    {
+    KRML_MAYBE_FOR15(i,
+      (uint32_t)0U,
+      (uint32_t)15U,
+      (uint32_t)1U,
       uint32_t *t11 = table + i * len1;
       uint32_t *t2 = table + i * len1 + len1;
-      Hacl_Bignum_Montgomery_bn_mont_mul_u32(len1, k1.n, k1.mu, aMc, t11, t2);
-    }
+      Hacl_Bignum_Montgomery_bn_mont_mul_u32(len1, k1.n, k1.mu, aMc, t11, t2););
     if (bBits % (uint32_t)4U != (uint32_t)0U)
     {
       uint32_t mask_l = (uint32_t)16U - (uint32_t)1U;
@@ -349,8 +350,10 @@ Hacl_GenericField32_exp_consttime(
       }
       uint32_t bits_c = ite & mask_l;
       memcpy(resM, table, len1 * sizeof (uint32_t));
-      for (uint32_t i1 = (uint32_t)0U; i1 < (uint32_t)15U; i1++)
-      {
+      KRML_MAYBE_FOR15(i1,
+        (uint32_t)0U,
+        (uint32_t)15U,
+        (uint32_t)1U,
         uint32_t c = FStar_UInt32_eq_mask(bits_c, i1 + (uint32_t)1U);
         uint32_t *res_j = table + (i1 + (uint32_t)1U) * len1;
         for (uint32_t i = (uint32_t)0U; i < len1; i++)
@@ -358,15 +361,15 @@ Hacl_GenericField32_exp_consttime(
           uint32_t *os = resM;
           uint32_t x = (c & res_j[i]) | (~c & resM[i]);
           os[i] = x;
-        }
-      }
+        });
     }
     for (uint32_t i0 = (uint32_t)0U; i0 < bBits / (uint32_t)4U; i0++)
     {
-      for (uint32_t i = (uint32_t)0U; i < (uint32_t)4U; i++)
-      {
-        Hacl_Bignum_Montgomery_bn_mont_sqr_u32(len1, k1.n, k1.mu, resM, resM);
-      }
+      KRML_MAYBE_FOR4(i,
+        (uint32_t)0U,
+        (uint32_t)4U,
+        (uint32_t)1U,
+        Hacl_Bignum_Montgomery_bn_mont_sqr_u32(len1, k1.n, k1.mu, resM, resM););
       uint32_t bk = bBits - bBits % (uint32_t)4U;
       uint32_t mask_l = (uint32_t)16U - (uint32_t)1U;
       uint32_t i1 = (bk - (uint32_t)4U * i0 - (uint32_t)4U) / (uint32_t)32U;
@@ -386,8 +389,10 @@ Hacl_GenericField32_exp_consttime(
       uint32_t a_bits_l[len1];
       memset(a_bits_l, 0U, len1 * sizeof (uint32_t));
       memcpy(a_bits_l, table, len1 * sizeof (uint32_t));
-      for (uint32_t i2 = (uint32_t)0U; i2 < (uint32_t)15U; i2++)
-      {
+      KRML_MAYBE_FOR15(i2,
+        (uint32_t)0U,
+        (uint32_t)15U,
+        (uint32_t)1U,
         uint32_t c = FStar_UInt32_eq_mask(bits_l, i2 + (uint32_t)1U);
         uint32_t *res_j = table + (i2 + (uint32_t)1U) * len1;
         for (uint32_t i = (uint32_t)0U; i < len1; i++)
@@ -395,8 +400,7 @@ Hacl_GenericField32_exp_consttime(
           uint32_t *os = a_bits_l;
           uint32_t x = (c & res_j[i]) | (~c & a_bits_l[i]);
           os[i] = x;
-        }
-      }
+        });
       Hacl_Bignum_Montgomery_bn_mont_mul_u32(len1, k1.n, k1.mu, resM, a_bits_l, resM);
     }
   }
@@ -469,12 +473,13 @@ Hacl_GenericField32_exp_vartime(
     memcpy(table, resM, len1 * sizeof (uint32_t));
     uint32_t *t1 = table + len1;
     memcpy(t1, aMc, len1 * sizeof (uint32_t));
-    for (uint32_t i = (uint32_t)0U; i < (uint32_t)15U; i++)
-    {
+    KRML_MAYBE_FOR15(i,
+      (uint32_t)0U,
+      (uint32_t)15U,
+      (uint32_t)1U,
       uint32_t *t11 = table + i * len1;
       uint32_t *t2 = table + i * len1 + len1;
-      Hacl_Bignum_Montgomery_bn_mont_mul_u32(len1, k1.n, k1.mu, aMc, t11, t2);
-    }
+      Hacl_Bignum_Montgomery_bn_mont_mul_u32(len1, k1.n, k1.mu, aMc, t11, t2););
     if (bBits % (uint32_t)4U != (uint32_t)0U)
     {
       uint32_t mask_l = (uint32_t)16U - (uint32_t)1U;
@@ -497,10 +502,11 @@ Hacl_GenericField32_exp_vartime(
     }
     for (uint32_t i = (uint32_t)0U; i < bBits / (uint32_t)4U; i++)
     {
-      for (uint32_t i0 = (uint32_t)0U; i0 < (uint32_t)4U; i0++)
-      {
-        Hacl_Bignum_Montgomery_bn_mont_sqr_u32(len1, k1.n, k1.mu, resM, resM);
-      }
+      KRML_MAYBE_FOR4(i0,
+        (uint32_t)0U,
+        (uint32_t)4U,
+        (uint32_t)1U,
+        Hacl_Bignum_Montgomery_bn_mont_sqr_u32(len1, k1.n, k1.mu, resM, resM););
       uint32_t bk = bBits - bBits % (uint32_t)4U;
       uint32_t mask_l = (uint32_t)16U - (uint32_t)1U;
       uint32_t i1 = (bk - (uint32_t)4U * i - (uint32_t)4U) / (uint32_t)32U;

--- a/dist/gcc-compatible/Hacl_GenericField64.c
+++ b/dist/gcc-compatible/Hacl_GenericField64.c
@@ -326,12 +326,13 @@ Hacl_GenericField64_exp_consttime(
     memcpy(table, resM, len1 * sizeof (uint64_t));
     uint64_t *t1 = table + len1;
     memcpy(t1, aMc, len1 * sizeof (uint64_t));
-    for (uint32_t i = (uint32_t)0U; i < (uint32_t)15U; i++)
-    {
+    KRML_MAYBE_FOR15(i,
+      (uint32_t)0U,
+      (uint32_t)15U,
+      (uint32_t)1U,
       uint64_t *t11 = table + i * len1;
       uint64_t *t2 = table + i * len1 + len1;
-      Hacl_Bignum_Montgomery_bn_mont_mul_u64(len1, k1.n, k1.mu, aMc, t11, t2);
-    }
+      Hacl_Bignum_Montgomery_bn_mont_mul_u64(len1, k1.n, k1.mu, aMc, t11, t2););
     if (bBits % (uint32_t)4U != (uint32_t)0U)
     {
       uint64_t mask_l = (uint64_t)16U - (uint64_t)1U;
@@ -349,8 +350,10 @@ Hacl_GenericField64_exp_consttime(
       }
       uint64_t bits_c = ite & mask_l;
       memcpy(resM, table, len1 * sizeof (uint64_t));
-      for (uint32_t i1 = (uint32_t)0U; i1 < (uint32_t)15U; i1++)
-      {
+      KRML_MAYBE_FOR15(i1,
+        (uint32_t)0U,
+        (uint32_t)15U,
+        (uint32_t)1U,
         uint64_t c = FStar_UInt64_eq_mask(bits_c, (uint64_t)(i1 + (uint32_t)1U));
         uint64_t *res_j = table + (i1 + (uint32_t)1U) * len1;
         for (uint32_t i = (uint32_t)0U; i < len1; i++)
@@ -358,15 +361,15 @@ Hacl_GenericField64_exp_consttime(
           uint64_t *os = resM;
           uint64_t x = (c & res_j[i]) | (~c & resM[i]);
           os[i] = x;
-        }
-      }
+        });
     }
     for (uint32_t i0 = (uint32_t)0U; i0 < bBits / (uint32_t)4U; i0++)
     {
-      for (uint32_t i = (uint32_t)0U; i < (uint32_t)4U; i++)
-      {
-        Hacl_Bignum_Montgomery_bn_mont_sqr_u64(len1, k1.n, k1.mu, resM, resM);
-      }
+      KRML_MAYBE_FOR4(i,
+        (uint32_t)0U,
+        (uint32_t)4U,
+        (uint32_t)1U,
+        Hacl_Bignum_Montgomery_bn_mont_sqr_u64(len1, k1.n, k1.mu, resM, resM););
       uint32_t bk = bBits - bBits % (uint32_t)4U;
       uint64_t mask_l = (uint64_t)16U - (uint64_t)1U;
       uint32_t i1 = (bk - (uint32_t)4U * i0 - (uint32_t)4U) / (uint32_t)64U;
@@ -386,8 +389,10 @@ Hacl_GenericField64_exp_consttime(
       uint64_t a_bits_l[len1];
       memset(a_bits_l, 0U, len1 * sizeof (uint64_t));
       memcpy(a_bits_l, table, len1 * sizeof (uint64_t));
-      for (uint32_t i2 = (uint32_t)0U; i2 < (uint32_t)15U; i2++)
-      {
+      KRML_MAYBE_FOR15(i2,
+        (uint32_t)0U,
+        (uint32_t)15U,
+        (uint32_t)1U,
         uint64_t c = FStar_UInt64_eq_mask(bits_l, (uint64_t)(i2 + (uint32_t)1U));
         uint64_t *res_j = table + (i2 + (uint32_t)1U) * len1;
         for (uint32_t i = (uint32_t)0U; i < len1; i++)
@@ -395,8 +400,7 @@ Hacl_GenericField64_exp_consttime(
           uint64_t *os = a_bits_l;
           uint64_t x = (c & res_j[i]) | (~c & a_bits_l[i]);
           os[i] = x;
-        }
-      }
+        });
       Hacl_Bignum_Montgomery_bn_mont_mul_u64(len1, k1.n, k1.mu, resM, a_bits_l, resM);
     }
   }
@@ -469,12 +473,13 @@ Hacl_GenericField64_exp_vartime(
     memcpy(table, resM, len1 * sizeof (uint64_t));
     uint64_t *t1 = table + len1;
     memcpy(t1, aMc, len1 * sizeof (uint64_t));
-    for (uint32_t i = (uint32_t)0U; i < (uint32_t)15U; i++)
-    {
+    KRML_MAYBE_FOR15(i,
+      (uint32_t)0U,
+      (uint32_t)15U,
+      (uint32_t)1U,
       uint64_t *t11 = table + i * len1;
       uint64_t *t2 = table + i * len1 + len1;
-      Hacl_Bignum_Montgomery_bn_mont_mul_u64(len1, k1.n, k1.mu, aMc, t11, t2);
-    }
+      Hacl_Bignum_Montgomery_bn_mont_mul_u64(len1, k1.n, k1.mu, aMc, t11, t2););
     if (bBits % (uint32_t)4U != (uint32_t)0U)
     {
       uint64_t mask_l = (uint64_t)16U - (uint64_t)1U;
@@ -497,10 +502,11 @@ Hacl_GenericField64_exp_vartime(
     }
     for (uint32_t i = (uint32_t)0U; i < bBits / (uint32_t)4U; i++)
     {
-      for (uint32_t i0 = (uint32_t)0U; i0 < (uint32_t)4U; i0++)
-      {
-        Hacl_Bignum_Montgomery_bn_mont_sqr_u64(len1, k1.n, k1.mu, resM, resM);
-      }
+      KRML_MAYBE_FOR4(i0,
+        (uint32_t)0U,
+        (uint32_t)4U,
+        (uint32_t)1U,
+        Hacl_Bignum_Montgomery_bn_mont_sqr_u64(len1, k1.n, k1.mu, resM, resM););
       uint32_t bk = bBits - bBits % (uint32_t)4U;
       uint64_t mask_l = (uint64_t)16U - (uint64_t)1U;
       uint32_t i1 = (bk - (uint32_t)4U * i - (uint32_t)4U) / (uint32_t)64U;

--- a/dist/gcc-compatible/Hacl_HPKE_Curve51_CP128_SHA256.c
+++ b/dist/gcc-compatible/Hacl_HPKE_Curve51_CP128_SHA256.c
@@ -667,12 +667,13 @@ Hacl_HPKE_Curve51_CP128_SHA256_sealBase(
     uint64_t s = o_ctx.ctx_seq[0U];
     uint8_t enc[12U] = { 0U };
     store64_be(enc + (uint32_t)4U, s);
-    for (uint32_t i = (uint32_t)0U; i < (uint32_t)12U; i++)
-    {
+    KRML_MAYBE_FOR12(i,
+      (uint32_t)0U,
+      (uint32_t)12U,
+      (uint32_t)1U,
       uint8_t xi = enc[i];
       uint8_t yi = o_ctx.ctx_nonce[i];
-      nonce[i] = xi ^ yi;
-    }
+      nonce[i] = xi ^ yi;);
     Hacl_Chacha20Poly1305_128_aead_encrypt(o_ctx.ctx_key,
       nonce,
       aadlen,
@@ -731,12 +732,13 @@ Hacl_HPKE_Curve51_CP128_SHA256_openBase(
     uint64_t s = o_ctx.ctx_seq[0U];
     uint8_t enc[12U] = { 0U };
     store64_be(enc + (uint32_t)4U, s);
-    for (uint32_t i = (uint32_t)0U; i < (uint32_t)12U; i++)
-    {
+    KRML_MAYBE_FOR12(i,
+      (uint32_t)0U,
+      (uint32_t)12U,
+      (uint32_t)1U,
       uint8_t xi = enc[i];
       uint8_t yi = o_ctx.ctx_nonce[i];
-      nonce[i] = xi ^ yi;
-    }
+      nonce[i] = xi ^ yi;);
     uint32_t
     res1 =
       Hacl_Chacha20Poly1305_128_aead_decrypt(o_ctx.ctx_key,

--- a/dist/gcc-compatible/Hacl_HPKE_Curve51_CP128_SHA512.c
+++ b/dist/gcc-compatible/Hacl_HPKE_Curve51_CP128_SHA512.c
@@ -667,12 +667,13 @@ Hacl_HPKE_Curve51_CP128_SHA512_sealBase(
     uint64_t s = o_ctx.ctx_seq[0U];
     uint8_t enc[12U] = { 0U };
     store64_be(enc + (uint32_t)4U, s);
-    for (uint32_t i = (uint32_t)0U; i < (uint32_t)12U; i++)
-    {
+    KRML_MAYBE_FOR12(i,
+      (uint32_t)0U,
+      (uint32_t)12U,
+      (uint32_t)1U,
       uint8_t xi = enc[i];
       uint8_t yi = o_ctx.ctx_nonce[i];
-      nonce[i] = xi ^ yi;
-    }
+      nonce[i] = xi ^ yi;);
     Hacl_Chacha20Poly1305_128_aead_encrypt(o_ctx.ctx_key,
       nonce,
       aadlen,
@@ -731,12 +732,13 @@ Hacl_HPKE_Curve51_CP128_SHA512_openBase(
     uint64_t s = o_ctx.ctx_seq[0U];
     uint8_t enc[12U] = { 0U };
     store64_be(enc + (uint32_t)4U, s);
-    for (uint32_t i = (uint32_t)0U; i < (uint32_t)12U; i++)
-    {
+    KRML_MAYBE_FOR12(i,
+      (uint32_t)0U,
+      (uint32_t)12U,
+      (uint32_t)1U,
       uint8_t xi = enc[i];
       uint8_t yi = o_ctx.ctx_nonce[i];
-      nonce[i] = xi ^ yi;
-    }
+      nonce[i] = xi ^ yi;);
     uint32_t
     res1 =
       Hacl_Chacha20Poly1305_128_aead_decrypt(o_ctx.ctx_key,

--- a/dist/gcc-compatible/Hacl_HPKE_Curve51_CP256_SHA256.c
+++ b/dist/gcc-compatible/Hacl_HPKE_Curve51_CP256_SHA256.c
@@ -667,12 +667,13 @@ Hacl_HPKE_Curve51_CP256_SHA256_sealBase(
     uint64_t s = o_ctx.ctx_seq[0U];
     uint8_t enc[12U] = { 0U };
     store64_be(enc + (uint32_t)4U, s);
-    for (uint32_t i = (uint32_t)0U; i < (uint32_t)12U; i++)
-    {
+    KRML_MAYBE_FOR12(i,
+      (uint32_t)0U,
+      (uint32_t)12U,
+      (uint32_t)1U,
       uint8_t xi = enc[i];
       uint8_t yi = o_ctx.ctx_nonce[i];
-      nonce[i] = xi ^ yi;
-    }
+      nonce[i] = xi ^ yi;);
     Hacl_Chacha20Poly1305_256_aead_encrypt(o_ctx.ctx_key,
       nonce,
       aadlen,
@@ -731,12 +732,13 @@ Hacl_HPKE_Curve51_CP256_SHA256_openBase(
     uint64_t s = o_ctx.ctx_seq[0U];
     uint8_t enc[12U] = { 0U };
     store64_be(enc + (uint32_t)4U, s);
-    for (uint32_t i = (uint32_t)0U; i < (uint32_t)12U; i++)
-    {
+    KRML_MAYBE_FOR12(i,
+      (uint32_t)0U,
+      (uint32_t)12U,
+      (uint32_t)1U,
       uint8_t xi = enc[i];
       uint8_t yi = o_ctx.ctx_nonce[i];
-      nonce[i] = xi ^ yi;
-    }
+      nonce[i] = xi ^ yi;);
     uint32_t
     res1 =
       Hacl_Chacha20Poly1305_256_aead_decrypt(o_ctx.ctx_key,

--- a/dist/gcc-compatible/Hacl_HPKE_Curve51_CP256_SHA512.c
+++ b/dist/gcc-compatible/Hacl_HPKE_Curve51_CP256_SHA512.c
@@ -667,12 +667,13 @@ Hacl_HPKE_Curve51_CP256_SHA512_sealBase(
     uint64_t s = o_ctx.ctx_seq[0U];
     uint8_t enc[12U] = { 0U };
     store64_be(enc + (uint32_t)4U, s);
-    for (uint32_t i = (uint32_t)0U; i < (uint32_t)12U; i++)
-    {
+    KRML_MAYBE_FOR12(i,
+      (uint32_t)0U,
+      (uint32_t)12U,
+      (uint32_t)1U,
       uint8_t xi = enc[i];
       uint8_t yi = o_ctx.ctx_nonce[i];
-      nonce[i] = xi ^ yi;
-    }
+      nonce[i] = xi ^ yi;);
     Hacl_Chacha20Poly1305_256_aead_encrypt(o_ctx.ctx_key,
       nonce,
       aadlen,
@@ -731,12 +732,13 @@ Hacl_HPKE_Curve51_CP256_SHA512_openBase(
     uint64_t s = o_ctx.ctx_seq[0U];
     uint8_t enc[12U] = { 0U };
     store64_be(enc + (uint32_t)4U, s);
-    for (uint32_t i = (uint32_t)0U; i < (uint32_t)12U; i++)
-    {
+    KRML_MAYBE_FOR12(i,
+      (uint32_t)0U,
+      (uint32_t)12U,
+      (uint32_t)1U,
       uint8_t xi = enc[i];
       uint8_t yi = o_ctx.ctx_nonce[i];
-      nonce[i] = xi ^ yi;
-    }
+      nonce[i] = xi ^ yi;);
     uint32_t
     res1 =
       Hacl_Chacha20Poly1305_256_aead_decrypt(o_ctx.ctx_key,

--- a/dist/gcc-compatible/Hacl_HPKE_Curve51_CP32_SHA256.c
+++ b/dist/gcc-compatible/Hacl_HPKE_Curve51_CP32_SHA256.c
@@ -666,12 +666,13 @@ Hacl_HPKE_Curve51_CP32_SHA256_sealBase(
     uint64_t s = o_ctx.ctx_seq[0U];
     uint8_t enc[12U] = { 0U };
     store64_be(enc + (uint32_t)4U, s);
-    for (uint32_t i = (uint32_t)0U; i < (uint32_t)12U; i++)
-    {
+    KRML_MAYBE_FOR12(i,
+      (uint32_t)0U,
+      (uint32_t)12U,
+      (uint32_t)1U,
       uint8_t xi = enc[i];
       uint8_t yi = o_ctx.ctx_nonce[i];
-      nonce[i] = xi ^ yi;
-    }
+      nonce[i] = xi ^ yi;);
     Hacl_Chacha20Poly1305_32_aead_encrypt(o_ctx.ctx_key,
       nonce,
       aadlen,
@@ -730,12 +731,13 @@ Hacl_HPKE_Curve51_CP32_SHA256_openBase(
     uint64_t s = o_ctx.ctx_seq[0U];
     uint8_t enc[12U] = { 0U };
     store64_be(enc + (uint32_t)4U, s);
-    for (uint32_t i = (uint32_t)0U; i < (uint32_t)12U; i++)
-    {
+    KRML_MAYBE_FOR12(i,
+      (uint32_t)0U,
+      (uint32_t)12U,
+      (uint32_t)1U,
       uint8_t xi = enc[i];
       uint8_t yi = o_ctx.ctx_nonce[i];
-      nonce[i] = xi ^ yi;
-    }
+      nonce[i] = xi ^ yi;);
     uint32_t
     res1 =
       Hacl_Chacha20Poly1305_32_aead_decrypt(o_ctx.ctx_key,

--- a/dist/gcc-compatible/Hacl_HPKE_Curve51_CP32_SHA512.c
+++ b/dist/gcc-compatible/Hacl_HPKE_Curve51_CP32_SHA512.c
@@ -666,12 +666,13 @@ Hacl_HPKE_Curve51_CP32_SHA512_sealBase(
     uint64_t s = o_ctx.ctx_seq[0U];
     uint8_t enc[12U] = { 0U };
     store64_be(enc + (uint32_t)4U, s);
-    for (uint32_t i = (uint32_t)0U; i < (uint32_t)12U; i++)
-    {
+    KRML_MAYBE_FOR12(i,
+      (uint32_t)0U,
+      (uint32_t)12U,
+      (uint32_t)1U,
       uint8_t xi = enc[i];
       uint8_t yi = o_ctx.ctx_nonce[i];
-      nonce[i] = xi ^ yi;
-    }
+      nonce[i] = xi ^ yi;);
     Hacl_Chacha20Poly1305_32_aead_encrypt(o_ctx.ctx_key,
       nonce,
       aadlen,
@@ -730,12 +731,13 @@ Hacl_HPKE_Curve51_CP32_SHA512_openBase(
     uint64_t s = o_ctx.ctx_seq[0U];
     uint8_t enc[12U] = { 0U };
     store64_be(enc + (uint32_t)4U, s);
-    for (uint32_t i = (uint32_t)0U; i < (uint32_t)12U; i++)
-    {
+    KRML_MAYBE_FOR12(i,
+      (uint32_t)0U,
+      (uint32_t)12U,
+      (uint32_t)1U,
       uint8_t xi = enc[i];
       uint8_t yi = o_ctx.ctx_nonce[i];
-      nonce[i] = xi ^ yi;
-    }
+      nonce[i] = xi ^ yi;);
     uint32_t
     res1 =
       Hacl_Chacha20Poly1305_32_aead_decrypt(o_ctx.ctx_key,

--- a/dist/gcc-compatible/Hacl_HPKE_Curve64_CP128_SHA256.c
+++ b/dist/gcc-compatible/Hacl_HPKE_Curve64_CP128_SHA256.c
@@ -667,12 +667,13 @@ Hacl_HPKE_Curve64_CP128_SHA256_sealBase(
     uint64_t s = o_ctx.ctx_seq[0U];
     uint8_t enc[12U] = { 0U };
     store64_be(enc + (uint32_t)4U, s);
-    for (uint32_t i = (uint32_t)0U; i < (uint32_t)12U; i++)
-    {
+    KRML_MAYBE_FOR12(i,
+      (uint32_t)0U,
+      (uint32_t)12U,
+      (uint32_t)1U,
       uint8_t xi = enc[i];
       uint8_t yi = o_ctx.ctx_nonce[i];
-      nonce[i] = xi ^ yi;
-    }
+      nonce[i] = xi ^ yi;);
     Hacl_Chacha20Poly1305_128_aead_encrypt(o_ctx.ctx_key,
       nonce,
       aadlen,
@@ -731,12 +732,13 @@ Hacl_HPKE_Curve64_CP128_SHA256_openBase(
     uint64_t s = o_ctx.ctx_seq[0U];
     uint8_t enc[12U] = { 0U };
     store64_be(enc + (uint32_t)4U, s);
-    for (uint32_t i = (uint32_t)0U; i < (uint32_t)12U; i++)
-    {
+    KRML_MAYBE_FOR12(i,
+      (uint32_t)0U,
+      (uint32_t)12U,
+      (uint32_t)1U,
       uint8_t xi = enc[i];
       uint8_t yi = o_ctx.ctx_nonce[i];
-      nonce[i] = xi ^ yi;
-    }
+      nonce[i] = xi ^ yi;);
     uint32_t
     res1 =
       Hacl_Chacha20Poly1305_128_aead_decrypt(o_ctx.ctx_key,

--- a/dist/gcc-compatible/Hacl_HPKE_Curve64_CP128_SHA512.c
+++ b/dist/gcc-compatible/Hacl_HPKE_Curve64_CP128_SHA512.c
@@ -667,12 +667,13 @@ Hacl_HPKE_Curve64_CP128_SHA512_sealBase(
     uint64_t s = o_ctx.ctx_seq[0U];
     uint8_t enc[12U] = { 0U };
     store64_be(enc + (uint32_t)4U, s);
-    for (uint32_t i = (uint32_t)0U; i < (uint32_t)12U; i++)
-    {
+    KRML_MAYBE_FOR12(i,
+      (uint32_t)0U,
+      (uint32_t)12U,
+      (uint32_t)1U,
       uint8_t xi = enc[i];
       uint8_t yi = o_ctx.ctx_nonce[i];
-      nonce[i] = xi ^ yi;
-    }
+      nonce[i] = xi ^ yi;);
     Hacl_Chacha20Poly1305_128_aead_encrypt(o_ctx.ctx_key,
       nonce,
       aadlen,
@@ -731,12 +732,13 @@ Hacl_HPKE_Curve64_CP128_SHA512_openBase(
     uint64_t s = o_ctx.ctx_seq[0U];
     uint8_t enc[12U] = { 0U };
     store64_be(enc + (uint32_t)4U, s);
-    for (uint32_t i = (uint32_t)0U; i < (uint32_t)12U; i++)
-    {
+    KRML_MAYBE_FOR12(i,
+      (uint32_t)0U,
+      (uint32_t)12U,
+      (uint32_t)1U,
       uint8_t xi = enc[i];
       uint8_t yi = o_ctx.ctx_nonce[i];
-      nonce[i] = xi ^ yi;
-    }
+      nonce[i] = xi ^ yi;);
     uint32_t
     res1 =
       Hacl_Chacha20Poly1305_128_aead_decrypt(o_ctx.ctx_key,

--- a/dist/gcc-compatible/Hacl_HPKE_Curve64_CP256_SHA256.c
+++ b/dist/gcc-compatible/Hacl_HPKE_Curve64_CP256_SHA256.c
@@ -667,12 +667,13 @@ Hacl_HPKE_Curve64_CP256_SHA256_sealBase(
     uint64_t s = o_ctx.ctx_seq[0U];
     uint8_t enc[12U] = { 0U };
     store64_be(enc + (uint32_t)4U, s);
-    for (uint32_t i = (uint32_t)0U; i < (uint32_t)12U; i++)
-    {
+    KRML_MAYBE_FOR12(i,
+      (uint32_t)0U,
+      (uint32_t)12U,
+      (uint32_t)1U,
       uint8_t xi = enc[i];
       uint8_t yi = o_ctx.ctx_nonce[i];
-      nonce[i] = xi ^ yi;
-    }
+      nonce[i] = xi ^ yi;);
     Hacl_Chacha20Poly1305_256_aead_encrypt(o_ctx.ctx_key,
       nonce,
       aadlen,
@@ -731,12 +732,13 @@ Hacl_HPKE_Curve64_CP256_SHA256_openBase(
     uint64_t s = o_ctx.ctx_seq[0U];
     uint8_t enc[12U] = { 0U };
     store64_be(enc + (uint32_t)4U, s);
-    for (uint32_t i = (uint32_t)0U; i < (uint32_t)12U; i++)
-    {
+    KRML_MAYBE_FOR12(i,
+      (uint32_t)0U,
+      (uint32_t)12U,
+      (uint32_t)1U,
       uint8_t xi = enc[i];
       uint8_t yi = o_ctx.ctx_nonce[i];
-      nonce[i] = xi ^ yi;
-    }
+      nonce[i] = xi ^ yi;);
     uint32_t
     res1 =
       Hacl_Chacha20Poly1305_256_aead_decrypt(o_ctx.ctx_key,

--- a/dist/gcc-compatible/Hacl_HPKE_Curve64_CP256_SHA512.c
+++ b/dist/gcc-compatible/Hacl_HPKE_Curve64_CP256_SHA512.c
@@ -667,12 +667,13 @@ Hacl_HPKE_Curve64_CP256_SHA512_sealBase(
     uint64_t s = o_ctx.ctx_seq[0U];
     uint8_t enc[12U] = { 0U };
     store64_be(enc + (uint32_t)4U, s);
-    for (uint32_t i = (uint32_t)0U; i < (uint32_t)12U; i++)
-    {
+    KRML_MAYBE_FOR12(i,
+      (uint32_t)0U,
+      (uint32_t)12U,
+      (uint32_t)1U,
       uint8_t xi = enc[i];
       uint8_t yi = o_ctx.ctx_nonce[i];
-      nonce[i] = xi ^ yi;
-    }
+      nonce[i] = xi ^ yi;);
     Hacl_Chacha20Poly1305_256_aead_encrypt(o_ctx.ctx_key,
       nonce,
       aadlen,
@@ -731,12 +732,13 @@ Hacl_HPKE_Curve64_CP256_SHA512_openBase(
     uint64_t s = o_ctx.ctx_seq[0U];
     uint8_t enc[12U] = { 0U };
     store64_be(enc + (uint32_t)4U, s);
-    for (uint32_t i = (uint32_t)0U; i < (uint32_t)12U; i++)
-    {
+    KRML_MAYBE_FOR12(i,
+      (uint32_t)0U,
+      (uint32_t)12U,
+      (uint32_t)1U,
       uint8_t xi = enc[i];
       uint8_t yi = o_ctx.ctx_nonce[i];
-      nonce[i] = xi ^ yi;
-    }
+      nonce[i] = xi ^ yi;);
     uint32_t
     res1 =
       Hacl_Chacha20Poly1305_256_aead_decrypt(o_ctx.ctx_key,

--- a/dist/gcc-compatible/Hacl_HPKE_Curve64_CP32_SHA256.c
+++ b/dist/gcc-compatible/Hacl_HPKE_Curve64_CP32_SHA256.c
@@ -666,12 +666,13 @@ Hacl_HPKE_Curve64_CP32_SHA256_sealBase(
     uint64_t s = o_ctx.ctx_seq[0U];
     uint8_t enc[12U] = { 0U };
     store64_be(enc + (uint32_t)4U, s);
-    for (uint32_t i = (uint32_t)0U; i < (uint32_t)12U; i++)
-    {
+    KRML_MAYBE_FOR12(i,
+      (uint32_t)0U,
+      (uint32_t)12U,
+      (uint32_t)1U,
       uint8_t xi = enc[i];
       uint8_t yi = o_ctx.ctx_nonce[i];
-      nonce[i] = xi ^ yi;
-    }
+      nonce[i] = xi ^ yi;);
     Hacl_Chacha20Poly1305_32_aead_encrypt(o_ctx.ctx_key,
       nonce,
       aadlen,
@@ -730,12 +731,13 @@ Hacl_HPKE_Curve64_CP32_SHA256_openBase(
     uint64_t s = o_ctx.ctx_seq[0U];
     uint8_t enc[12U] = { 0U };
     store64_be(enc + (uint32_t)4U, s);
-    for (uint32_t i = (uint32_t)0U; i < (uint32_t)12U; i++)
-    {
+    KRML_MAYBE_FOR12(i,
+      (uint32_t)0U,
+      (uint32_t)12U,
+      (uint32_t)1U,
       uint8_t xi = enc[i];
       uint8_t yi = o_ctx.ctx_nonce[i];
-      nonce[i] = xi ^ yi;
-    }
+      nonce[i] = xi ^ yi;);
     uint32_t
     res1 =
       Hacl_Chacha20Poly1305_32_aead_decrypt(o_ctx.ctx_key,

--- a/dist/gcc-compatible/Hacl_HPKE_Curve64_CP32_SHA512.c
+++ b/dist/gcc-compatible/Hacl_HPKE_Curve64_CP32_SHA512.c
@@ -666,12 +666,13 @@ Hacl_HPKE_Curve64_CP32_SHA512_sealBase(
     uint64_t s = o_ctx.ctx_seq[0U];
     uint8_t enc[12U] = { 0U };
     store64_be(enc + (uint32_t)4U, s);
-    for (uint32_t i = (uint32_t)0U; i < (uint32_t)12U; i++)
-    {
+    KRML_MAYBE_FOR12(i,
+      (uint32_t)0U,
+      (uint32_t)12U,
+      (uint32_t)1U,
       uint8_t xi = enc[i];
       uint8_t yi = o_ctx.ctx_nonce[i];
-      nonce[i] = xi ^ yi;
-    }
+      nonce[i] = xi ^ yi;);
     Hacl_Chacha20Poly1305_32_aead_encrypt(o_ctx.ctx_key,
       nonce,
       aadlen,
@@ -730,12 +731,13 @@ Hacl_HPKE_Curve64_CP32_SHA512_openBase(
     uint64_t s = o_ctx.ctx_seq[0U];
     uint8_t enc[12U] = { 0U };
     store64_be(enc + (uint32_t)4U, s);
-    for (uint32_t i = (uint32_t)0U; i < (uint32_t)12U; i++)
-    {
+    KRML_MAYBE_FOR12(i,
+      (uint32_t)0U,
+      (uint32_t)12U,
+      (uint32_t)1U,
       uint8_t xi = enc[i];
       uint8_t yi = o_ctx.ctx_nonce[i];
-      nonce[i] = xi ^ yi;
-    }
+      nonce[i] = xi ^ yi;);
     uint32_t
     res1 =
       Hacl_Chacha20Poly1305_32_aead_decrypt(o_ctx.ctx_key,

--- a/dist/gcc-compatible/Hacl_HPKE_P256_CP128_SHA256.c
+++ b/dist/gcc-compatible/Hacl_HPKE_P256_CP128_SHA256.c
@@ -749,12 +749,13 @@ Hacl_HPKE_P256_CP128_SHA256_sealBase(
     uint64_t s = o_ctx.ctx_seq[0U];
     uint8_t enc[12U] = { 0U };
     store64_be(enc + (uint32_t)4U, s);
-    for (uint32_t i = (uint32_t)0U; i < (uint32_t)12U; i++)
-    {
+    KRML_MAYBE_FOR12(i,
+      (uint32_t)0U,
+      (uint32_t)12U,
+      (uint32_t)1U,
       uint8_t xi = enc[i];
       uint8_t yi = o_ctx.ctx_nonce[i];
-      nonce[i] = xi ^ yi;
-    }
+      nonce[i] = xi ^ yi;);
     Hacl_Chacha20Poly1305_128_aead_encrypt(o_ctx.ctx_key,
       nonce,
       aadlen,
@@ -813,12 +814,13 @@ Hacl_HPKE_P256_CP128_SHA256_openBase(
     uint64_t s = o_ctx.ctx_seq[0U];
     uint8_t enc[12U] = { 0U };
     store64_be(enc + (uint32_t)4U, s);
-    for (uint32_t i = (uint32_t)0U; i < (uint32_t)12U; i++)
-    {
+    KRML_MAYBE_FOR12(i,
+      (uint32_t)0U,
+      (uint32_t)12U,
+      (uint32_t)1U,
       uint8_t xi = enc[i];
       uint8_t yi = o_ctx.ctx_nonce[i];
-      nonce[i] = xi ^ yi;
-    }
+      nonce[i] = xi ^ yi;);
     uint32_t
     res1 =
       Hacl_Chacha20Poly1305_128_aead_decrypt(o_ctx.ctx_key,

--- a/dist/gcc-compatible/Hacl_HPKE_P256_CP256_SHA256.c
+++ b/dist/gcc-compatible/Hacl_HPKE_P256_CP256_SHA256.c
@@ -749,12 +749,13 @@ Hacl_HPKE_P256_CP256_SHA256_sealBase(
     uint64_t s = o_ctx.ctx_seq[0U];
     uint8_t enc[12U] = { 0U };
     store64_be(enc + (uint32_t)4U, s);
-    for (uint32_t i = (uint32_t)0U; i < (uint32_t)12U; i++)
-    {
+    KRML_MAYBE_FOR12(i,
+      (uint32_t)0U,
+      (uint32_t)12U,
+      (uint32_t)1U,
       uint8_t xi = enc[i];
       uint8_t yi = o_ctx.ctx_nonce[i];
-      nonce[i] = xi ^ yi;
-    }
+      nonce[i] = xi ^ yi;);
     Hacl_Chacha20Poly1305_256_aead_encrypt(o_ctx.ctx_key,
       nonce,
       aadlen,
@@ -813,12 +814,13 @@ Hacl_HPKE_P256_CP256_SHA256_openBase(
     uint64_t s = o_ctx.ctx_seq[0U];
     uint8_t enc[12U] = { 0U };
     store64_be(enc + (uint32_t)4U, s);
-    for (uint32_t i = (uint32_t)0U; i < (uint32_t)12U; i++)
-    {
+    KRML_MAYBE_FOR12(i,
+      (uint32_t)0U,
+      (uint32_t)12U,
+      (uint32_t)1U,
       uint8_t xi = enc[i];
       uint8_t yi = o_ctx.ctx_nonce[i];
-      nonce[i] = xi ^ yi;
-    }
+      nonce[i] = xi ^ yi;);
     uint32_t
     res1 =
       Hacl_Chacha20Poly1305_256_aead_decrypt(o_ctx.ctx_key,

--- a/dist/gcc-compatible/Hacl_HPKE_P256_CP32_SHA256.c
+++ b/dist/gcc-compatible/Hacl_HPKE_P256_CP32_SHA256.c
@@ -749,12 +749,13 @@ Hacl_HPKE_P256_CP32_SHA256_sealBase(
     uint64_t s = o_ctx.ctx_seq[0U];
     uint8_t enc[12U] = { 0U };
     store64_be(enc + (uint32_t)4U, s);
-    for (uint32_t i = (uint32_t)0U; i < (uint32_t)12U; i++)
-    {
+    KRML_MAYBE_FOR12(i,
+      (uint32_t)0U,
+      (uint32_t)12U,
+      (uint32_t)1U,
       uint8_t xi = enc[i];
       uint8_t yi = o_ctx.ctx_nonce[i];
-      nonce[i] = xi ^ yi;
-    }
+      nonce[i] = xi ^ yi;);
     Hacl_Chacha20Poly1305_32_aead_encrypt(o_ctx.ctx_key,
       nonce,
       aadlen,
@@ -813,12 +814,13 @@ Hacl_HPKE_P256_CP32_SHA256_openBase(
     uint64_t s = o_ctx.ctx_seq[0U];
     uint8_t enc[12U] = { 0U };
     store64_be(enc + (uint32_t)4U, s);
-    for (uint32_t i = (uint32_t)0U; i < (uint32_t)12U; i++)
-    {
+    KRML_MAYBE_FOR12(i,
+      (uint32_t)0U,
+      (uint32_t)12U,
+      (uint32_t)1U,
       uint8_t xi = enc[i];
       uint8_t yi = o_ctx.ctx_nonce[i];
-      nonce[i] = xi ^ yi;
-    }
+      nonce[i] = xi ^ yi;);
     uint32_t
     res1 =
       Hacl_Chacha20Poly1305_32_aead_decrypt(o_ctx.ctx_key,

--- a/dist/gcc-compatible/Hacl_Hash_Blake2.c
+++ b/dist/gcc-compatible/Hacl_Hash_Blake2.c
@@ -31,15 +31,16 @@ uint64_t Hacl_Hash_Core_Blake2_update_blake2s_32(uint32_t *s, uint64_t totlen, u
   uint32_t wv[16U] = { 0U };
   uint64_t totlen1 = totlen + (uint64_t)(uint32_t)64U;
   uint32_t m_w[16U] = { 0U };
-  for (uint32_t i = (uint32_t)0U; i < (uint32_t)16U; i++)
-  {
+  KRML_MAYBE_FOR16(i,
+    (uint32_t)0U,
+    (uint32_t)16U,
+    (uint32_t)1U,
     uint32_t *os = m_w;
     uint8_t *bj = block + i * (uint32_t)4U;
     uint32_t u = load32_le(bj);
     uint32_t r = u;
     uint32_t x = r;
-    os[i] = x;
-  }
+    os[i] = x;);
   uint32_t mask[4U] = { 0U };
   uint32_t wv_14 = (uint32_t)0U;
   uint32_t wv_15 = (uint32_t)0U;
@@ -49,14 +50,17 @@ uint64_t Hacl_Hash_Core_Blake2_update_blake2s_32(uint32_t *s, uint64_t totlen, u
   mask[3U] = wv_15;
   memcpy(wv, s, (uint32_t)4U * (uint32_t)4U * sizeof (uint32_t));
   uint32_t *wv3 = wv + (uint32_t)3U * (uint32_t)4U;
-  for (uint32_t i = (uint32_t)0U; i < (uint32_t)4U; i++)
-  {
+  KRML_MAYBE_FOR4(i,
+    (uint32_t)0U,
+    (uint32_t)4U,
+    (uint32_t)1U,
     uint32_t *os = wv3;
     uint32_t x = wv3[i] ^ mask[i];
-    os[i] = x;
-  }
-  for (uint32_t i0 = (uint32_t)0U; i0 < (uint32_t)10U; i0++)
-  {
+    os[i] = x;);
+  KRML_MAYBE_FOR10(i0,
+    (uint32_t)0U,
+    (uint32_t)10U,
+    (uint32_t)1U,
     uint32_t start_idx = i0 % (uint32_t)10U * (uint32_t)16U;
     KRML_CHECK_SIZE(sizeof (uint32_t), (uint32_t)4U * (uint32_t)4U);
     uint32_t m_st[(uint32_t)4U * (uint32_t)4U];
@@ -119,112 +123,126 @@ uint64_t Hacl_Hash_Core_Blake2_update_blake2s_32(uint32_t *s, uint64_t totlen, u
     uint32_t d0 = (uint32_t)3U;
     uint32_t *wv_a0 = wv + a * (uint32_t)4U;
     uint32_t *wv_b0 = wv + b0 * (uint32_t)4U;
-    for (uint32_t i = (uint32_t)0U; i < (uint32_t)4U; i++)
-    {
+    KRML_MAYBE_FOR4(i,
+      (uint32_t)0U,
+      (uint32_t)4U,
+      (uint32_t)1U,
       uint32_t *os = wv_a0;
       uint32_t x1 = wv_a0[i] + wv_b0[i];
-      os[i] = x1;
-    }
-    for (uint32_t i = (uint32_t)0U; i < (uint32_t)4U; i++)
-    {
+      os[i] = x1;);
+    KRML_MAYBE_FOR4(i,
+      (uint32_t)0U,
+      (uint32_t)4U,
+      (uint32_t)1U,
       uint32_t *os = wv_a0;
       uint32_t x1 = wv_a0[i] + x[i];
-      os[i] = x1;
-    }
+      os[i] = x1;);
     uint32_t *wv_a1 = wv + d0 * (uint32_t)4U;
     uint32_t *wv_b1 = wv + a * (uint32_t)4U;
-    for (uint32_t i = (uint32_t)0U; i < (uint32_t)4U; i++)
-    {
+    KRML_MAYBE_FOR4(i,
+      (uint32_t)0U,
+      (uint32_t)4U,
+      (uint32_t)1U,
       uint32_t *os = wv_a1;
       uint32_t x1 = wv_a1[i] ^ wv_b1[i];
-      os[i] = x1;
-    }
+      os[i] = x1;);
     uint32_t *r10 = wv_a1;
-    for (uint32_t i = (uint32_t)0U; i < (uint32_t)4U; i++)
-    {
+    KRML_MAYBE_FOR4(i,
+      (uint32_t)0U,
+      (uint32_t)4U,
+      (uint32_t)1U,
       uint32_t *os = r10;
       uint32_t x1 = r10[i];
       uint32_t x10 = x1 >> (uint32_t)16U | x1 << (uint32_t)16U;
-      os[i] = x10;
-    }
+      os[i] = x10;);
     uint32_t *wv_a2 = wv + c0 * (uint32_t)4U;
     uint32_t *wv_b2 = wv + d0 * (uint32_t)4U;
-    for (uint32_t i = (uint32_t)0U; i < (uint32_t)4U; i++)
-    {
+    KRML_MAYBE_FOR4(i,
+      (uint32_t)0U,
+      (uint32_t)4U,
+      (uint32_t)1U,
       uint32_t *os = wv_a2;
       uint32_t x1 = wv_a2[i] + wv_b2[i];
-      os[i] = x1;
-    }
+      os[i] = x1;);
     uint32_t *wv_a3 = wv + b0 * (uint32_t)4U;
     uint32_t *wv_b3 = wv + c0 * (uint32_t)4U;
-    for (uint32_t i = (uint32_t)0U; i < (uint32_t)4U; i++)
-    {
+    KRML_MAYBE_FOR4(i,
+      (uint32_t)0U,
+      (uint32_t)4U,
+      (uint32_t)1U,
       uint32_t *os = wv_a3;
       uint32_t x1 = wv_a3[i] ^ wv_b3[i];
-      os[i] = x1;
-    }
+      os[i] = x1;);
     uint32_t *r12 = wv_a3;
-    for (uint32_t i = (uint32_t)0U; i < (uint32_t)4U; i++)
-    {
+    KRML_MAYBE_FOR4(i,
+      (uint32_t)0U,
+      (uint32_t)4U,
+      (uint32_t)1U,
       uint32_t *os = r12;
       uint32_t x1 = r12[i];
       uint32_t x10 = x1 >> (uint32_t)12U | x1 << (uint32_t)20U;
-      os[i] = x10;
-    }
+      os[i] = x10;);
     uint32_t *wv_a4 = wv + a * (uint32_t)4U;
     uint32_t *wv_b4 = wv + b0 * (uint32_t)4U;
-    for (uint32_t i = (uint32_t)0U; i < (uint32_t)4U; i++)
-    {
+    KRML_MAYBE_FOR4(i,
+      (uint32_t)0U,
+      (uint32_t)4U,
+      (uint32_t)1U,
       uint32_t *os = wv_a4;
       uint32_t x1 = wv_a4[i] + wv_b4[i];
-      os[i] = x1;
-    }
-    for (uint32_t i = (uint32_t)0U; i < (uint32_t)4U; i++)
-    {
+      os[i] = x1;);
+    KRML_MAYBE_FOR4(i,
+      (uint32_t)0U,
+      (uint32_t)4U,
+      (uint32_t)1U,
       uint32_t *os = wv_a4;
       uint32_t x1 = wv_a4[i] + y[i];
-      os[i] = x1;
-    }
+      os[i] = x1;);
     uint32_t *wv_a5 = wv + d0 * (uint32_t)4U;
     uint32_t *wv_b5 = wv + a * (uint32_t)4U;
-    for (uint32_t i = (uint32_t)0U; i < (uint32_t)4U; i++)
-    {
+    KRML_MAYBE_FOR4(i,
+      (uint32_t)0U,
+      (uint32_t)4U,
+      (uint32_t)1U,
       uint32_t *os = wv_a5;
       uint32_t x1 = wv_a5[i] ^ wv_b5[i];
-      os[i] = x1;
-    }
+      os[i] = x1;);
     uint32_t *r13 = wv_a5;
-    for (uint32_t i = (uint32_t)0U; i < (uint32_t)4U; i++)
-    {
+    KRML_MAYBE_FOR4(i,
+      (uint32_t)0U,
+      (uint32_t)4U,
+      (uint32_t)1U,
       uint32_t *os = r13;
       uint32_t x1 = r13[i];
       uint32_t x10 = x1 >> (uint32_t)8U | x1 << (uint32_t)24U;
-      os[i] = x10;
-    }
+      os[i] = x10;);
     uint32_t *wv_a6 = wv + c0 * (uint32_t)4U;
     uint32_t *wv_b6 = wv + d0 * (uint32_t)4U;
-    for (uint32_t i = (uint32_t)0U; i < (uint32_t)4U; i++)
-    {
+    KRML_MAYBE_FOR4(i,
+      (uint32_t)0U,
+      (uint32_t)4U,
+      (uint32_t)1U,
       uint32_t *os = wv_a6;
       uint32_t x1 = wv_a6[i] + wv_b6[i];
-      os[i] = x1;
-    }
+      os[i] = x1;);
     uint32_t *wv_a7 = wv + b0 * (uint32_t)4U;
     uint32_t *wv_b7 = wv + c0 * (uint32_t)4U;
-    for (uint32_t i = (uint32_t)0U; i < (uint32_t)4U; i++)
-    {
+    KRML_MAYBE_FOR4(i,
+      (uint32_t)0U,
+      (uint32_t)4U,
+      (uint32_t)1U,
       uint32_t *os = wv_a7;
       uint32_t x1 = wv_a7[i] ^ wv_b7[i];
-      os[i] = x1;
-    }
+      os[i] = x1;);
     uint32_t *r14 = wv_a7;
-    for (uint32_t i = (uint32_t)0U; i < (uint32_t)4U; i++)
-    {
+    KRML_MAYBE_FOR4(i,
+      (uint32_t)0U,
+      (uint32_t)4U,
+      (uint32_t)1U,
       uint32_t *os = r14;
       uint32_t x1 = r14[i];
       uint32_t x10 = x1 >> (uint32_t)7U | x1 << (uint32_t)25U;
-      os[i] = x10;
-    }
+      os[i] = x10;);
     uint32_t *r15 = wv + (uint32_t)1U * (uint32_t)4U;
     uint32_t *r21 = wv + (uint32_t)2U * (uint32_t)4U;
     uint32_t *r31 = wv + (uint32_t)3U * (uint32_t)4U;
@@ -261,112 +279,126 @@ uint64_t Hacl_Hash_Core_Blake2_update_blake2s_32(uint32_t *s, uint64_t totlen, u
     uint32_t d = (uint32_t)3U;
     uint32_t *wv_a = wv + a0 * (uint32_t)4U;
     uint32_t *wv_b8 = wv + b * (uint32_t)4U;
-    for (uint32_t i = (uint32_t)0U; i < (uint32_t)4U; i++)
-    {
+    KRML_MAYBE_FOR4(i,
+      (uint32_t)0U,
+      (uint32_t)4U,
+      (uint32_t)1U,
       uint32_t *os = wv_a;
       uint32_t x1 = wv_a[i] + wv_b8[i];
-      os[i] = x1;
-    }
-    for (uint32_t i = (uint32_t)0U; i < (uint32_t)4U; i++)
-    {
+      os[i] = x1;);
+    KRML_MAYBE_FOR4(i,
+      (uint32_t)0U,
+      (uint32_t)4U,
+      (uint32_t)1U,
       uint32_t *os = wv_a;
       uint32_t x1 = wv_a[i] + z[i];
-      os[i] = x1;
-    }
+      os[i] = x1;);
     uint32_t *wv_a8 = wv + d * (uint32_t)4U;
     uint32_t *wv_b9 = wv + a0 * (uint32_t)4U;
-    for (uint32_t i = (uint32_t)0U; i < (uint32_t)4U; i++)
-    {
+    KRML_MAYBE_FOR4(i,
+      (uint32_t)0U,
+      (uint32_t)4U,
+      (uint32_t)1U,
       uint32_t *os = wv_a8;
       uint32_t x1 = wv_a8[i] ^ wv_b9[i];
-      os[i] = x1;
-    }
+      os[i] = x1;);
     uint32_t *r16 = wv_a8;
-    for (uint32_t i = (uint32_t)0U; i < (uint32_t)4U; i++)
-    {
+    KRML_MAYBE_FOR4(i,
+      (uint32_t)0U,
+      (uint32_t)4U,
+      (uint32_t)1U,
       uint32_t *os = r16;
       uint32_t x1 = r16[i];
       uint32_t x13 = x1 >> (uint32_t)16U | x1 << (uint32_t)16U;
-      os[i] = x13;
-    }
+      os[i] = x13;);
     uint32_t *wv_a9 = wv + c * (uint32_t)4U;
     uint32_t *wv_b10 = wv + d * (uint32_t)4U;
-    for (uint32_t i = (uint32_t)0U; i < (uint32_t)4U; i++)
-    {
+    KRML_MAYBE_FOR4(i,
+      (uint32_t)0U,
+      (uint32_t)4U,
+      (uint32_t)1U,
       uint32_t *os = wv_a9;
       uint32_t x1 = wv_a9[i] + wv_b10[i];
-      os[i] = x1;
-    }
+      os[i] = x1;);
     uint32_t *wv_a10 = wv + b * (uint32_t)4U;
     uint32_t *wv_b11 = wv + c * (uint32_t)4U;
-    for (uint32_t i = (uint32_t)0U; i < (uint32_t)4U; i++)
-    {
+    KRML_MAYBE_FOR4(i,
+      (uint32_t)0U,
+      (uint32_t)4U,
+      (uint32_t)1U,
       uint32_t *os = wv_a10;
       uint32_t x1 = wv_a10[i] ^ wv_b11[i];
-      os[i] = x1;
-    }
+      os[i] = x1;);
     uint32_t *r17 = wv_a10;
-    for (uint32_t i = (uint32_t)0U; i < (uint32_t)4U; i++)
-    {
+    KRML_MAYBE_FOR4(i,
+      (uint32_t)0U,
+      (uint32_t)4U,
+      (uint32_t)1U,
       uint32_t *os = r17;
       uint32_t x1 = r17[i];
       uint32_t x13 = x1 >> (uint32_t)12U | x1 << (uint32_t)20U;
-      os[i] = x13;
-    }
+      os[i] = x13;);
     uint32_t *wv_a11 = wv + a0 * (uint32_t)4U;
     uint32_t *wv_b12 = wv + b * (uint32_t)4U;
-    for (uint32_t i = (uint32_t)0U; i < (uint32_t)4U; i++)
-    {
+    KRML_MAYBE_FOR4(i,
+      (uint32_t)0U,
+      (uint32_t)4U,
+      (uint32_t)1U,
       uint32_t *os = wv_a11;
       uint32_t x1 = wv_a11[i] + wv_b12[i];
-      os[i] = x1;
-    }
-    for (uint32_t i = (uint32_t)0U; i < (uint32_t)4U; i++)
-    {
+      os[i] = x1;);
+    KRML_MAYBE_FOR4(i,
+      (uint32_t)0U,
+      (uint32_t)4U,
+      (uint32_t)1U,
       uint32_t *os = wv_a11;
       uint32_t x1 = wv_a11[i] + w[i];
-      os[i] = x1;
-    }
+      os[i] = x1;);
     uint32_t *wv_a12 = wv + d * (uint32_t)4U;
     uint32_t *wv_b13 = wv + a0 * (uint32_t)4U;
-    for (uint32_t i = (uint32_t)0U; i < (uint32_t)4U; i++)
-    {
+    KRML_MAYBE_FOR4(i,
+      (uint32_t)0U,
+      (uint32_t)4U,
+      (uint32_t)1U,
       uint32_t *os = wv_a12;
       uint32_t x1 = wv_a12[i] ^ wv_b13[i];
-      os[i] = x1;
-    }
+      os[i] = x1;);
     uint32_t *r18 = wv_a12;
-    for (uint32_t i = (uint32_t)0U; i < (uint32_t)4U; i++)
-    {
+    KRML_MAYBE_FOR4(i,
+      (uint32_t)0U,
+      (uint32_t)4U,
+      (uint32_t)1U,
       uint32_t *os = r18;
       uint32_t x1 = r18[i];
       uint32_t x13 = x1 >> (uint32_t)8U | x1 << (uint32_t)24U;
-      os[i] = x13;
-    }
+      os[i] = x13;);
     uint32_t *wv_a13 = wv + c * (uint32_t)4U;
     uint32_t *wv_b14 = wv + d * (uint32_t)4U;
-    for (uint32_t i = (uint32_t)0U; i < (uint32_t)4U; i++)
-    {
+    KRML_MAYBE_FOR4(i,
+      (uint32_t)0U,
+      (uint32_t)4U,
+      (uint32_t)1U,
       uint32_t *os = wv_a13;
       uint32_t x1 = wv_a13[i] + wv_b14[i];
-      os[i] = x1;
-    }
+      os[i] = x1;);
     uint32_t *wv_a14 = wv + b * (uint32_t)4U;
     uint32_t *wv_b = wv + c * (uint32_t)4U;
-    for (uint32_t i = (uint32_t)0U; i < (uint32_t)4U; i++)
-    {
+    KRML_MAYBE_FOR4(i,
+      (uint32_t)0U,
+      (uint32_t)4U,
+      (uint32_t)1U,
       uint32_t *os = wv_a14;
       uint32_t x1 = wv_a14[i] ^ wv_b[i];
-      os[i] = x1;
-    }
+      os[i] = x1;);
     uint32_t *r19 = wv_a14;
-    for (uint32_t i = (uint32_t)0U; i < (uint32_t)4U; i++)
-    {
+    KRML_MAYBE_FOR4(i,
+      (uint32_t)0U,
+      (uint32_t)4U,
+      (uint32_t)1U,
       uint32_t *os = r19;
       uint32_t x1 = r19[i];
       uint32_t x13 = x1 >> (uint32_t)7U | x1 << (uint32_t)25U;
-      os[i] = x13;
-    }
+      os[i] = x13;);
     uint32_t *r113 = wv + (uint32_t)1U * (uint32_t)4U;
     uint32_t *r2 = wv + (uint32_t)2U * (uint32_t)4U;
     uint32_t *r3 = wv + (uint32_t)3U * (uint32_t)4U;
@@ -396,38 +428,41 @@ uint64_t Hacl_Hash_Core_Blake2_update_blake2s_32(uint32_t *s, uint64_t totlen, u
     r115[0U] = x0;
     r115[1U] = x1;
     r115[2U] = x2;
-    r115[3U] = x3;
-  }
+    r115[3U] = x3;);
   uint32_t *s0 = s + (uint32_t)0U * (uint32_t)4U;
   uint32_t *s1 = s + (uint32_t)1U * (uint32_t)4U;
   uint32_t *r0 = wv + (uint32_t)0U * (uint32_t)4U;
   uint32_t *r1 = wv + (uint32_t)1U * (uint32_t)4U;
   uint32_t *r2 = wv + (uint32_t)2U * (uint32_t)4U;
   uint32_t *r3 = wv + (uint32_t)3U * (uint32_t)4U;
-  for (uint32_t i = (uint32_t)0U; i < (uint32_t)4U; i++)
-  {
+  KRML_MAYBE_FOR4(i,
+    (uint32_t)0U,
+    (uint32_t)4U,
+    (uint32_t)1U,
     uint32_t *os = s0;
     uint32_t x = s0[i] ^ r0[i];
-    os[i] = x;
-  }
-  for (uint32_t i = (uint32_t)0U; i < (uint32_t)4U; i++)
-  {
+    os[i] = x;);
+  KRML_MAYBE_FOR4(i,
+    (uint32_t)0U,
+    (uint32_t)4U,
+    (uint32_t)1U,
     uint32_t *os = s0;
     uint32_t x = s0[i] ^ r2[i];
-    os[i] = x;
-  }
-  for (uint32_t i = (uint32_t)0U; i < (uint32_t)4U; i++)
-  {
+    os[i] = x;);
+  KRML_MAYBE_FOR4(i,
+    (uint32_t)0U,
+    (uint32_t)4U,
+    (uint32_t)1U,
     uint32_t *os = s1;
     uint32_t x = s1[i] ^ r1[i];
-    os[i] = x;
-  }
-  for (uint32_t i = (uint32_t)0U; i < (uint32_t)4U; i++)
-  {
+    os[i] = x;);
+  KRML_MAYBE_FOR4(i,
+    (uint32_t)0U,
+    (uint32_t)4U,
+    (uint32_t)1U,
     uint32_t *os = s1;
     uint32_t x = s1[i] ^ r3[i];
-    os[i] = x;
-  }
+    os[i] = x;);
   return totlen1;
 }
 
@@ -441,14 +476,16 @@ void Hacl_Hash_Core_Blake2_finish_blake2s_32(uint32_t *s, uint64_t ev, uint8_t *
   uint8_t *second = b + (uint32_t)4U * (uint32_t)4U;
   uint32_t *row0 = s + (uint32_t)0U * (uint32_t)4U;
   uint32_t *row1 = s + (uint32_t)1U * (uint32_t)4U;
-  for (uint32_t i = (uint32_t)0U; i < (uint32_t)4U; i++)
-  {
-    store32_le(first + i * (uint32_t)4U, row0[i]);
-  }
-  for (uint32_t i = (uint32_t)0U; i < (uint32_t)4U; i++)
-  {
-    store32_le(second + i * (uint32_t)4U, row1[i]);
-  }
+  KRML_MAYBE_FOR4(i,
+    (uint32_t)0U,
+    (uint32_t)4U,
+    (uint32_t)1U,
+    store32_le(first + i * (uint32_t)4U, row0[i]););
+  KRML_MAYBE_FOR4(i,
+    (uint32_t)0U,
+    (uint32_t)4U,
+    (uint32_t)1U,
+    store32_le(second + i * (uint32_t)4U, row1[i]););
   uint8_t *final = b;
   memcpy(dst, final, (uint32_t)32U * sizeof (uint8_t));
   Lib_Memzero0_memzero(b, double_row * sizeof (b[0U]));
@@ -467,15 +504,16 @@ Hacl_Hash_Core_Blake2_update_blake2b_32(
     FStar_UInt128_add_mod(totlen,
       FStar_UInt128_uint64_to_uint128((uint64_t)(uint32_t)128U));
   uint64_t m_w[16U] = { 0U };
-  for (uint32_t i = (uint32_t)0U; i < (uint32_t)16U; i++)
-  {
+  KRML_MAYBE_FOR16(i,
+    (uint32_t)0U,
+    (uint32_t)16U,
+    (uint32_t)1U,
     uint64_t *os = m_w;
     uint8_t *bj = block + i * (uint32_t)8U;
     uint64_t u = load64_le(bj);
     uint64_t r = u;
     uint64_t x = r;
-    os[i] = x;
-  }
+    os[i] = x;);
   uint64_t mask[4U] = { 0U };
   uint64_t wv_14 = (uint64_t)0U;
   uint64_t wv_15 = (uint64_t)0U;
@@ -485,14 +523,17 @@ Hacl_Hash_Core_Blake2_update_blake2b_32(
   mask[3U] = wv_15;
   memcpy(wv, s, (uint32_t)4U * (uint32_t)4U * sizeof (uint64_t));
   uint64_t *wv3 = wv + (uint32_t)3U * (uint32_t)4U;
-  for (uint32_t i = (uint32_t)0U; i < (uint32_t)4U; i++)
-  {
+  KRML_MAYBE_FOR4(i,
+    (uint32_t)0U,
+    (uint32_t)4U,
+    (uint32_t)1U,
     uint64_t *os = wv3;
     uint64_t x = wv3[i] ^ mask[i];
-    os[i] = x;
-  }
-  for (uint32_t i0 = (uint32_t)0U; i0 < (uint32_t)12U; i0++)
-  {
+    os[i] = x;);
+  KRML_MAYBE_FOR12(i0,
+    (uint32_t)0U,
+    (uint32_t)12U,
+    (uint32_t)1U,
     uint32_t start_idx = i0 % (uint32_t)10U * (uint32_t)16U;
     KRML_CHECK_SIZE(sizeof (uint64_t), (uint32_t)4U * (uint32_t)4U);
     uint64_t m_st[(uint32_t)4U * (uint32_t)4U];
@@ -555,112 +596,126 @@ Hacl_Hash_Core_Blake2_update_blake2b_32(
     uint32_t d0 = (uint32_t)3U;
     uint64_t *wv_a0 = wv + a * (uint32_t)4U;
     uint64_t *wv_b0 = wv + b0 * (uint32_t)4U;
-    for (uint32_t i = (uint32_t)0U; i < (uint32_t)4U; i++)
-    {
+    KRML_MAYBE_FOR4(i,
+      (uint32_t)0U,
+      (uint32_t)4U,
+      (uint32_t)1U,
       uint64_t *os = wv_a0;
       uint64_t x1 = wv_a0[i] + wv_b0[i];
-      os[i] = x1;
-    }
-    for (uint32_t i = (uint32_t)0U; i < (uint32_t)4U; i++)
-    {
+      os[i] = x1;);
+    KRML_MAYBE_FOR4(i,
+      (uint32_t)0U,
+      (uint32_t)4U,
+      (uint32_t)1U,
       uint64_t *os = wv_a0;
       uint64_t x1 = wv_a0[i] + x[i];
-      os[i] = x1;
-    }
+      os[i] = x1;);
     uint64_t *wv_a1 = wv + d0 * (uint32_t)4U;
     uint64_t *wv_b1 = wv + a * (uint32_t)4U;
-    for (uint32_t i = (uint32_t)0U; i < (uint32_t)4U; i++)
-    {
+    KRML_MAYBE_FOR4(i,
+      (uint32_t)0U,
+      (uint32_t)4U,
+      (uint32_t)1U,
       uint64_t *os = wv_a1;
       uint64_t x1 = wv_a1[i] ^ wv_b1[i];
-      os[i] = x1;
-    }
+      os[i] = x1;);
     uint64_t *r10 = wv_a1;
-    for (uint32_t i = (uint32_t)0U; i < (uint32_t)4U; i++)
-    {
+    KRML_MAYBE_FOR4(i,
+      (uint32_t)0U,
+      (uint32_t)4U,
+      (uint32_t)1U,
       uint64_t *os = r10;
       uint64_t x1 = r10[i];
       uint64_t x10 = x1 >> (uint32_t)32U | x1 << (uint32_t)32U;
-      os[i] = x10;
-    }
+      os[i] = x10;);
     uint64_t *wv_a2 = wv + c0 * (uint32_t)4U;
     uint64_t *wv_b2 = wv + d0 * (uint32_t)4U;
-    for (uint32_t i = (uint32_t)0U; i < (uint32_t)4U; i++)
-    {
+    KRML_MAYBE_FOR4(i,
+      (uint32_t)0U,
+      (uint32_t)4U,
+      (uint32_t)1U,
       uint64_t *os = wv_a2;
       uint64_t x1 = wv_a2[i] + wv_b2[i];
-      os[i] = x1;
-    }
+      os[i] = x1;);
     uint64_t *wv_a3 = wv + b0 * (uint32_t)4U;
     uint64_t *wv_b3 = wv + c0 * (uint32_t)4U;
-    for (uint32_t i = (uint32_t)0U; i < (uint32_t)4U; i++)
-    {
+    KRML_MAYBE_FOR4(i,
+      (uint32_t)0U,
+      (uint32_t)4U,
+      (uint32_t)1U,
       uint64_t *os = wv_a3;
       uint64_t x1 = wv_a3[i] ^ wv_b3[i];
-      os[i] = x1;
-    }
+      os[i] = x1;);
     uint64_t *r12 = wv_a3;
-    for (uint32_t i = (uint32_t)0U; i < (uint32_t)4U; i++)
-    {
+    KRML_MAYBE_FOR4(i,
+      (uint32_t)0U,
+      (uint32_t)4U,
+      (uint32_t)1U,
       uint64_t *os = r12;
       uint64_t x1 = r12[i];
       uint64_t x10 = x1 >> (uint32_t)24U | x1 << (uint32_t)40U;
-      os[i] = x10;
-    }
+      os[i] = x10;);
     uint64_t *wv_a4 = wv + a * (uint32_t)4U;
     uint64_t *wv_b4 = wv + b0 * (uint32_t)4U;
-    for (uint32_t i = (uint32_t)0U; i < (uint32_t)4U; i++)
-    {
+    KRML_MAYBE_FOR4(i,
+      (uint32_t)0U,
+      (uint32_t)4U,
+      (uint32_t)1U,
       uint64_t *os = wv_a4;
       uint64_t x1 = wv_a4[i] + wv_b4[i];
-      os[i] = x1;
-    }
-    for (uint32_t i = (uint32_t)0U; i < (uint32_t)4U; i++)
-    {
+      os[i] = x1;);
+    KRML_MAYBE_FOR4(i,
+      (uint32_t)0U,
+      (uint32_t)4U,
+      (uint32_t)1U,
       uint64_t *os = wv_a4;
       uint64_t x1 = wv_a4[i] + y[i];
-      os[i] = x1;
-    }
+      os[i] = x1;);
     uint64_t *wv_a5 = wv + d0 * (uint32_t)4U;
     uint64_t *wv_b5 = wv + a * (uint32_t)4U;
-    for (uint32_t i = (uint32_t)0U; i < (uint32_t)4U; i++)
-    {
+    KRML_MAYBE_FOR4(i,
+      (uint32_t)0U,
+      (uint32_t)4U,
+      (uint32_t)1U,
       uint64_t *os = wv_a5;
       uint64_t x1 = wv_a5[i] ^ wv_b5[i];
-      os[i] = x1;
-    }
+      os[i] = x1;);
     uint64_t *r13 = wv_a5;
-    for (uint32_t i = (uint32_t)0U; i < (uint32_t)4U; i++)
-    {
+    KRML_MAYBE_FOR4(i,
+      (uint32_t)0U,
+      (uint32_t)4U,
+      (uint32_t)1U,
       uint64_t *os = r13;
       uint64_t x1 = r13[i];
       uint64_t x10 = x1 >> (uint32_t)16U | x1 << (uint32_t)48U;
-      os[i] = x10;
-    }
+      os[i] = x10;);
     uint64_t *wv_a6 = wv + c0 * (uint32_t)4U;
     uint64_t *wv_b6 = wv + d0 * (uint32_t)4U;
-    for (uint32_t i = (uint32_t)0U; i < (uint32_t)4U; i++)
-    {
+    KRML_MAYBE_FOR4(i,
+      (uint32_t)0U,
+      (uint32_t)4U,
+      (uint32_t)1U,
       uint64_t *os = wv_a6;
       uint64_t x1 = wv_a6[i] + wv_b6[i];
-      os[i] = x1;
-    }
+      os[i] = x1;);
     uint64_t *wv_a7 = wv + b0 * (uint32_t)4U;
     uint64_t *wv_b7 = wv + c0 * (uint32_t)4U;
-    for (uint32_t i = (uint32_t)0U; i < (uint32_t)4U; i++)
-    {
+    KRML_MAYBE_FOR4(i,
+      (uint32_t)0U,
+      (uint32_t)4U,
+      (uint32_t)1U,
       uint64_t *os = wv_a7;
       uint64_t x1 = wv_a7[i] ^ wv_b7[i];
-      os[i] = x1;
-    }
+      os[i] = x1;);
     uint64_t *r14 = wv_a7;
-    for (uint32_t i = (uint32_t)0U; i < (uint32_t)4U; i++)
-    {
+    KRML_MAYBE_FOR4(i,
+      (uint32_t)0U,
+      (uint32_t)4U,
+      (uint32_t)1U,
       uint64_t *os = r14;
       uint64_t x1 = r14[i];
       uint64_t x10 = x1 >> (uint32_t)63U | x1 << (uint32_t)1U;
-      os[i] = x10;
-    }
+      os[i] = x10;);
     uint64_t *r15 = wv + (uint32_t)1U * (uint32_t)4U;
     uint64_t *r21 = wv + (uint32_t)2U * (uint32_t)4U;
     uint64_t *r31 = wv + (uint32_t)3U * (uint32_t)4U;
@@ -697,112 +752,126 @@ Hacl_Hash_Core_Blake2_update_blake2b_32(
     uint32_t d = (uint32_t)3U;
     uint64_t *wv_a = wv + a0 * (uint32_t)4U;
     uint64_t *wv_b8 = wv + b * (uint32_t)4U;
-    for (uint32_t i = (uint32_t)0U; i < (uint32_t)4U; i++)
-    {
+    KRML_MAYBE_FOR4(i,
+      (uint32_t)0U,
+      (uint32_t)4U,
+      (uint32_t)1U,
       uint64_t *os = wv_a;
       uint64_t x1 = wv_a[i] + wv_b8[i];
-      os[i] = x1;
-    }
-    for (uint32_t i = (uint32_t)0U; i < (uint32_t)4U; i++)
-    {
+      os[i] = x1;);
+    KRML_MAYBE_FOR4(i,
+      (uint32_t)0U,
+      (uint32_t)4U,
+      (uint32_t)1U,
       uint64_t *os = wv_a;
       uint64_t x1 = wv_a[i] + z[i];
-      os[i] = x1;
-    }
+      os[i] = x1;);
     uint64_t *wv_a8 = wv + d * (uint32_t)4U;
     uint64_t *wv_b9 = wv + a0 * (uint32_t)4U;
-    for (uint32_t i = (uint32_t)0U; i < (uint32_t)4U; i++)
-    {
+    KRML_MAYBE_FOR4(i,
+      (uint32_t)0U,
+      (uint32_t)4U,
+      (uint32_t)1U,
       uint64_t *os = wv_a8;
       uint64_t x1 = wv_a8[i] ^ wv_b9[i];
-      os[i] = x1;
-    }
+      os[i] = x1;);
     uint64_t *r16 = wv_a8;
-    for (uint32_t i = (uint32_t)0U; i < (uint32_t)4U; i++)
-    {
+    KRML_MAYBE_FOR4(i,
+      (uint32_t)0U,
+      (uint32_t)4U,
+      (uint32_t)1U,
       uint64_t *os = r16;
       uint64_t x1 = r16[i];
       uint64_t x13 = x1 >> (uint32_t)32U | x1 << (uint32_t)32U;
-      os[i] = x13;
-    }
+      os[i] = x13;);
     uint64_t *wv_a9 = wv + c * (uint32_t)4U;
     uint64_t *wv_b10 = wv + d * (uint32_t)4U;
-    for (uint32_t i = (uint32_t)0U; i < (uint32_t)4U; i++)
-    {
+    KRML_MAYBE_FOR4(i,
+      (uint32_t)0U,
+      (uint32_t)4U,
+      (uint32_t)1U,
       uint64_t *os = wv_a9;
       uint64_t x1 = wv_a9[i] + wv_b10[i];
-      os[i] = x1;
-    }
+      os[i] = x1;);
     uint64_t *wv_a10 = wv + b * (uint32_t)4U;
     uint64_t *wv_b11 = wv + c * (uint32_t)4U;
-    for (uint32_t i = (uint32_t)0U; i < (uint32_t)4U; i++)
-    {
+    KRML_MAYBE_FOR4(i,
+      (uint32_t)0U,
+      (uint32_t)4U,
+      (uint32_t)1U,
       uint64_t *os = wv_a10;
       uint64_t x1 = wv_a10[i] ^ wv_b11[i];
-      os[i] = x1;
-    }
+      os[i] = x1;);
     uint64_t *r17 = wv_a10;
-    for (uint32_t i = (uint32_t)0U; i < (uint32_t)4U; i++)
-    {
+    KRML_MAYBE_FOR4(i,
+      (uint32_t)0U,
+      (uint32_t)4U,
+      (uint32_t)1U,
       uint64_t *os = r17;
       uint64_t x1 = r17[i];
       uint64_t x13 = x1 >> (uint32_t)24U | x1 << (uint32_t)40U;
-      os[i] = x13;
-    }
+      os[i] = x13;);
     uint64_t *wv_a11 = wv + a0 * (uint32_t)4U;
     uint64_t *wv_b12 = wv + b * (uint32_t)4U;
-    for (uint32_t i = (uint32_t)0U; i < (uint32_t)4U; i++)
-    {
+    KRML_MAYBE_FOR4(i,
+      (uint32_t)0U,
+      (uint32_t)4U,
+      (uint32_t)1U,
       uint64_t *os = wv_a11;
       uint64_t x1 = wv_a11[i] + wv_b12[i];
-      os[i] = x1;
-    }
-    for (uint32_t i = (uint32_t)0U; i < (uint32_t)4U; i++)
-    {
+      os[i] = x1;);
+    KRML_MAYBE_FOR4(i,
+      (uint32_t)0U,
+      (uint32_t)4U,
+      (uint32_t)1U,
       uint64_t *os = wv_a11;
       uint64_t x1 = wv_a11[i] + w[i];
-      os[i] = x1;
-    }
+      os[i] = x1;);
     uint64_t *wv_a12 = wv + d * (uint32_t)4U;
     uint64_t *wv_b13 = wv + a0 * (uint32_t)4U;
-    for (uint32_t i = (uint32_t)0U; i < (uint32_t)4U; i++)
-    {
+    KRML_MAYBE_FOR4(i,
+      (uint32_t)0U,
+      (uint32_t)4U,
+      (uint32_t)1U,
       uint64_t *os = wv_a12;
       uint64_t x1 = wv_a12[i] ^ wv_b13[i];
-      os[i] = x1;
-    }
+      os[i] = x1;);
     uint64_t *r18 = wv_a12;
-    for (uint32_t i = (uint32_t)0U; i < (uint32_t)4U; i++)
-    {
+    KRML_MAYBE_FOR4(i,
+      (uint32_t)0U,
+      (uint32_t)4U,
+      (uint32_t)1U,
       uint64_t *os = r18;
       uint64_t x1 = r18[i];
       uint64_t x13 = x1 >> (uint32_t)16U | x1 << (uint32_t)48U;
-      os[i] = x13;
-    }
+      os[i] = x13;);
     uint64_t *wv_a13 = wv + c * (uint32_t)4U;
     uint64_t *wv_b14 = wv + d * (uint32_t)4U;
-    for (uint32_t i = (uint32_t)0U; i < (uint32_t)4U; i++)
-    {
+    KRML_MAYBE_FOR4(i,
+      (uint32_t)0U,
+      (uint32_t)4U,
+      (uint32_t)1U,
       uint64_t *os = wv_a13;
       uint64_t x1 = wv_a13[i] + wv_b14[i];
-      os[i] = x1;
-    }
+      os[i] = x1;);
     uint64_t *wv_a14 = wv + b * (uint32_t)4U;
     uint64_t *wv_b = wv + c * (uint32_t)4U;
-    for (uint32_t i = (uint32_t)0U; i < (uint32_t)4U; i++)
-    {
+    KRML_MAYBE_FOR4(i,
+      (uint32_t)0U,
+      (uint32_t)4U,
+      (uint32_t)1U,
       uint64_t *os = wv_a14;
       uint64_t x1 = wv_a14[i] ^ wv_b[i];
-      os[i] = x1;
-    }
+      os[i] = x1;);
     uint64_t *r19 = wv_a14;
-    for (uint32_t i = (uint32_t)0U; i < (uint32_t)4U; i++)
-    {
+    KRML_MAYBE_FOR4(i,
+      (uint32_t)0U,
+      (uint32_t)4U,
+      (uint32_t)1U,
       uint64_t *os = r19;
       uint64_t x1 = r19[i];
       uint64_t x13 = x1 >> (uint32_t)63U | x1 << (uint32_t)1U;
-      os[i] = x13;
-    }
+      os[i] = x13;);
     uint64_t *r113 = wv + (uint32_t)1U * (uint32_t)4U;
     uint64_t *r2 = wv + (uint32_t)2U * (uint32_t)4U;
     uint64_t *r3 = wv + (uint32_t)3U * (uint32_t)4U;
@@ -832,38 +901,41 @@ Hacl_Hash_Core_Blake2_update_blake2b_32(
     r115[0U] = x0;
     r115[1U] = x1;
     r115[2U] = x2;
-    r115[3U] = x3;
-  }
+    r115[3U] = x3;);
   uint64_t *s0 = s + (uint32_t)0U * (uint32_t)4U;
   uint64_t *s1 = s + (uint32_t)1U * (uint32_t)4U;
   uint64_t *r0 = wv + (uint32_t)0U * (uint32_t)4U;
   uint64_t *r1 = wv + (uint32_t)1U * (uint32_t)4U;
   uint64_t *r2 = wv + (uint32_t)2U * (uint32_t)4U;
   uint64_t *r3 = wv + (uint32_t)3U * (uint32_t)4U;
-  for (uint32_t i = (uint32_t)0U; i < (uint32_t)4U; i++)
-  {
+  KRML_MAYBE_FOR4(i,
+    (uint32_t)0U,
+    (uint32_t)4U,
+    (uint32_t)1U,
     uint64_t *os = s0;
     uint64_t x = s0[i] ^ r0[i];
-    os[i] = x;
-  }
-  for (uint32_t i = (uint32_t)0U; i < (uint32_t)4U; i++)
-  {
+    os[i] = x;);
+  KRML_MAYBE_FOR4(i,
+    (uint32_t)0U,
+    (uint32_t)4U,
+    (uint32_t)1U,
     uint64_t *os = s0;
     uint64_t x = s0[i] ^ r2[i];
-    os[i] = x;
-  }
-  for (uint32_t i = (uint32_t)0U; i < (uint32_t)4U; i++)
-  {
+    os[i] = x;);
+  KRML_MAYBE_FOR4(i,
+    (uint32_t)0U,
+    (uint32_t)4U,
+    (uint32_t)1U,
     uint64_t *os = s1;
     uint64_t x = s1[i] ^ r1[i];
-    os[i] = x;
-  }
-  for (uint32_t i = (uint32_t)0U; i < (uint32_t)4U; i++)
-  {
+    os[i] = x;);
+  KRML_MAYBE_FOR4(i,
+    (uint32_t)0U,
+    (uint32_t)4U,
+    (uint32_t)1U,
     uint64_t *os = s1;
     uint64_t x = s1[i] ^ r3[i];
-    os[i] = x;
-  }
+    os[i] = x;);
   return totlen1;
 }
 
@@ -878,14 +950,16 @@ Hacl_Hash_Core_Blake2_finish_blake2b_32(uint64_t *s, FStar_UInt128_uint128 ev, u
   uint8_t *second = b + (uint32_t)4U * (uint32_t)8U;
   uint64_t *row0 = s + (uint32_t)0U * (uint32_t)4U;
   uint64_t *row1 = s + (uint32_t)1U * (uint32_t)4U;
-  for (uint32_t i = (uint32_t)0U; i < (uint32_t)4U; i++)
-  {
-    store64_le(first + i * (uint32_t)8U, row0[i]);
-  }
-  for (uint32_t i = (uint32_t)0U; i < (uint32_t)4U; i++)
-  {
-    store64_le(second + i * (uint32_t)8U, row1[i]);
-  }
+  KRML_MAYBE_FOR4(i,
+    (uint32_t)0U,
+    (uint32_t)4U,
+    (uint32_t)1U,
+    store64_le(first + i * (uint32_t)8U, row0[i]););
+  KRML_MAYBE_FOR4(i,
+    (uint32_t)0U,
+    (uint32_t)4U,
+    (uint32_t)1U,
+    store64_le(second + i * (uint32_t)8U, row1[i]););
   uint8_t *final = b;
   memcpy(dst, final, (uint32_t)64U * sizeof (uint8_t));
   Lib_Memzero0_memzero(b, double_row * sizeof (b[0U]));
@@ -983,15 +1057,16 @@ Hacl_Hash_Blake2_update_last_blake2s_32(
   memcpy(tmp_rest, rest, rest_len * sizeof (uint8_t));
   uint64_t totlen = ev_ + (uint64_t)rest_len;
   uint32_t m_w[16U] = { 0U };
-  for (uint32_t i = (uint32_t)0U; i < (uint32_t)16U; i++)
-  {
+  KRML_MAYBE_FOR16(i,
+    (uint32_t)0U,
+    (uint32_t)16U,
+    (uint32_t)1U,
     uint32_t *os = m_w;
     uint8_t *bj = tmp + i * (uint32_t)4U;
     uint32_t u = load32_le(bj);
     uint32_t r = u;
     uint32_t x = r;
-    os[i] = x;
-  }
+    os[i] = x;);
   uint32_t mask[4U] = { 0U };
   uint32_t wv_14 = (uint32_t)0xFFFFFFFFU;
   uint32_t wv_15 = (uint32_t)0U;
@@ -1001,14 +1076,17 @@ Hacl_Hash_Blake2_update_last_blake2s_32(
   mask[3U] = wv_15;
   memcpy(wv, s, (uint32_t)4U * (uint32_t)4U * sizeof (uint32_t));
   uint32_t *wv3 = wv + (uint32_t)3U * (uint32_t)4U;
-  for (uint32_t i = (uint32_t)0U; i < (uint32_t)4U; i++)
-  {
+  KRML_MAYBE_FOR4(i,
+    (uint32_t)0U,
+    (uint32_t)4U,
+    (uint32_t)1U,
     uint32_t *os = wv3;
     uint32_t x = wv3[i] ^ mask[i];
-    os[i] = x;
-  }
-  for (uint32_t i0 = (uint32_t)0U; i0 < (uint32_t)10U; i0++)
-  {
+    os[i] = x;);
+  KRML_MAYBE_FOR10(i0,
+    (uint32_t)0U,
+    (uint32_t)10U,
+    (uint32_t)1U,
     uint32_t start_idx = i0 % (uint32_t)10U * (uint32_t)16U;
     KRML_CHECK_SIZE(sizeof (uint32_t), (uint32_t)4U * (uint32_t)4U);
     uint32_t m_st[(uint32_t)4U * (uint32_t)4U];
@@ -1071,112 +1149,126 @@ Hacl_Hash_Blake2_update_last_blake2s_32(
     uint32_t d0 = (uint32_t)3U;
     uint32_t *wv_a0 = wv + a * (uint32_t)4U;
     uint32_t *wv_b0 = wv + b0 * (uint32_t)4U;
-    for (uint32_t i = (uint32_t)0U; i < (uint32_t)4U; i++)
-    {
+    KRML_MAYBE_FOR4(i,
+      (uint32_t)0U,
+      (uint32_t)4U,
+      (uint32_t)1U,
       uint32_t *os = wv_a0;
       uint32_t x1 = wv_a0[i] + wv_b0[i];
-      os[i] = x1;
-    }
-    for (uint32_t i = (uint32_t)0U; i < (uint32_t)4U; i++)
-    {
+      os[i] = x1;);
+    KRML_MAYBE_FOR4(i,
+      (uint32_t)0U,
+      (uint32_t)4U,
+      (uint32_t)1U,
       uint32_t *os = wv_a0;
       uint32_t x1 = wv_a0[i] + x[i];
-      os[i] = x1;
-    }
+      os[i] = x1;);
     uint32_t *wv_a1 = wv + d0 * (uint32_t)4U;
     uint32_t *wv_b1 = wv + a * (uint32_t)4U;
-    for (uint32_t i = (uint32_t)0U; i < (uint32_t)4U; i++)
-    {
+    KRML_MAYBE_FOR4(i,
+      (uint32_t)0U,
+      (uint32_t)4U,
+      (uint32_t)1U,
       uint32_t *os = wv_a1;
       uint32_t x1 = wv_a1[i] ^ wv_b1[i];
-      os[i] = x1;
-    }
+      os[i] = x1;);
     uint32_t *r10 = wv_a1;
-    for (uint32_t i = (uint32_t)0U; i < (uint32_t)4U; i++)
-    {
+    KRML_MAYBE_FOR4(i,
+      (uint32_t)0U,
+      (uint32_t)4U,
+      (uint32_t)1U,
       uint32_t *os = r10;
       uint32_t x1 = r10[i];
       uint32_t x10 = x1 >> (uint32_t)16U | x1 << (uint32_t)16U;
-      os[i] = x10;
-    }
+      os[i] = x10;);
     uint32_t *wv_a2 = wv + c0 * (uint32_t)4U;
     uint32_t *wv_b2 = wv + d0 * (uint32_t)4U;
-    for (uint32_t i = (uint32_t)0U; i < (uint32_t)4U; i++)
-    {
+    KRML_MAYBE_FOR4(i,
+      (uint32_t)0U,
+      (uint32_t)4U,
+      (uint32_t)1U,
       uint32_t *os = wv_a2;
       uint32_t x1 = wv_a2[i] + wv_b2[i];
-      os[i] = x1;
-    }
+      os[i] = x1;);
     uint32_t *wv_a3 = wv + b0 * (uint32_t)4U;
     uint32_t *wv_b3 = wv + c0 * (uint32_t)4U;
-    for (uint32_t i = (uint32_t)0U; i < (uint32_t)4U; i++)
-    {
+    KRML_MAYBE_FOR4(i,
+      (uint32_t)0U,
+      (uint32_t)4U,
+      (uint32_t)1U,
       uint32_t *os = wv_a3;
       uint32_t x1 = wv_a3[i] ^ wv_b3[i];
-      os[i] = x1;
-    }
+      os[i] = x1;);
     uint32_t *r12 = wv_a3;
-    for (uint32_t i = (uint32_t)0U; i < (uint32_t)4U; i++)
-    {
+    KRML_MAYBE_FOR4(i,
+      (uint32_t)0U,
+      (uint32_t)4U,
+      (uint32_t)1U,
       uint32_t *os = r12;
       uint32_t x1 = r12[i];
       uint32_t x10 = x1 >> (uint32_t)12U | x1 << (uint32_t)20U;
-      os[i] = x10;
-    }
+      os[i] = x10;);
     uint32_t *wv_a4 = wv + a * (uint32_t)4U;
     uint32_t *wv_b4 = wv + b0 * (uint32_t)4U;
-    for (uint32_t i = (uint32_t)0U; i < (uint32_t)4U; i++)
-    {
+    KRML_MAYBE_FOR4(i,
+      (uint32_t)0U,
+      (uint32_t)4U,
+      (uint32_t)1U,
       uint32_t *os = wv_a4;
       uint32_t x1 = wv_a4[i] + wv_b4[i];
-      os[i] = x1;
-    }
-    for (uint32_t i = (uint32_t)0U; i < (uint32_t)4U; i++)
-    {
+      os[i] = x1;);
+    KRML_MAYBE_FOR4(i,
+      (uint32_t)0U,
+      (uint32_t)4U,
+      (uint32_t)1U,
       uint32_t *os = wv_a4;
       uint32_t x1 = wv_a4[i] + y[i];
-      os[i] = x1;
-    }
+      os[i] = x1;);
     uint32_t *wv_a5 = wv + d0 * (uint32_t)4U;
     uint32_t *wv_b5 = wv + a * (uint32_t)4U;
-    for (uint32_t i = (uint32_t)0U; i < (uint32_t)4U; i++)
-    {
+    KRML_MAYBE_FOR4(i,
+      (uint32_t)0U,
+      (uint32_t)4U,
+      (uint32_t)1U,
       uint32_t *os = wv_a5;
       uint32_t x1 = wv_a5[i] ^ wv_b5[i];
-      os[i] = x1;
-    }
+      os[i] = x1;);
     uint32_t *r13 = wv_a5;
-    for (uint32_t i = (uint32_t)0U; i < (uint32_t)4U; i++)
-    {
+    KRML_MAYBE_FOR4(i,
+      (uint32_t)0U,
+      (uint32_t)4U,
+      (uint32_t)1U,
       uint32_t *os = r13;
       uint32_t x1 = r13[i];
       uint32_t x10 = x1 >> (uint32_t)8U | x1 << (uint32_t)24U;
-      os[i] = x10;
-    }
+      os[i] = x10;);
     uint32_t *wv_a6 = wv + c0 * (uint32_t)4U;
     uint32_t *wv_b6 = wv + d0 * (uint32_t)4U;
-    for (uint32_t i = (uint32_t)0U; i < (uint32_t)4U; i++)
-    {
+    KRML_MAYBE_FOR4(i,
+      (uint32_t)0U,
+      (uint32_t)4U,
+      (uint32_t)1U,
       uint32_t *os = wv_a6;
       uint32_t x1 = wv_a6[i] + wv_b6[i];
-      os[i] = x1;
-    }
+      os[i] = x1;);
     uint32_t *wv_a7 = wv + b0 * (uint32_t)4U;
     uint32_t *wv_b7 = wv + c0 * (uint32_t)4U;
-    for (uint32_t i = (uint32_t)0U; i < (uint32_t)4U; i++)
-    {
+    KRML_MAYBE_FOR4(i,
+      (uint32_t)0U,
+      (uint32_t)4U,
+      (uint32_t)1U,
       uint32_t *os = wv_a7;
       uint32_t x1 = wv_a7[i] ^ wv_b7[i];
-      os[i] = x1;
-    }
+      os[i] = x1;);
     uint32_t *r14 = wv_a7;
-    for (uint32_t i = (uint32_t)0U; i < (uint32_t)4U; i++)
-    {
+    KRML_MAYBE_FOR4(i,
+      (uint32_t)0U,
+      (uint32_t)4U,
+      (uint32_t)1U,
       uint32_t *os = r14;
       uint32_t x1 = r14[i];
       uint32_t x10 = x1 >> (uint32_t)7U | x1 << (uint32_t)25U;
-      os[i] = x10;
-    }
+      os[i] = x10;);
     uint32_t *r15 = wv + (uint32_t)1U * (uint32_t)4U;
     uint32_t *r21 = wv + (uint32_t)2U * (uint32_t)4U;
     uint32_t *r31 = wv + (uint32_t)3U * (uint32_t)4U;
@@ -1213,112 +1305,126 @@ Hacl_Hash_Blake2_update_last_blake2s_32(
     uint32_t d = (uint32_t)3U;
     uint32_t *wv_a = wv + a0 * (uint32_t)4U;
     uint32_t *wv_b8 = wv + b * (uint32_t)4U;
-    for (uint32_t i = (uint32_t)0U; i < (uint32_t)4U; i++)
-    {
+    KRML_MAYBE_FOR4(i,
+      (uint32_t)0U,
+      (uint32_t)4U,
+      (uint32_t)1U,
       uint32_t *os = wv_a;
       uint32_t x1 = wv_a[i] + wv_b8[i];
-      os[i] = x1;
-    }
-    for (uint32_t i = (uint32_t)0U; i < (uint32_t)4U; i++)
-    {
+      os[i] = x1;);
+    KRML_MAYBE_FOR4(i,
+      (uint32_t)0U,
+      (uint32_t)4U,
+      (uint32_t)1U,
       uint32_t *os = wv_a;
       uint32_t x1 = wv_a[i] + z[i];
-      os[i] = x1;
-    }
+      os[i] = x1;);
     uint32_t *wv_a8 = wv + d * (uint32_t)4U;
     uint32_t *wv_b9 = wv + a0 * (uint32_t)4U;
-    for (uint32_t i = (uint32_t)0U; i < (uint32_t)4U; i++)
-    {
+    KRML_MAYBE_FOR4(i,
+      (uint32_t)0U,
+      (uint32_t)4U,
+      (uint32_t)1U,
       uint32_t *os = wv_a8;
       uint32_t x1 = wv_a8[i] ^ wv_b9[i];
-      os[i] = x1;
-    }
+      os[i] = x1;);
     uint32_t *r16 = wv_a8;
-    for (uint32_t i = (uint32_t)0U; i < (uint32_t)4U; i++)
-    {
+    KRML_MAYBE_FOR4(i,
+      (uint32_t)0U,
+      (uint32_t)4U,
+      (uint32_t)1U,
       uint32_t *os = r16;
       uint32_t x1 = r16[i];
       uint32_t x13 = x1 >> (uint32_t)16U | x1 << (uint32_t)16U;
-      os[i] = x13;
-    }
+      os[i] = x13;);
     uint32_t *wv_a9 = wv + c * (uint32_t)4U;
     uint32_t *wv_b10 = wv + d * (uint32_t)4U;
-    for (uint32_t i = (uint32_t)0U; i < (uint32_t)4U; i++)
-    {
+    KRML_MAYBE_FOR4(i,
+      (uint32_t)0U,
+      (uint32_t)4U,
+      (uint32_t)1U,
       uint32_t *os = wv_a9;
       uint32_t x1 = wv_a9[i] + wv_b10[i];
-      os[i] = x1;
-    }
+      os[i] = x1;);
     uint32_t *wv_a10 = wv + b * (uint32_t)4U;
     uint32_t *wv_b11 = wv + c * (uint32_t)4U;
-    for (uint32_t i = (uint32_t)0U; i < (uint32_t)4U; i++)
-    {
+    KRML_MAYBE_FOR4(i,
+      (uint32_t)0U,
+      (uint32_t)4U,
+      (uint32_t)1U,
       uint32_t *os = wv_a10;
       uint32_t x1 = wv_a10[i] ^ wv_b11[i];
-      os[i] = x1;
-    }
+      os[i] = x1;);
     uint32_t *r17 = wv_a10;
-    for (uint32_t i = (uint32_t)0U; i < (uint32_t)4U; i++)
-    {
+    KRML_MAYBE_FOR4(i,
+      (uint32_t)0U,
+      (uint32_t)4U,
+      (uint32_t)1U,
       uint32_t *os = r17;
       uint32_t x1 = r17[i];
       uint32_t x13 = x1 >> (uint32_t)12U | x1 << (uint32_t)20U;
-      os[i] = x13;
-    }
+      os[i] = x13;);
     uint32_t *wv_a11 = wv + a0 * (uint32_t)4U;
     uint32_t *wv_b12 = wv + b * (uint32_t)4U;
-    for (uint32_t i = (uint32_t)0U; i < (uint32_t)4U; i++)
-    {
+    KRML_MAYBE_FOR4(i,
+      (uint32_t)0U,
+      (uint32_t)4U,
+      (uint32_t)1U,
       uint32_t *os = wv_a11;
       uint32_t x1 = wv_a11[i] + wv_b12[i];
-      os[i] = x1;
-    }
-    for (uint32_t i = (uint32_t)0U; i < (uint32_t)4U; i++)
-    {
+      os[i] = x1;);
+    KRML_MAYBE_FOR4(i,
+      (uint32_t)0U,
+      (uint32_t)4U,
+      (uint32_t)1U,
       uint32_t *os = wv_a11;
       uint32_t x1 = wv_a11[i] + w[i];
-      os[i] = x1;
-    }
+      os[i] = x1;);
     uint32_t *wv_a12 = wv + d * (uint32_t)4U;
     uint32_t *wv_b13 = wv + a0 * (uint32_t)4U;
-    for (uint32_t i = (uint32_t)0U; i < (uint32_t)4U; i++)
-    {
+    KRML_MAYBE_FOR4(i,
+      (uint32_t)0U,
+      (uint32_t)4U,
+      (uint32_t)1U,
       uint32_t *os = wv_a12;
       uint32_t x1 = wv_a12[i] ^ wv_b13[i];
-      os[i] = x1;
-    }
+      os[i] = x1;);
     uint32_t *r18 = wv_a12;
-    for (uint32_t i = (uint32_t)0U; i < (uint32_t)4U; i++)
-    {
+    KRML_MAYBE_FOR4(i,
+      (uint32_t)0U,
+      (uint32_t)4U,
+      (uint32_t)1U,
       uint32_t *os = r18;
       uint32_t x1 = r18[i];
       uint32_t x13 = x1 >> (uint32_t)8U | x1 << (uint32_t)24U;
-      os[i] = x13;
-    }
+      os[i] = x13;);
     uint32_t *wv_a13 = wv + c * (uint32_t)4U;
     uint32_t *wv_b14 = wv + d * (uint32_t)4U;
-    for (uint32_t i = (uint32_t)0U; i < (uint32_t)4U; i++)
-    {
+    KRML_MAYBE_FOR4(i,
+      (uint32_t)0U,
+      (uint32_t)4U,
+      (uint32_t)1U,
       uint32_t *os = wv_a13;
       uint32_t x1 = wv_a13[i] + wv_b14[i];
-      os[i] = x1;
-    }
+      os[i] = x1;);
     uint32_t *wv_a14 = wv + b * (uint32_t)4U;
     uint32_t *wv_b = wv + c * (uint32_t)4U;
-    for (uint32_t i = (uint32_t)0U; i < (uint32_t)4U; i++)
-    {
+    KRML_MAYBE_FOR4(i,
+      (uint32_t)0U,
+      (uint32_t)4U,
+      (uint32_t)1U,
       uint32_t *os = wv_a14;
       uint32_t x1 = wv_a14[i] ^ wv_b[i];
-      os[i] = x1;
-    }
+      os[i] = x1;);
     uint32_t *r19 = wv_a14;
-    for (uint32_t i = (uint32_t)0U; i < (uint32_t)4U; i++)
-    {
+    KRML_MAYBE_FOR4(i,
+      (uint32_t)0U,
+      (uint32_t)4U,
+      (uint32_t)1U,
       uint32_t *os = r19;
       uint32_t x1 = r19[i];
       uint32_t x13 = x1 >> (uint32_t)7U | x1 << (uint32_t)25U;
-      os[i] = x13;
-    }
+      os[i] = x13;);
     uint32_t *r113 = wv + (uint32_t)1U * (uint32_t)4U;
     uint32_t *r2 = wv + (uint32_t)2U * (uint32_t)4U;
     uint32_t *r3 = wv + (uint32_t)3U * (uint32_t)4U;
@@ -1348,38 +1454,41 @@ Hacl_Hash_Blake2_update_last_blake2s_32(
     r115[0U] = x0;
     r115[1U] = x1;
     r115[2U] = x2;
-    r115[3U] = x3;
-  }
+    r115[3U] = x3;);
   uint32_t *s0 = s + (uint32_t)0U * (uint32_t)4U;
   uint32_t *s1 = s + (uint32_t)1U * (uint32_t)4U;
   uint32_t *r0 = wv + (uint32_t)0U * (uint32_t)4U;
   uint32_t *r1 = wv + (uint32_t)1U * (uint32_t)4U;
   uint32_t *r2 = wv + (uint32_t)2U * (uint32_t)4U;
   uint32_t *r3 = wv + (uint32_t)3U * (uint32_t)4U;
-  for (uint32_t i = (uint32_t)0U; i < (uint32_t)4U; i++)
-  {
+  KRML_MAYBE_FOR4(i,
+    (uint32_t)0U,
+    (uint32_t)4U,
+    (uint32_t)1U,
     uint32_t *os = s0;
     uint32_t x = s0[i] ^ r0[i];
-    os[i] = x;
-  }
-  for (uint32_t i = (uint32_t)0U; i < (uint32_t)4U; i++)
-  {
+    os[i] = x;);
+  KRML_MAYBE_FOR4(i,
+    (uint32_t)0U,
+    (uint32_t)4U,
+    (uint32_t)1U,
     uint32_t *os = s0;
     uint32_t x = s0[i] ^ r2[i];
-    os[i] = x;
-  }
-  for (uint32_t i = (uint32_t)0U; i < (uint32_t)4U; i++)
-  {
+    os[i] = x;);
+  KRML_MAYBE_FOR4(i,
+    (uint32_t)0U,
+    (uint32_t)4U,
+    (uint32_t)1U,
     uint32_t *os = s1;
     uint32_t x = s1[i] ^ r1[i];
-    os[i] = x;
-  }
-  for (uint32_t i = (uint32_t)0U; i < (uint32_t)4U; i++)
-  {
+    os[i] = x;);
+  KRML_MAYBE_FOR4(i,
+    (uint32_t)0U,
+    (uint32_t)4U,
+    (uint32_t)1U,
     uint32_t *os = s1;
     uint32_t x = s1[i] ^ r3[i];
-    os[i] = x;
-  }
+    os[i] = x;);
   return (uint64_t)0U;
 }
 
@@ -1432,15 +1541,16 @@ Hacl_Hash_Blake2_update_last_blake2b_32(
   FStar_UInt128_uint128
   totlen = FStar_UInt128_add_mod(ev_, FStar_UInt128_uint64_to_uint128((uint64_t)rest_len));
   uint64_t m_w[16U] = { 0U };
-  for (uint32_t i = (uint32_t)0U; i < (uint32_t)16U; i++)
-  {
+  KRML_MAYBE_FOR16(i,
+    (uint32_t)0U,
+    (uint32_t)16U,
+    (uint32_t)1U,
     uint64_t *os = m_w;
     uint8_t *bj = tmp + i * (uint32_t)8U;
     uint64_t u = load64_le(bj);
     uint64_t r = u;
     uint64_t x = r;
-    os[i] = x;
-  }
+    os[i] = x;);
   uint64_t mask[4U] = { 0U };
   uint64_t wv_14 = (uint64_t)0xFFFFFFFFFFFFFFFFU;
   uint64_t wv_15 = (uint64_t)0U;
@@ -1450,14 +1560,17 @@ Hacl_Hash_Blake2_update_last_blake2b_32(
   mask[3U] = wv_15;
   memcpy(wv, s, (uint32_t)4U * (uint32_t)4U * sizeof (uint64_t));
   uint64_t *wv3 = wv + (uint32_t)3U * (uint32_t)4U;
-  for (uint32_t i = (uint32_t)0U; i < (uint32_t)4U; i++)
-  {
+  KRML_MAYBE_FOR4(i,
+    (uint32_t)0U,
+    (uint32_t)4U,
+    (uint32_t)1U,
     uint64_t *os = wv3;
     uint64_t x = wv3[i] ^ mask[i];
-    os[i] = x;
-  }
-  for (uint32_t i0 = (uint32_t)0U; i0 < (uint32_t)12U; i0++)
-  {
+    os[i] = x;);
+  KRML_MAYBE_FOR12(i0,
+    (uint32_t)0U,
+    (uint32_t)12U,
+    (uint32_t)1U,
     uint32_t start_idx = i0 % (uint32_t)10U * (uint32_t)16U;
     KRML_CHECK_SIZE(sizeof (uint64_t), (uint32_t)4U * (uint32_t)4U);
     uint64_t m_st[(uint32_t)4U * (uint32_t)4U];
@@ -1520,112 +1633,126 @@ Hacl_Hash_Blake2_update_last_blake2b_32(
     uint32_t d0 = (uint32_t)3U;
     uint64_t *wv_a0 = wv + a * (uint32_t)4U;
     uint64_t *wv_b0 = wv + b0 * (uint32_t)4U;
-    for (uint32_t i = (uint32_t)0U; i < (uint32_t)4U; i++)
-    {
+    KRML_MAYBE_FOR4(i,
+      (uint32_t)0U,
+      (uint32_t)4U,
+      (uint32_t)1U,
       uint64_t *os = wv_a0;
       uint64_t x1 = wv_a0[i] + wv_b0[i];
-      os[i] = x1;
-    }
-    for (uint32_t i = (uint32_t)0U; i < (uint32_t)4U; i++)
-    {
+      os[i] = x1;);
+    KRML_MAYBE_FOR4(i,
+      (uint32_t)0U,
+      (uint32_t)4U,
+      (uint32_t)1U,
       uint64_t *os = wv_a0;
       uint64_t x1 = wv_a0[i] + x[i];
-      os[i] = x1;
-    }
+      os[i] = x1;);
     uint64_t *wv_a1 = wv + d0 * (uint32_t)4U;
     uint64_t *wv_b1 = wv + a * (uint32_t)4U;
-    for (uint32_t i = (uint32_t)0U; i < (uint32_t)4U; i++)
-    {
+    KRML_MAYBE_FOR4(i,
+      (uint32_t)0U,
+      (uint32_t)4U,
+      (uint32_t)1U,
       uint64_t *os = wv_a1;
       uint64_t x1 = wv_a1[i] ^ wv_b1[i];
-      os[i] = x1;
-    }
+      os[i] = x1;);
     uint64_t *r10 = wv_a1;
-    for (uint32_t i = (uint32_t)0U; i < (uint32_t)4U; i++)
-    {
+    KRML_MAYBE_FOR4(i,
+      (uint32_t)0U,
+      (uint32_t)4U,
+      (uint32_t)1U,
       uint64_t *os = r10;
       uint64_t x1 = r10[i];
       uint64_t x10 = x1 >> (uint32_t)32U | x1 << (uint32_t)32U;
-      os[i] = x10;
-    }
+      os[i] = x10;);
     uint64_t *wv_a2 = wv + c0 * (uint32_t)4U;
     uint64_t *wv_b2 = wv + d0 * (uint32_t)4U;
-    for (uint32_t i = (uint32_t)0U; i < (uint32_t)4U; i++)
-    {
+    KRML_MAYBE_FOR4(i,
+      (uint32_t)0U,
+      (uint32_t)4U,
+      (uint32_t)1U,
       uint64_t *os = wv_a2;
       uint64_t x1 = wv_a2[i] + wv_b2[i];
-      os[i] = x1;
-    }
+      os[i] = x1;);
     uint64_t *wv_a3 = wv + b0 * (uint32_t)4U;
     uint64_t *wv_b3 = wv + c0 * (uint32_t)4U;
-    for (uint32_t i = (uint32_t)0U; i < (uint32_t)4U; i++)
-    {
+    KRML_MAYBE_FOR4(i,
+      (uint32_t)0U,
+      (uint32_t)4U,
+      (uint32_t)1U,
       uint64_t *os = wv_a3;
       uint64_t x1 = wv_a3[i] ^ wv_b3[i];
-      os[i] = x1;
-    }
+      os[i] = x1;);
     uint64_t *r12 = wv_a3;
-    for (uint32_t i = (uint32_t)0U; i < (uint32_t)4U; i++)
-    {
+    KRML_MAYBE_FOR4(i,
+      (uint32_t)0U,
+      (uint32_t)4U,
+      (uint32_t)1U,
       uint64_t *os = r12;
       uint64_t x1 = r12[i];
       uint64_t x10 = x1 >> (uint32_t)24U | x1 << (uint32_t)40U;
-      os[i] = x10;
-    }
+      os[i] = x10;);
     uint64_t *wv_a4 = wv + a * (uint32_t)4U;
     uint64_t *wv_b4 = wv + b0 * (uint32_t)4U;
-    for (uint32_t i = (uint32_t)0U; i < (uint32_t)4U; i++)
-    {
+    KRML_MAYBE_FOR4(i,
+      (uint32_t)0U,
+      (uint32_t)4U,
+      (uint32_t)1U,
       uint64_t *os = wv_a4;
       uint64_t x1 = wv_a4[i] + wv_b4[i];
-      os[i] = x1;
-    }
-    for (uint32_t i = (uint32_t)0U; i < (uint32_t)4U; i++)
-    {
+      os[i] = x1;);
+    KRML_MAYBE_FOR4(i,
+      (uint32_t)0U,
+      (uint32_t)4U,
+      (uint32_t)1U,
       uint64_t *os = wv_a4;
       uint64_t x1 = wv_a4[i] + y[i];
-      os[i] = x1;
-    }
+      os[i] = x1;);
     uint64_t *wv_a5 = wv + d0 * (uint32_t)4U;
     uint64_t *wv_b5 = wv + a * (uint32_t)4U;
-    for (uint32_t i = (uint32_t)0U; i < (uint32_t)4U; i++)
-    {
+    KRML_MAYBE_FOR4(i,
+      (uint32_t)0U,
+      (uint32_t)4U,
+      (uint32_t)1U,
       uint64_t *os = wv_a5;
       uint64_t x1 = wv_a5[i] ^ wv_b5[i];
-      os[i] = x1;
-    }
+      os[i] = x1;);
     uint64_t *r13 = wv_a5;
-    for (uint32_t i = (uint32_t)0U; i < (uint32_t)4U; i++)
-    {
+    KRML_MAYBE_FOR4(i,
+      (uint32_t)0U,
+      (uint32_t)4U,
+      (uint32_t)1U,
       uint64_t *os = r13;
       uint64_t x1 = r13[i];
       uint64_t x10 = x1 >> (uint32_t)16U | x1 << (uint32_t)48U;
-      os[i] = x10;
-    }
+      os[i] = x10;);
     uint64_t *wv_a6 = wv + c0 * (uint32_t)4U;
     uint64_t *wv_b6 = wv + d0 * (uint32_t)4U;
-    for (uint32_t i = (uint32_t)0U; i < (uint32_t)4U; i++)
-    {
+    KRML_MAYBE_FOR4(i,
+      (uint32_t)0U,
+      (uint32_t)4U,
+      (uint32_t)1U,
       uint64_t *os = wv_a6;
       uint64_t x1 = wv_a6[i] + wv_b6[i];
-      os[i] = x1;
-    }
+      os[i] = x1;);
     uint64_t *wv_a7 = wv + b0 * (uint32_t)4U;
     uint64_t *wv_b7 = wv + c0 * (uint32_t)4U;
-    for (uint32_t i = (uint32_t)0U; i < (uint32_t)4U; i++)
-    {
+    KRML_MAYBE_FOR4(i,
+      (uint32_t)0U,
+      (uint32_t)4U,
+      (uint32_t)1U,
       uint64_t *os = wv_a7;
       uint64_t x1 = wv_a7[i] ^ wv_b7[i];
-      os[i] = x1;
-    }
+      os[i] = x1;);
     uint64_t *r14 = wv_a7;
-    for (uint32_t i = (uint32_t)0U; i < (uint32_t)4U; i++)
-    {
+    KRML_MAYBE_FOR4(i,
+      (uint32_t)0U,
+      (uint32_t)4U,
+      (uint32_t)1U,
       uint64_t *os = r14;
       uint64_t x1 = r14[i];
       uint64_t x10 = x1 >> (uint32_t)63U | x1 << (uint32_t)1U;
-      os[i] = x10;
-    }
+      os[i] = x10;);
     uint64_t *r15 = wv + (uint32_t)1U * (uint32_t)4U;
     uint64_t *r21 = wv + (uint32_t)2U * (uint32_t)4U;
     uint64_t *r31 = wv + (uint32_t)3U * (uint32_t)4U;
@@ -1662,112 +1789,126 @@ Hacl_Hash_Blake2_update_last_blake2b_32(
     uint32_t d = (uint32_t)3U;
     uint64_t *wv_a = wv + a0 * (uint32_t)4U;
     uint64_t *wv_b8 = wv + b * (uint32_t)4U;
-    for (uint32_t i = (uint32_t)0U; i < (uint32_t)4U; i++)
-    {
+    KRML_MAYBE_FOR4(i,
+      (uint32_t)0U,
+      (uint32_t)4U,
+      (uint32_t)1U,
       uint64_t *os = wv_a;
       uint64_t x1 = wv_a[i] + wv_b8[i];
-      os[i] = x1;
-    }
-    for (uint32_t i = (uint32_t)0U; i < (uint32_t)4U; i++)
-    {
+      os[i] = x1;);
+    KRML_MAYBE_FOR4(i,
+      (uint32_t)0U,
+      (uint32_t)4U,
+      (uint32_t)1U,
       uint64_t *os = wv_a;
       uint64_t x1 = wv_a[i] + z[i];
-      os[i] = x1;
-    }
+      os[i] = x1;);
     uint64_t *wv_a8 = wv + d * (uint32_t)4U;
     uint64_t *wv_b9 = wv + a0 * (uint32_t)4U;
-    for (uint32_t i = (uint32_t)0U; i < (uint32_t)4U; i++)
-    {
+    KRML_MAYBE_FOR4(i,
+      (uint32_t)0U,
+      (uint32_t)4U,
+      (uint32_t)1U,
       uint64_t *os = wv_a8;
       uint64_t x1 = wv_a8[i] ^ wv_b9[i];
-      os[i] = x1;
-    }
+      os[i] = x1;);
     uint64_t *r16 = wv_a8;
-    for (uint32_t i = (uint32_t)0U; i < (uint32_t)4U; i++)
-    {
+    KRML_MAYBE_FOR4(i,
+      (uint32_t)0U,
+      (uint32_t)4U,
+      (uint32_t)1U,
       uint64_t *os = r16;
       uint64_t x1 = r16[i];
       uint64_t x13 = x1 >> (uint32_t)32U | x1 << (uint32_t)32U;
-      os[i] = x13;
-    }
+      os[i] = x13;);
     uint64_t *wv_a9 = wv + c * (uint32_t)4U;
     uint64_t *wv_b10 = wv + d * (uint32_t)4U;
-    for (uint32_t i = (uint32_t)0U; i < (uint32_t)4U; i++)
-    {
+    KRML_MAYBE_FOR4(i,
+      (uint32_t)0U,
+      (uint32_t)4U,
+      (uint32_t)1U,
       uint64_t *os = wv_a9;
       uint64_t x1 = wv_a9[i] + wv_b10[i];
-      os[i] = x1;
-    }
+      os[i] = x1;);
     uint64_t *wv_a10 = wv + b * (uint32_t)4U;
     uint64_t *wv_b11 = wv + c * (uint32_t)4U;
-    for (uint32_t i = (uint32_t)0U; i < (uint32_t)4U; i++)
-    {
+    KRML_MAYBE_FOR4(i,
+      (uint32_t)0U,
+      (uint32_t)4U,
+      (uint32_t)1U,
       uint64_t *os = wv_a10;
       uint64_t x1 = wv_a10[i] ^ wv_b11[i];
-      os[i] = x1;
-    }
+      os[i] = x1;);
     uint64_t *r17 = wv_a10;
-    for (uint32_t i = (uint32_t)0U; i < (uint32_t)4U; i++)
-    {
+    KRML_MAYBE_FOR4(i,
+      (uint32_t)0U,
+      (uint32_t)4U,
+      (uint32_t)1U,
       uint64_t *os = r17;
       uint64_t x1 = r17[i];
       uint64_t x13 = x1 >> (uint32_t)24U | x1 << (uint32_t)40U;
-      os[i] = x13;
-    }
+      os[i] = x13;);
     uint64_t *wv_a11 = wv + a0 * (uint32_t)4U;
     uint64_t *wv_b12 = wv + b * (uint32_t)4U;
-    for (uint32_t i = (uint32_t)0U; i < (uint32_t)4U; i++)
-    {
+    KRML_MAYBE_FOR4(i,
+      (uint32_t)0U,
+      (uint32_t)4U,
+      (uint32_t)1U,
       uint64_t *os = wv_a11;
       uint64_t x1 = wv_a11[i] + wv_b12[i];
-      os[i] = x1;
-    }
-    for (uint32_t i = (uint32_t)0U; i < (uint32_t)4U; i++)
-    {
+      os[i] = x1;);
+    KRML_MAYBE_FOR4(i,
+      (uint32_t)0U,
+      (uint32_t)4U,
+      (uint32_t)1U,
       uint64_t *os = wv_a11;
       uint64_t x1 = wv_a11[i] + w[i];
-      os[i] = x1;
-    }
+      os[i] = x1;);
     uint64_t *wv_a12 = wv + d * (uint32_t)4U;
     uint64_t *wv_b13 = wv + a0 * (uint32_t)4U;
-    for (uint32_t i = (uint32_t)0U; i < (uint32_t)4U; i++)
-    {
+    KRML_MAYBE_FOR4(i,
+      (uint32_t)0U,
+      (uint32_t)4U,
+      (uint32_t)1U,
       uint64_t *os = wv_a12;
       uint64_t x1 = wv_a12[i] ^ wv_b13[i];
-      os[i] = x1;
-    }
+      os[i] = x1;);
     uint64_t *r18 = wv_a12;
-    for (uint32_t i = (uint32_t)0U; i < (uint32_t)4U; i++)
-    {
+    KRML_MAYBE_FOR4(i,
+      (uint32_t)0U,
+      (uint32_t)4U,
+      (uint32_t)1U,
       uint64_t *os = r18;
       uint64_t x1 = r18[i];
       uint64_t x13 = x1 >> (uint32_t)16U | x1 << (uint32_t)48U;
-      os[i] = x13;
-    }
+      os[i] = x13;);
     uint64_t *wv_a13 = wv + c * (uint32_t)4U;
     uint64_t *wv_b14 = wv + d * (uint32_t)4U;
-    for (uint32_t i = (uint32_t)0U; i < (uint32_t)4U; i++)
-    {
+    KRML_MAYBE_FOR4(i,
+      (uint32_t)0U,
+      (uint32_t)4U,
+      (uint32_t)1U,
       uint64_t *os = wv_a13;
       uint64_t x1 = wv_a13[i] + wv_b14[i];
-      os[i] = x1;
-    }
+      os[i] = x1;);
     uint64_t *wv_a14 = wv + b * (uint32_t)4U;
     uint64_t *wv_b = wv + c * (uint32_t)4U;
-    for (uint32_t i = (uint32_t)0U; i < (uint32_t)4U; i++)
-    {
+    KRML_MAYBE_FOR4(i,
+      (uint32_t)0U,
+      (uint32_t)4U,
+      (uint32_t)1U,
       uint64_t *os = wv_a14;
       uint64_t x1 = wv_a14[i] ^ wv_b[i];
-      os[i] = x1;
-    }
+      os[i] = x1;);
     uint64_t *r19 = wv_a14;
-    for (uint32_t i = (uint32_t)0U; i < (uint32_t)4U; i++)
-    {
+    KRML_MAYBE_FOR4(i,
+      (uint32_t)0U,
+      (uint32_t)4U,
+      (uint32_t)1U,
       uint64_t *os = r19;
       uint64_t x1 = r19[i];
       uint64_t x13 = x1 >> (uint32_t)63U | x1 << (uint32_t)1U;
-      os[i] = x13;
-    }
+      os[i] = x13;);
     uint64_t *r113 = wv + (uint32_t)1U * (uint32_t)4U;
     uint64_t *r2 = wv + (uint32_t)2U * (uint32_t)4U;
     uint64_t *r3 = wv + (uint32_t)3U * (uint32_t)4U;
@@ -1797,38 +1938,41 @@ Hacl_Hash_Blake2_update_last_blake2b_32(
     r115[0U] = x0;
     r115[1U] = x1;
     r115[2U] = x2;
-    r115[3U] = x3;
-  }
+    r115[3U] = x3;);
   uint64_t *s0 = s + (uint32_t)0U * (uint32_t)4U;
   uint64_t *s1 = s + (uint32_t)1U * (uint32_t)4U;
   uint64_t *r0 = wv + (uint32_t)0U * (uint32_t)4U;
   uint64_t *r1 = wv + (uint32_t)1U * (uint32_t)4U;
   uint64_t *r2 = wv + (uint32_t)2U * (uint32_t)4U;
   uint64_t *r3 = wv + (uint32_t)3U * (uint32_t)4U;
-  for (uint32_t i = (uint32_t)0U; i < (uint32_t)4U; i++)
-  {
+  KRML_MAYBE_FOR4(i,
+    (uint32_t)0U,
+    (uint32_t)4U,
+    (uint32_t)1U,
     uint64_t *os = s0;
     uint64_t x = s0[i] ^ r0[i];
-    os[i] = x;
-  }
-  for (uint32_t i = (uint32_t)0U; i < (uint32_t)4U; i++)
-  {
+    os[i] = x;);
+  KRML_MAYBE_FOR4(i,
+    (uint32_t)0U,
+    (uint32_t)4U,
+    (uint32_t)1U,
     uint64_t *os = s0;
     uint64_t x = s0[i] ^ r2[i];
-    os[i] = x;
-  }
-  for (uint32_t i = (uint32_t)0U; i < (uint32_t)4U; i++)
-  {
+    os[i] = x;);
+  KRML_MAYBE_FOR4(i,
+    (uint32_t)0U,
+    (uint32_t)4U,
+    (uint32_t)1U,
     uint64_t *os = s1;
     uint64_t x = s1[i] ^ r1[i];
-    os[i] = x;
-  }
-  for (uint32_t i = (uint32_t)0U; i < (uint32_t)4U; i++)
-  {
+    os[i] = x;);
+  KRML_MAYBE_FOR4(i,
+    (uint32_t)0U,
+    (uint32_t)4U,
+    (uint32_t)1U,
     uint64_t *os = s1;
     uint64_t x = s1[i] ^ r3[i];
-    os[i] = x;
-  }
+    os[i] = x;);
   return FStar_UInt128_uint64_to_uint128((uint64_t)0U);
 }
 
@@ -1852,15 +1996,16 @@ blake2b_update_block(
 )
 {
   uint64_t m_w[16U] = { 0U };
-  for (uint32_t i = (uint32_t)0U; i < (uint32_t)16U; i++)
-  {
+  KRML_MAYBE_FOR16(i,
+    (uint32_t)0U,
+    (uint32_t)16U,
+    (uint32_t)1U,
     uint64_t *os = m_w;
     uint8_t *bj = d + i * (uint32_t)8U;
     uint64_t u = load64_le(bj);
     uint64_t r = u;
     uint64_t x = r;
-    os[i] = x;
-  }
+    os[i] = x;);
   uint64_t mask[4U] = { 0U };
   uint64_t wv_14;
   if (flag)
@@ -1878,14 +2023,17 @@ blake2b_update_block(
   mask[3U] = wv_15;
   memcpy(wv, hash, (uint32_t)4U * (uint32_t)4U * sizeof (uint64_t));
   uint64_t *wv3 = wv + (uint32_t)3U * (uint32_t)4U;
-  for (uint32_t i = (uint32_t)0U; i < (uint32_t)4U; i++)
-  {
+  KRML_MAYBE_FOR4(i,
+    (uint32_t)0U,
+    (uint32_t)4U,
+    (uint32_t)1U,
     uint64_t *os = wv3;
     uint64_t x = wv3[i] ^ mask[i];
-    os[i] = x;
-  }
-  for (uint32_t i0 = (uint32_t)0U; i0 < (uint32_t)12U; i0++)
-  {
+    os[i] = x;);
+  KRML_MAYBE_FOR12(i0,
+    (uint32_t)0U,
+    (uint32_t)12U,
+    (uint32_t)1U,
     uint32_t start_idx = i0 % (uint32_t)10U * (uint32_t)16U;
     KRML_CHECK_SIZE(sizeof (uint64_t), (uint32_t)4U * (uint32_t)4U);
     uint64_t m_st[(uint32_t)4U * (uint32_t)4U];
@@ -1948,112 +2096,126 @@ blake2b_update_block(
     uint32_t d10 = (uint32_t)3U;
     uint64_t *wv_a0 = wv + a * (uint32_t)4U;
     uint64_t *wv_b0 = wv + b0 * (uint32_t)4U;
-    for (uint32_t i = (uint32_t)0U; i < (uint32_t)4U; i++)
-    {
+    KRML_MAYBE_FOR4(i,
+      (uint32_t)0U,
+      (uint32_t)4U,
+      (uint32_t)1U,
       uint64_t *os = wv_a0;
       uint64_t x1 = wv_a0[i] + wv_b0[i];
-      os[i] = x1;
-    }
-    for (uint32_t i = (uint32_t)0U; i < (uint32_t)4U; i++)
-    {
+      os[i] = x1;);
+    KRML_MAYBE_FOR4(i,
+      (uint32_t)0U,
+      (uint32_t)4U,
+      (uint32_t)1U,
       uint64_t *os = wv_a0;
       uint64_t x1 = wv_a0[i] + x[i];
-      os[i] = x1;
-    }
+      os[i] = x1;);
     uint64_t *wv_a1 = wv + d10 * (uint32_t)4U;
     uint64_t *wv_b1 = wv + a * (uint32_t)4U;
-    for (uint32_t i = (uint32_t)0U; i < (uint32_t)4U; i++)
-    {
+    KRML_MAYBE_FOR4(i,
+      (uint32_t)0U,
+      (uint32_t)4U,
+      (uint32_t)1U,
       uint64_t *os = wv_a1;
       uint64_t x1 = wv_a1[i] ^ wv_b1[i];
-      os[i] = x1;
-    }
+      os[i] = x1;);
     uint64_t *r10 = wv_a1;
-    for (uint32_t i = (uint32_t)0U; i < (uint32_t)4U; i++)
-    {
+    KRML_MAYBE_FOR4(i,
+      (uint32_t)0U,
+      (uint32_t)4U,
+      (uint32_t)1U,
       uint64_t *os = r10;
       uint64_t x1 = r10[i];
       uint64_t x10 = x1 >> (uint32_t)32U | x1 << (uint32_t)32U;
-      os[i] = x10;
-    }
+      os[i] = x10;);
     uint64_t *wv_a2 = wv + c0 * (uint32_t)4U;
     uint64_t *wv_b2 = wv + d10 * (uint32_t)4U;
-    for (uint32_t i = (uint32_t)0U; i < (uint32_t)4U; i++)
-    {
+    KRML_MAYBE_FOR4(i,
+      (uint32_t)0U,
+      (uint32_t)4U,
+      (uint32_t)1U,
       uint64_t *os = wv_a2;
       uint64_t x1 = wv_a2[i] + wv_b2[i];
-      os[i] = x1;
-    }
+      os[i] = x1;);
     uint64_t *wv_a3 = wv + b0 * (uint32_t)4U;
     uint64_t *wv_b3 = wv + c0 * (uint32_t)4U;
-    for (uint32_t i = (uint32_t)0U; i < (uint32_t)4U; i++)
-    {
+    KRML_MAYBE_FOR4(i,
+      (uint32_t)0U,
+      (uint32_t)4U,
+      (uint32_t)1U,
       uint64_t *os = wv_a3;
       uint64_t x1 = wv_a3[i] ^ wv_b3[i];
-      os[i] = x1;
-    }
+      os[i] = x1;);
     uint64_t *r12 = wv_a3;
-    for (uint32_t i = (uint32_t)0U; i < (uint32_t)4U; i++)
-    {
+    KRML_MAYBE_FOR4(i,
+      (uint32_t)0U,
+      (uint32_t)4U,
+      (uint32_t)1U,
       uint64_t *os = r12;
       uint64_t x1 = r12[i];
       uint64_t x10 = x1 >> (uint32_t)24U | x1 << (uint32_t)40U;
-      os[i] = x10;
-    }
+      os[i] = x10;);
     uint64_t *wv_a4 = wv + a * (uint32_t)4U;
     uint64_t *wv_b4 = wv + b0 * (uint32_t)4U;
-    for (uint32_t i = (uint32_t)0U; i < (uint32_t)4U; i++)
-    {
+    KRML_MAYBE_FOR4(i,
+      (uint32_t)0U,
+      (uint32_t)4U,
+      (uint32_t)1U,
       uint64_t *os = wv_a4;
       uint64_t x1 = wv_a4[i] + wv_b4[i];
-      os[i] = x1;
-    }
-    for (uint32_t i = (uint32_t)0U; i < (uint32_t)4U; i++)
-    {
+      os[i] = x1;);
+    KRML_MAYBE_FOR4(i,
+      (uint32_t)0U,
+      (uint32_t)4U,
+      (uint32_t)1U,
       uint64_t *os = wv_a4;
       uint64_t x1 = wv_a4[i] + y[i];
-      os[i] = x1;
-    }
+      os[i] = x1;);
     uint64_t *wv_a5 = wv + d10 * (uint32_t)4U;
     uint64_t *wv_b5 = wv + a * (uint32_t)4U;
-    for (uint32_t i = (uint32_t)0U; i < (uint32_t)4U; i++)
-    {
+    KRML_MAYBE_FOR4(i,
+      (uint32_t)0U,
+      (uint32_t)4U,
+      (uint32_t)1U,
       uint64_t *os = wv_a5;
       uint64_t x1 = wv_a5[i] ^ wv_b5[i];
-      os[i] = x1;
-    }
+      os[i] = x1;);
     uint64_t *r13 = wv_a5;
-    for (uint32_t i = (uint32_t)0U; i < (uint32_t)4U; i++)
-    {
+    KRML_MAYBE_FOR4(i,
+      (uint32_t)0U,
+      (uint32_t)4U,
+      (uint32_t)1U,
       uint64_t *os = r13;
       uint64_t x1 = r13[i];
       uint64_t x10 = x1 >> (uint32_t)16U | x1 << (uint32_t)48U;
-      os[i] = x10;
-    }
+      os[i] = x10;);
     uint64_t *wv_a6 = wv + c0 * (uint32_t)4U;
     uint64_t *wv_b6 = wv + d10 * (uint32_t)4U;
-    for (uint32_t i = (uint32_t)0U; i < (uint32_t)4U; i++)
-    {
+    KRML_MAYBE_FOR4(i,
+      (uint32_t)0U,
+      (uint32_t)4U,
+      (uint32_t)1U,
       uint64_t *os = wv_a6;
       uint64_t x1 = wv_a6[i] + wv_b6[i];
-      os[i] = x1;
-    }
+      os[i] = x1;);
     uint64_t *wv_a7 = wv + b0 * (uint32_t)4U;
     uint64_t *wv_b7 = wv + c0 * (uint32_t)4U;
-    for (uint32_t i = (uint32_t)0U; i < (uint32_t)4U; i++)
-    {
+    KRML_MAYBE_FOR4(i,
+      (uint32_t)0U,
+      (uint32_t)4U,
+      (uint32_t)1U,
       uint64_t *os = wv_a7;
       uint64_t x1 = wv_a7[i] ^ wv_b7[i];
-      os[i] = x1;
-    }
+      os[i] = x1;);
     uint64_t *r14 = wv_a7;
-    for (uint32_t i = (uint32_t)0U; i < (uint32_t)4U; i++)
-    {
+    KRML_MAYBE_FOR4(i,
+      (uint32_t)0U,
+      (uint32_t)4U,
+      (uint32_t)1U,
       uint64_t *os = r14;
       uint64_t x1 = r14[i];
       uint64_t x10 = x1 >> (uint32_t)63U | x1 << (uint32_t)1U;
-      os[i] = x10;
-    }
+      os[i] = x10;);
     uint64_t *r15 = wv + (uint32_t)1U * (uint32_t)4U;
     uint64_t *r21 = wv + (uint32_t)2U * (uint32_t)4U;
     uint64_t *r31 = wv + (uint32_t)3U * (uint32_t)4U;
@@ -2090,112 +2252,126 @@ blake2b_update_block(
     uint32_t d1 = (uint32_t)3U;
     uint64_t *wv_a = wv + a0 * (uint32_t)4U;
     uint64_t *wv_b8 = wv + b * (uint32_t)4U;
-    for (uint32_t i = (uint32_t)0U; i < (uint32_t)4U; i++)
-    {
+    KRML_MAYBE_FOR4(i,
+      (uint32_t)0U,
+      (uint32_t)4U,
+      (uint32_t)1U,
       uint64_t *os = wv_a;
       uint64_t x1 = wv_a[i] + wv_b8[i];
-      os[i] = x1;
-    }
-    for (uint32_t i = (uint32_t)0U; i < (uint32_t)4U; i++)
-    {
+      os[i] = x1;);
+    KRML_MAYBE_FOR4(i,
+      (uint32_t)0U,
+      (uint32_t)4U,
+      (uint32_t)1U,
       uint64_t *os = wv_a;
       uint64_t x1 = wv_a[i] + z[i];
-      os[i] = x1;
-    }
+      os[i] = x1;);
     uint64_t *wv_a8 = wv + d1 * (uint32_t)4U;
     uint64_t *wv_b9 = wv + a0 * (uint32_t)4U;
-    for (uint32_t i = (uint32_t)0U; i < (uint32_t)4U; i++)
-    {
+    KRML_MAYBE_FOR4(i,
+      (uint32_t)0U,
+      (uint32_t)4U,
+      (uint32_t)1U,
       uint64_t *os = wv_a8;
       uint64_t x1 = wv_a8[i] ^ wv_b9[i];
-      os[i] = x1;
-    }
+      os[i] = x1;);
     uint64_t *r16 = wv_a8;
-    for (uint32_t i = (uint32_t)0U; i < (uint32_t)4U; i++)
-    {
+    KRML_MAYBE_FOR4(i,
+      (uint32_t)0U,
+      (uint32_t)4U,
+      (uint32_t)1U,
       uint64_t *os = r16;
       uint64_t x1 = r16[i];
       uint64_t x13 = x1 >> (uint32_t)32U | x1 << (uint32_t)32U;
-      os[i] = x13;
-    }
+      os[i] = x13;);
     uint64_t *wv_a9 = wv + c * (uint32_t)4U;
     uint64_t *wv_b10 = wv + d1 * (uint32_t)4U;
-    for (uint32_t i = (uint32_t)0U; i < (uint32_t)4U; i++)
-    {
+    KRML_MAYBE_FOR4(i,
+      (uint32_t)0U,
+      (uint32_t)4U,
+      (uint32_t)1U,
       uint64_t *os = wv_a9;
       uint64_t x1 = wv_a9[i] + wv_b10[i];
-      os[i] = x1;
-    }
+      os[i] = x1;);
     uint64_t *wv_a10 = wv + b * (uint32_t)4U;
     uint64_t *wv_b11 = wv + c * (uint32_t)4U;
-    for (uint32_t i = (uint32_t)0U; i < (uint32_t)4U; i++)
-    {
+    KRML_MAYBE_FOR4(i,
+      (uint32_t)0U,
+      (uint32_t)4U,
+      (uint32_t)1U,
       uint64_t *os = wv_a10;
       uint64_t x1 = wv_a10[i] ^ wv_b11[i];
-      os[i] = x1;
-    }
+      os[i] = x1;);
     uint64_t *r17 = wv_a10;
-    for (uint32_t i = (uint32_t)0U; i < (uint32_t)4U; i++)
-    {
+    KRML_MAYBE_FOR4(i,
+      (uint32_t)0U,
+      (uint32_t)4U,
+      (uint32_t)1U,
       uint64_t *os = r17;
       uint64_t x1 = r17[i];
       uint64_t x13 = x1 >> (uint32_t)24U | x1 << (uint32_t)40U;
-      os[i] = x13;
-    }
+      os[i] = x13;);
     uint64_t *wv_a11 = wv + a0 * (uint32_t)4U;
     uint64_t *wv_b12 = wv + b * (uint32_t)4U;
-    for (uint32_t i = (uint32_t)0U; i < (uint32_t)4U; i++)
-    {
+    KRML_MAYBE_FOR4(i,
+      (uint32_t)0U,
+      (uint32_t)4U,
+      (uint32_t)1U,
       uint64_t *os = wv_a11;
       uint64_t x1 = wv_a11[i] + wv_b12[i];
-      os[i] = x1;
-    }
-    for (uint32_t i = (uint32_t)0U; i < (uint32_t)4U; i++)
-    {
+      os[i] = x1;);
+    KRML_MAYBE_FOR4(i,
+      (uint32_t)0U,
+      (uint32_t)4U,
+      (uint32_t)1U,
       uint64_t *os = wv_a11;
       uint64_t x1 = wv_a11[i] + w[i];
-      os[i] = x1;
-    }
+      os[i] = x1;);
     uint64_t *wv_a12 = wv + d1 * (uint32_t)4U;
     uint64_t *wv_b13 = wv + a0 * (uint32_t)4U;
-    for (uint32_t i = (uint32_t)0U; i < (uint32_t)4U; i++)
-    {
+    KRML_MAYBE_FOR4(i,
+      (uint32_t)0U,
+      (uint32_t)4U,
+      (uint32_t)1U,
       uint64_t *os = wv_a12;
       uint64_t x1 = wv_a12[i] ^ wv_b13[i];
-      os[i] = x1;
-    }
+      os[i] = x1;);
     uint64_t *r18 = wv_a12;
-    for (uint32_t i = (uint32_t)0U; i < (uint32_t)4U; i++)
-    {
+    KRML_MAYBE_FOR4(i,
+      (uint32_t)0U,
+      (uint32_t)4U,
+      (uint32_t)1U,
       uint64_t *os = r18;
       uint64_t x1 = r18[i];
       uint64_t x13 = x1 >> (uint32_t)16U | x1 << (uint32_t)48U;
-      os[i] = x13;
-    }
+      os[i] = x13;);
     uint64_t *wv_a13 = wv + c * (uint32_t)4U;
     uint64_t *wv_b14 = wv + d1 * (uint32_t)4U;
-    for (uint32_t i = (uint32_t)0U; i < (uint32_t)4U; i++)
-    {
+    KRML_MAYBE_FOR4(i,
+      (uint32_t)0U,
+      (uint32_t)4U,
+      (uint32_t)1U,
       uint64_t *os = wv_a13;
       uint64_t x1 = wv_a13[i] + wv_b14[i];
-      os[i] = x1;
-    }
+      os[i] = x1;);
     uint64_t *wv_a14 = wv + b * (uint32_t)4U;
     uint64_t *wv_b = wv + c * (uint32_t)4U;
-    for (uint32_t i = (uint32_t)0U; i < (uint32_t)4U; i++)
-    {
+    KRML_MAYBE_FOR4(i,
+      (uint32_t)0U,
+      (uint32_t)4U,
+      (uint32_t)1U,
       uint64_t *os = wv_a14;
       uint64_t x1 = wv_a14[i] ^ wv_b[i];
-      os[i] = x1;
-    }
+      os[i] = x1;);
     uint64_t *r19 = wv_a14;
-    for (uint32_t i = (uint32_t)0U; i < (uint32_t)4U; i++)
-    {
+    KRML_MAYBE_FOR4(i,
+      (uint32_t)0U,
+      (uint32_t)4U,
+      (uint32_t)1U,
       uint64_t *os = r19;
       uint64_t x1 = r19[i];
       uint64_t x13 = x1 >> (uint32_t)63U | x1 << (uint32_t)1U;
-      os[i] = x13;
-    }
+      os[i] = x13;);
     uint64_t *r113 = wv + (uint32_t)1U * (uint32_t)4U;
     uint64_t *r2 = wv + (uint32_t)2U * (uint32_t)4U;
     uint64_t *r3 = wv + (uint32_t)3U * (uint32_t)4U;
@@ -2225,38 +2401,41 @@ blake2b_update_block(
     r115[0U] = x0;
     r115[1U] = x1;
     r115[2U] = x2;
-    r115[3U] = x3;
-  }
+    r115[3U] = x3;);
   uint64_t *s0 = hash + (uint32_t)0U * (uint32_t)4U;
   uint64_t *s1 = hash + (uint32_t)1U * (uint32_t)4U;
   uint64_t *r0 = wv + (uint32_t)0U * (uint32_t)4U;
   uint64_t *r1 = wv + (uint32_t)1U * (uint32_t)4U;
   uint64_t *r2 = wv + (uint32_t)2U * (uint32_t)4U;
   uint64_t *r3 = wv + (uint32_t)3U * (uint32_t)4U;
-  for (uint32_t i = (uint32_t)0U; i < (uint32_t)4U; i++)
-  {
+  KRML_MAYBE_FOR4(i,
+    (uint32_t)0U,
+    (uint32_t)4U,
+    (uint32_t)1U,
     uint64_t *os = s0;
     uint64_t x = s0[i] ^ r0[i];
-    os[i] = x;
-  }
-  for (uint32_t i = (uint32_t)0U; i < (uint32_t)4U; i++)
-  {
+    os[i] = x;);
+  KRML_MAYBE_FOR4(i,
+    (uint32_t)0U,
+    (uint32_t)4U,
+    (uint32_t)1U,
     uint64_t *os = s0;
     uint64_t x = s0[i] ^ r2[i];
-    os[i] = x;
-  }
-  for (uint32_t i = (uint32_t)0U; i < (uint32_t)4U; i++)
-  {
+    os[i] = x;);
+  KRML_MAYBE_FOR4(i,
+    (uint32_t)0U,
+    (uint32_t)4U,
+    (uint32_t)1U,
     uint64_t *os = s1;
     uint64_t x = s1[i] ^ r1[i];
-    os[i] = x;
-  }
-  for (uint32_t i = (uint32_t)0U; i < (uint32_t)4U; i++)
-  {
+    os[i] = x;);
+  KRML_MAYBE_FOR4(i,
+    (uint32_t)0U,
+    (uint32_t)4U,
+    (uint32_t)1U,
     uint64_t *os = s1;
     uint64_t x = s1[i] ^ r3[i];
-    os[i] = x;
-  }
+    os[i] = x;);
 }
 
 inline void Hacl_Blake2b_32_blake2b_init(uint64_t *hash, uint32_t kk, uint32_t nn)
@@ -2415,14 +2594,16 @@ inline void Hacl_Blake2b_32_blake2b_finish(uint32_t nn, uint8_t *output, uint64_
   uint8_t *second = b + (uint32_t)4U * (uint32_t)8U;
   uint64_t *row0 = hash + (uint32_t)0U * (uint32_t)4U;
   uint64_t *row1 = hash + (uint32_t)1U * (uint32_t)4U;
-  for (uint32_t i = (uint32_t)0U; i < (uint32_t)4U; i++)
-  {
-    store64_le(first + i * (uint32_t)8U, row0[i]);
-  }
-  for (uint32_t i = (uint32_t)0U; i < (uint32_t)4U; i++)
-  {
-    store64_le(second + i * (uint32_t)8U, row1[i]);
-  }
+  KRML_MAYBE_FOR4(i,
+    (uint32_t)0U,
+    (uint32_t)4U,
+    (uint32_t)1U,
+    store64_le(first + i * (uint32_t)8U, row0[i]););
+  KRML_MAYBE_FOR4(i,
+    (uint32_t)0U,
+    (uint32_t)4U,
+    (uint32_t)1U,
+    store64_le(second + i * (uint32_t)8U, row1[i]););
   uint8_t *final = b;
   memcpy(output, final, nn * sizeof (uint8_t));
   Lib_Memzero0_memzero(b, double_row * sizeof (b[0U]));
@@ -2459,15 +2640,16 @@ static inline void
 blake2s_update_block(uint32_t *wv, uint32_t *hash, bool flag, uint64_t totlen, uint8_t *d)
 {
   uint32_t m_w[16U] = { 0U };
-  for (uint32_t i = (uint32_t)0U; i < (uint32_t)16U; i++)
-  {
+  KRML_MAYBE_FOR16(i,
+    (uint32_t)0U,
+    (uint32_t)16U,
+    (uint32_t)1U,
     uint32_t *os = m_w;
     uint8_t *bj = d + i * (uint32_t)4U;
     uint32_t u = load32_le(bj);
     uint32_t r = u;
     uint32_t x = r;
-    os[i] = x;
-  }
+    os[i] = x;);
   uint32_t mask[4U] = { 0U };
   uint32_t wv_14;
   if (flag)
@@ -2485,14 +2667,17 @@ blake2s_update_block(uint32_t *wv, uint32_t *hash, bool flag, uint64_t totlen, u
   mask[3U] = wv_15;
   memcpy(wv, hash, (uint32_t)4U * (uint32_t)4U * sizeof (uint32_t));
   uint32_t *wv3 = wv + (uint32_t)3U * (uint32_t)4U;
-  for (uint32_t i = (uint32_t)0U; i < (uint32_t)4U; i++)
-  {
+  KRML_MAYBE_FOR4(i,
+    (uint32_t)0U,
+    (uint32_t)4U,
+    (uint32_t)1U,
     uint32_t *os = wv3;
     uint32_t x = wv3[i] ^ mask[i];
-    os[i] = x;
-  }
-  for (uint32_t i0 = (uint32_t)0U; i0 < (uint32_t)10U; i0++)
-  {
+    os[i] = x;);
+  KRML_MAYBE_FOR10(i0,
+    (uint32_t)0U,
+    (uint32_t)10U,
+    (uint32_t)1U,
     uint32_t start_idx = i0 % (uint32_t)10U * (uint32_t)16U;
     KRML_CHECK_SIZE(sizeof (uint32_t), (uint32_t)4U * (uint32_t)4U);
     uint32_t m_st[(uint32_t)4U * (uint32_t)4U];
@@ -2555,112 +2740,126 @@ blake2s_update_block(uint32_t *wv, uint32_t *hash, bool flag, uint64_t totlen, u
     uint32_t d10 = (uint32_t)3U;
     uint32_t *wv_a0 = wv + a * (uint32_t)4U;
     uint32_t *wv_b0 = wv + b0 * (uint32_t)4U;
-    for (uint32_t i = (uint32_t)0U; i < (uint32_t)4U; i++)
-    {
+    KRML_MAYBE_FOR4(i,
+      (uint32_t)0U,
+      (uint32_t)4U,
+      (uint32_t)1U,
       uint32_t *os = wv_a0;
       uint32_t x1 = wv_a0[i] + wv_b0[i];
-      os[i] = x1;
-    }
-    for (uint32_t i = (uint32_t)0U; i < (uint32_t)4U; i++)
-    {
+      os[i] = x1;);
+    KRML_MAYBE_FOR4(i,
+      (uint32_t)0U,
+      (uint32_t)4U,
+      (uint32_t)1U,
       uint32_t *os = wv_a0;
       uint32_t x1 = wv_a0[i] + x[i];
-      os[i] = x1;
-    }
+      os[i] = x1;);
     uint32_t *wv_a1 = wv + d10 * (uint32_t)4U;
     uint32_t *wv_b1 = wv + a * (uint32_t)4U;
-    for (uint32_t i = (uint32_t)0U; i < (uint32_t)4U; i++)
-    {
+    KRML_MAYBE_FOR4(i,
+      (uint32_t)0U,
+      (uint32_t)4U,
+      (uint32_t)1U,
       uint32_t *os = wv_a1;
       uint32_t x1 = wv_a1[i] ^ wv_b1[i];
-      os[i] = x1;
-    }
+      os[i] = x1;);
     uint32_t *r10 = wv_a1;
-    for (uint32_t i = (uint32_t)0U; i < (uint32_t)4U; i++)
-    {
+    KRML_MAYBE_FOR4(i,
+      (uint32_t)0U,
+      (uint32_t)4U,
+      (uint32_t)1U,
       uint32_t *os = r10;
       uint32_t x1 = r10[i];
       uint32_t x10 = x1 >> (uint32_t)16U | x1 << (uint32_t)16U;
-      os[i] = x10;
-    }
+      os[i] = x10;);
     uint32_t *wv_a2 = wv + c0 * (uint32_t)4U;
     uint32_t *wv_b2 = wv + d10 * (uint32_t)4U;
-    for (uint32_t i = (uint32_t)0U; i < (uint32_t)4U; i++)
-    {
+    KRML_MAYBE_FOR4(i,
+      (uint32_t)0U,
+      (uint32_t)4U,
+      (uint32_t)1U,
       uint32_t *os = wv_a2;
       uint32_t x1 = wv_a2[i] + wv_b2[i];
-      os[i] = x1;
-    }
+      os[i] = x1;);
     uint32_t *wv_a3 = wv + b0 * (uint32_t)4U;
     uint32_t *wv_b3 = wv + c0 * (uint32_t)4U;
-    for (uint32_t i = (uint32_t)0U; i < (uint32_t)4U; i++)
-    {
+    KRML_MAYBE_FOR4(i,
+      (uint32_t)0U,
+      (uint32_t)4U,
+      (uint32_t)1U,
       uint32_t *os = wv_a3;
       uint32_t x1 = wv_a3[i] ^ wv_b3[i];
-      os[i] = x1;
-    }
+      os[i] = x1;);
     uint32_t *r12 = wv_a3;
-    for (uint32_t i = (uint32_t)0U; i < (uint32_t)4U; i++)
-    {
+    KRML_MAYBE_FOR4(i,
+      (uint32_t)0U,
+      (uint32_t)4U,
+      (uint32_t)1U,
       uint32_t *os = r12;
       uint32_t x1 = r12[i];
       uint32_t x10 = x1 >> (uint32_t)12U | x1 << (uint32_t)20U;
-      os[i] = x10;
-    }
+      os[i] = x10;);
     uint32_t *wv_a4 = wv + a * (uint32_t)4U;
     uint32_t *wv_b4 = wv + b0 * (uint32_t)4U;
-    for (uint32_t i = (uint32_t)0U; i < (uint32_t)4U; i++)
-    {
+    KRML_MAYBE_FOR4(i,
+      (uint32_t)0U,
+      (uint32_t)4U,
+      (uint32_t)1U,
       uint32_t *os = wv_a4;
       uint32_t x1 = wv_a4[i] + wv_b4[i];
-      os[i] = x1;
-    }
-    for (uint32_t i = (uint32_t)0U; i < (uint32_t)4U; i++)
-    {
+      os[i] = x1;);
+    KRML_MAYBE_FOR4(i,
+      (uint32_t)0U,
+      (uint32_t)4U,
+      (uint32_t)1U,
       uint32_t *os = wv_a4;
       uint32_t x1 = wv_a4[i] + y[i];
-      os[i] = x1;
-    }
+      os[i] = x1;);
     uint32_t *wv_a5 = wv + d10 * (uint32_t)4U;
     uint32_t *wv_b5 = wv + a * (uint32_t)4U;
-    for (uint32_t i = (uint32_t)0U; i < (uint32_t)4U; i++)
-    {
+    KRML_MAYBE_FOR4(i,
+      (uint32_t)0U,
+      (uint32_t)4U,
+      (uint32_t)1U,
       uint32_t *os = wv_a5;
       uint32_t x1 = wv_a5[i] ^ wv_b5[i];
-      os[i] = x1;
-    }
+      os[i] = x1;);
     uint32_t *r13 = wv_a5;
-    for (uint32_t i = (uint32_t)0U; i < (uint32_t)4U; i++)
-    {
+    KRML_MAYBE_FOR4(i,
+      (uint32_t)0U,
+      (uint32_t)4U,
+      (uint32_t)1U,
       uint32_t *os = r13;
       uint32_t x1 = r13[i];
       uint32_t x10 = x1 >> (uint32_t)8U | x1 << (uint32_t)24U;
-      os[i] = x10;
-    }
+      os[i] = x10;);
     uint32_t *wv_a6 = wv + c0 * (uint32_t)4U;
     uint32_t *wv_b6 = wv + d10 * (uint32_t)4U;
-    for (uint32_t i = (uint32_t)0U; i < (uint32_t)4U; i++)
-    {
+    KRML_MAYBE_FOR4(i,
+      (uint32_t)0U,
+      (uint32_t)4U,
+      (uint32_t)1U,
       uint32_t *os = wv_a6;
       uint32_t x1 = wv_a6[i] + wv_b6[i];
-      os[i] = x1;
-    }
+      os[i] = x1;);
     uint32_t *wv_a7 = wv + b0 * (uint32_t)4U;
     uint32_t *wv_b7 = wv + c0 * (uint32_t)4U;
-    for (uint32_t i = (uint32_t)0U; i < (uint32_t)4U; i++)
-    {
+    KRML_MAYBE_FOR4(i,
+      (uint32_t)0U,
+      (uint32_t)4U,
+      (uint32_t)1U,
       uint32_t *os = wv_a7;
       uint32_t x1 = wv_a7[i] ^ wv_b7[i];
-      os[i] = x1;
-    }
+      os[i] = x1;);
     uint32_t *r14 = wv_a7;
-    for (uint32_t i = (uint32_t)0U; i < (uint32_t)4U; i++)
-    {
+    KRML_MAYBE_FOR4(i,
+      (uint32_t)0U,
+      (uint32_t)4U,
+      (uint32_t)1U,
       uint32_t *os = r14;
       uint32_t x1 = r14[i];
       uint32_t x10 = x1 >> (uint32_t)7U | x1 << (uint32_t)25U;
-      os[i] = x10;
-    }
+      os[i] = x10;);
     uint32_t *r15 = wv + (uint32_t)1U * (uint32_t)4U;
     uint32_t *r21 = wv + (uint32_t)2U * (uint32_t)4U;
     uint32_t *r31 = wv + (uint32_t)3U * (uint32_t)4U;
@@ -2697,112 +2896,126 @@ blake2s_update_block(uint32_t *wv, uint32_t *hash, bool flag, uint64_t totlen, u
     uint32_t d1 = (uint32_t)3U;
     uint32_t *wv_a = wv + a0 * (uint32_t)4U;
     uint32_t *wv_b8 = wv + b * (uint32_t)4U;
-    for (uint32_t i = (uint32_t)0U; i < (uint32_t)4U; i++)
-    {
+    KRML_MAYBE_FOR4(i,
+      (uint32_t)0U,
+      (uint32_t)4U,
+      (uint32_t)1U,
       uint32_t *os = wv_a;
       uint32_t x1 = wv_a[i] + wv_b8[i];
-      os[i] = x1;
-    }
-    for (uint32_t i = (uint32_t)0U; i < (uint32_t)4U; i++)
-    {
+      os[i] = x1;);
+    KRML_MAYBE_FOR4(i,
+      (uint32_t)0U,
+      (uint32_t)4U,
+      (uint32_t)1U,
       uint32_t *os = wv_a;
       uint32_t x1 = wv_a[i] + z[i];
-      os[i] = x1;
-    }
+      os[i] = x1;);
     uint32_t *wv_a8 = wv + d1 * (uint32_t)4U;
     uint32_t *wv_b9 = wv + a0 * (uint32_t)4U;
-    for (uint32_t i = (uint32_t)0U; i < (uint32_t)4U; i++)
-    {
+    KRML_MAYBE_FOR4(i,
+      (uint32_t)0U,
+      (uint32_t)4U,
+      (uint32_t)1U,
       uint32_t *os = wv_a8;
       uint32_t x1 = wv_a8[i] ^ wv_b9[i];
-      os[i] = x1;
-    }
+      os[i] = x1;);
     uint32_t *r16 = wv_a8;
-    for (uint32_t i = (uint32_t)0U; i < (uint32_t)4U; i++)
-    {
+    KRML_MAYBE_FOR4(i,
+      (uint32_t)0U,
+      (uint32_t)4U,
+      (uint32_t)1U,
       uint32_t *os = r16;
       uint32_t x1 = r16[i];
       uint32_t x13 = x1 >> (uint32_t)16U | x1 << (uint32_t)16U;
-      os[i] = x13;
-    }
+      os[i] = x13;);
     uint32_t *wv_a9 = wv + c * (uint32_t)4U;
     uint32_t *wv_b10 = wv + d1 * (uint32_t)4U;
-    for (uint32_t i = (uint32_t)0U; i < (uint32_t)4U; i++)
-    {
+    KRML_MAYBE_FOR4(i,
+      (uint32_t)0U,
+      (uint32_t)4U,
+      (uint32_t)1U,
       uint32_t *os = wv_a9;
       uint32_t x1 = wv_a9[i] + wv_b10[i];
-      os[i] = x1;
-    }
+      os[i] = x1;);
     uint32_t *wv_a10 = wv + b * (uint32_t)4U;
     uint32_t *wv_b11 = wv + c * (uint32_t)4U;
-    for (uint32_t i = (uint32_t)0U; i < (uint32_t)4U; i++)
-    {
+    KRML_MAYBE_FOR4(i,
+      (uint32_t)0U,
+      (uint32_t)4U,
+      (uint32_t)1U,
       uint32_t *os = wv_a10;
       uint32_t x1 = wv_a10[i] ^ wv_b11[i];
-      os[i] = x1;
-    }
+      os[i] = x1;);
     uint32_t *r17 = wv_a10;
-    for (uint32_t i = (uint32_t)0U; i < (uint32_t)4U; i++)
-    {
+    KRML_MAYBE_FOR4(i,
+      (uint32_t)0U,
+      (uint32_t)4U,
+      (uint32_t)1U,
       uint32_t *os = r17;
       uint32_t x1 = r17[i];
       uint32_t x13 = x1 >> (uint32_t)12U | x1 << (uint32_t)20U;
-      os[i] = x13;
-    }
+      os[i] = x13;);
     uint32_t *wv_a11 = wv + a0 * (uint32_t)4U;
     uint32_t *wv_b12 = wv + b * (uint32_t)4U;
-    for (uint32_t i = (uint32_t)0U; i < (uint32_t)4U; i++)
-    {
+    KRML_MAYBE_FOR4(i,
+      (uint32_t)0U,
+      (uint32_t)4U,
+      (uint32_t)1U,
       uint32_t *os = wv_a11;
       uint32_t x1 = wv_a11[i] + wv_b12[i];
-      os[i] = x1;
-    }
-    for (uint32_t i = (uint32_t)0U; i < (uint32_t)4U; i++)
-    {
+      os[i] = x1;);
+    KRML_MAYBE_FOR4(i,
+      (uint32_t)0U,
+      (uint32_t)4U,
+      (uint32_t)1U,
       uint32_t *os = wv_a11;
       uint32_t x1 = wv_a11[i] + w[i];
-      os[i] = x1;
-    }
+      os[i] = x1;);
     uint32_t *wv_a12 = wv + d1 * (uint32_t)4U;
     uint32_t *wv_b13 = wv + a0 * (uint32_t)4U;
-    for (uint32_t i = (uint32_t)0U; i < (uint32_t)4U; i++)
-    {
+    KRML_MAYBE_FOR4(i,
+      (uint32_t)0U,
+      (uint32_t)4U,
+      (uint32_t)1U,
       uint32_t *os = wv_a12;
       uint32_t x1 = wv_a12[i] ^ wv_b13[i];
-      os[i] = x1;
-    }
+      os[i] = x1;);
     uint32_t *r18 = wv_a12;
-    for (uint32_t i = (uint32_t)0U; i < (uint32_t)4U; i++)
-    {
+    KRML_MAYBE_FOR4(i,
+      (uint32_t)0U,
+      (uint32_t)4U,
+      (uint32_t)1U,
       uint32_t *os = r18;
       uint32_t x1 = r18[i];
       uint32_t x13 = x1 >> (uint32_t)8U | x1 << (uint32_t)24U;
-      os[i] = x13;
-    }
+      os[i] = x13;);
     uint32_t *wv_a13 = wv + c * (uint32_t)4U;
     uint32_t *wv_b14 = wv + d1 * (uint32_t)4U;
-    for (uint32_t i = (uint32_t)0U; i < (uint32_t)4U; i++)
-    {
+    KRML_MAYBE_FOR4(i,
+      (uint32_t)0U,
+      (uint32_t)4U,
+      (uint32_t)1U,
       uint32_t *os = wv_a13;
       uint32_t x1 = wv_a13[i] + wv_b14[i];
-      os[i] = x1;
-    }
+      os[i] = x1;);
     uint32_t *wv_a14 = wv + b * (uint32_t)4U;
     uint32_t *wv_b = wv + c * (uint32_t)4U;
-    for (uint32_t i = (uint32_t)0U; i < (uint32_t)4U; i++)
-    {
+    KRML_MAYBE_FOR4(i,
+      (uint32_t)0U,
+      (uint32_t)4U,
+      (uint32_t)1U,
       uint32_t *os = wv_a14;
       uint32_t x1 = wv_a14[i] ^ wv_b[i];
-      os[i] = x1;
-    }
+      os[i] = x1;);
     uint32_t *r19 = wv_a14;
-    for (uint32_t i = (uint32_t)0U; i < (uint32_t)4U; i++)
-    {
+    KRML_MAYBE_FOR4(i,
+      (uint32_t)0U,
+      (uint32_t)4U,
+      (uint32_t)1U,
       uint32_t *os = r19;
       uint32_t x1 = r19[i];
       uint32_t x13 = x1 >> (uint32_t)7U | x1 << (uint32_t)25U;
-      os[i] = x13;
-    }
+      os[i] = x13;);
     uint32_t *r113 = wv + (uint32_t)1U * (uint32_t)4U;
     uint32_t *r2 = wv + (uint32_t)2U * (uint32_t)4U;
     uint32_t *r3 = wv + (uint32_t)3U * (uint32_t)4U;
@@ -2832,38 +3045,41 @@ blake2s_update_block(uint32_t *wv, uint32_t *hash, bool flag, uint64_t totlen, u
     r115[0U] = x0;
     r115[1U] = x1;
     r115[2U] = x2;
-    r115[3U] = x3;
-  }
+    r115[3U] = x3;);
   uint32_t *s0 = hash + (uint32_t)0U * (uint32_t)4U;
   uint32_t *s1 = hash + (uint32_t)1U * (uint32_t)4U;
   uint32_t *r0 = wv + (uint32_t)0U * (uint32_t)4U;
   uint32_t *r1 = wv + (uint32_t)1U * (uint32_t)4U;
   uint32_t *r2 = wv + (uint32_t)2U * (uint32_t)4U;
   uint32_t *r3 = wv + (uint32_t)3U * (uint32_t)4U;
-  for (uint32_t i = (uint32_t)0U; i < (uint32_t)4U; i++)
-  {
+  KRML_MAYBE_FOR4(i,
+    (uint32_t)0U,
+    (uint32_t)4U,
+    (uint32_t)1U,
     uint32_t *os = s0;
     uint32_t x = s0[i] ^ r0[i];
-    os[i] = x;
-  }
-  for (uint32_t i = (uint32_t)0U; i < (uint32_t)4U; i++)
-  {
+    os[i] = x;);
+  KRML_MAYBE_FOR4(i,
+    (uint32_t)0U,
+    (uint32_t)4U,
+    (uint32_t)1U,
     uint32_t *os = s0;
     uint32_t x = s0[i] ^ r2[i];
-    os[i] = x;
-  }
-  for (uint32_t i = (uint32_t)0U; i < (uint32_t)4U; i++)
-  {
+    os[i] = x;);
+  KRML_MAYBE_FOR4(i,
+    (uint32_t)0U,
+    (uint32_t)4U,
+    (uint32_t)1U,
     uint32_t *os = s1;
     uint32_t x = s1[i] ^ r1[i];
-    os[i] = x;
-  }
-  for (uint32_t i = (uint32_t)0U; i < (uint32_t)4U; i++)
-  {
+    os[i] = x;);
+  KRML_MAYBE_FOR4(i,
+    (uint32_t)0U,
+    (uint32_t)4U,
+    (uint32_t)1U,
     uint32_t *os = s1;
     uint32_t x = s1[i] ^ r3[i];
-    os[i] = x;
-  }
+    os[i] = x;);
 }
 
 inline void Hacl_Blake2s_32_blake2s_init(uint32_t *hash, uint32_t kk, uint32_t nn)
@@ -3014,14 +3230,16 @@ inline void Hacl_Blake2s_32_blake2s_finish(uint32_t nn, uint8_t *output, uint32_
   uint8_t *second = b + (uint32_t)4U * (uint32_t)4U;
   uint32_t *row0 = hash + (uint32_t)0U * (uint32_t)4U;
   uint32_t *row1 = hash + (uint32_t)1U * (uint32_t)4U;
-  for (uint32_t i = (uint32_t)0U; i < (uint32_t)4U; i++)
-  {
-    store32_le(first + i * (uint32_t)4U, row0[i]);
-  }
-  for (uint32_t i = (uint32_t)0U; i < (uint32_t)4U; i++)
-  {
-    store32_le(second + i * (uint32_t)4U, row1[i]);
-  }
+  KRML_MAYBE_FOR4(i,
+    (uint32_t)0U,
+    (uint32_t)4U,
+    (uint32_t)1U,
+    store32_le(first + i * (uint32_t)4U, row0[i]););
+  KRML_MAYBE_FOR4(i,
+    (uint32_t)0U,
+    (uint32_t)4U,
+    (uint32_t)1U,
+    store32_le(second + i * (uint32_t)4U, row1[i]););
   uint8_t *final = b;
   memcpy(output, final, nn * sizeof (uint8_t));
   Lib_Memzero0_memzero(b, double_row * sizeof (b[0U]));

--- a/dist/gcc-compatible/Hacl_Hash_Blake2b_256.c
+++ b/dist/gcc-compatible/Hacl_Hash_Blake2b_256.c
@@ -40,15 +40,16 @@ update_blake2b_256(
     FStar_UInt128_add_mod(totlen,
       FStar_UInt128_uint64_to_uint128((uint64_t)(uint32_t)128U));
   uint64_t m_w[16U] = { 0U };
-  for (uint32_t i = (uint32_t)0U; i < (uint32_t)16U; i++)
-  {
+  KRML_MAYBE_FOR16(i,
+    (uint32_t)0U,
+    (uint32_t)16U,
+    (uint32_t)1U,
     uint64_t *os = m_w;
     uint8_t *bj = block + i * (uint32_t)8U;
     uint64_t u = load64_le(bj);
     uint64_t r = u;
     uint64_t x = r;
-    os[i] = x;
-  }
+    os[i] = x;);
   Lib_IntVector_Intrinsics_vec256 mask = Lib_IntVector_Intrinsics_vec256_zero;
   uint64_t wv_14 = (uint64_t)0U;
   uint64_t wv_15 = (uint64_t)0U;
@@ -60,8 +61,10 @@ update_blake2b_256(
   memcpy(wv, s, (uint32_t)4U * (uint32_t)1U * sizeof (Lib_IntVector_Intrinsics_vec256));
   Lib_IntVector_Intrinsics_vec256 *wv3 = wv + (uint32_t)3U * (uint32_t)1U;
   wv3[0U] = Lib_IntVector_Intrinsics_vec256_xor(wv3[0U], mask);
-  for (uint32_t i = (uint32_t)0U; i < (uint32_t)12U; i++)
-  {
+  KRML_MAYBE_FOR12(i,
+    (uint32_t)0U,
+    (uint32_t)12U,
+    (uint32_t)1U,
     uint32_t start_idx = i % (uint32_t)10U * (uint32_t)16U;
     KRML_CHECK_SIZE(sizeof (Lib_IntVector_Intrinsics_vec256), (uint32_t)4U * (uint32_t)1U);
     Lib_IntVector_Intrinsics_vec256 m_st[(uint32_t)4U * (uint32_t)1U];
@@ -192,8 +195,7 @@ update_blake2b_256(
     Lib_IntVector_Intrinsics_vec256 v04 = r3[0U];
     Lib_IntVector_Intrinsics_vec256
     v14 = Lib_IntVector_Intrinsics_vec256_rotate_right_lanes64(v04, (uint32_t)1U);
-    r3[0U] = v14;
-  }
+    r3[0U] = v14;);
   Lib_IntVector_Intrinsics_vec256 *s0 = s + (uint32_t)0U * (uint32_t)1U;
   Lib_IntVector_Intrinsics_vec256 *s1 = s + (uint32_t)1U * (uint32_t)1U;
   Lib_IntVector_Intrinsics_vec256 *r0 = wv + (uint32_t)0U * (uint32_t)1U;
@@ -303,15 +305,16 @@ Hacl_Hash_Blake2b_256_update_last_blake2b_256(
   FStar_UInt128_uint128
   totlen = FStar_UInt128_add_mod(ev_, FStar_UInt128_uint64_to_uint128((uint64_t)rest_len));
   uint64_t m_w[16U] = { 0U };
-  for (uint32_t i = (uint32_t)0U; i < (uint32_t)16U; i++)
-  {
+  KRML_MAYBE_FOR16(i,
+    (uint32_t)0U,
+    (uint32_t)16U,
+    (uint32_t)1U,
     uint64_t *os = m_w;
     uint8_t *bj = tmp + i * (uint32_t)8U;
     uint64_t u = load64_le(bj);
     uint64_t r = u;
     uint64_t x = r;
-    os[i] = x;
-  }
+    os[i] = x;);
   Lib_IntVector_Intrinsics_vec256 mask = Lib_IntVector_Intrinsics_vec256_zero;
   uint64_t wv_14 = (uint64_t)0xFFFFFFFFFFFFFFFFU;
   uint64_t wv_15 = (uint64_t)0U;
@@ -323,8 +326,10 @@ Hacl_Hash_Blake2b_256_update_last_blake2b_256(
   memcpy(wv, s, (uint32_t)4U * (uint32_t)1U * sizeof (Lib_IntVector_Intrinsics_vec256));
   Lib_IntVector_Intrinsics_vec256 *wv3 = wv + (uint32_t)3U * (uint32_t)1U;
   wv3[0U] = Lib_IntVector_Intrinsics_vec256_xor(wv3[0U], mask);
-  for (uint32_t i = (uint32_t)0U; i < (uint32_t)12U; i++)
-  {
+  KRML_MAYBE_FOR12(i,
+    (uint32_t)0U,
+    (uint32_t)12U,
+    (uint32_t)1U,
     uint32_t start_idx = i % (uint32_t)10U * (uint32_t)16U;
     KRML_CHECK_SIZE(sizeof (Lib_IntVector_Intrinsics_vec256), (uint32_t)4U * (uint32_t)1U);
     Lib_IntVector_Intrinsics_vec256 m_st[(uint32_t)4U * (uint32_t)1U];
@@ -455,8 +460,7 @@ Hacl_Hash_Blake2b_256_update_last_blake2b_256(
     Lib_IntVector_Intrinsics_vec256 v04 = r3[0U];
     Lib_IntVector_Intrinsics_vec256
     v14 = Lib_IntVector_Intrinsics_vec256_rotate_right_lanes64(v04, (uint32_t)1U);
-    r3[0U] = v14;
-  }
+    r3[0U] = v14;);
   Lib_IntVector_Intrinsics_vec256 *s0 = s + (uint32_t)0U * (uint32_t)1U;
   Lib_IntVector_Intrinsics_vec256 *s1 = s + (uint32_t)1U * (uint32_t)1U;
   Lib_IntVector_Intrinsics_vec256 *r0 = wv + (uint32_t)0U * (uint32_t)1U;
@@ -485,15 +489,16 @@ blake2b_update_block(
 )
 {
   uint64_t m_w[16U] = { 0U };
-  for (uint32_t i = (uint32_t)0U; i < (uint32_t)16U; i++)
-  {
+  KRML_MAYBE_FOR16(i,
+    (uint32_t)0U,
+    (uint32_t)16U,
+    (uint32_t)1U,
     uint64_t *os = m_w;
     uint8_t *bj = d + i * (uint32_t)8U;
     uint64_t u = load64_le(bj);
     uint64_t r = u;
     uint64_t x = r;
-    os[i] = x;
-  }
+    os[i] = x;);
   Lib_IntVector_Intrinsics_vec256 mask = Lib_IntVector_Intrinsics_vec256_zero;
   uint64_t wv_14;
   if (flag)
@@ -513,8 +518,10 @@ blake2b_update_block(
   memcpy(wv, hash, (uint32_t)4U * (uint32_t)1U * sizeof (Lib_IntVector_Intrinsics_vec256));
   Lib_IntVector_Intrinsics_vec256 *wv3 = wv + (uint32_t)3U * (uint32_t)1U;
   wv3[0U] = Lib_IntVector_Intrinsics_vec256_xor(wv3[0U], mask);
-  for (uint32_t i = (uint32_t)0U; i < (uint32_t)12U; i++)
-  {
+  KRML_MAYBE_FOR12(i,
+    (uint32_t)0U,
+    (uint32_t)12U,
+    (uint32_t)1U,
     uint32_t start_idx = i % (uint32_t)10U * (uint32_t)16U;
     KRML_CHECK_SIZE(sizeof (Lib_IntVector_Intrinsics_vec256), (uint32_t)4U * (uint32_t)1U);
     Lib_IntVector_Intrinsics_vec256 m_st[(uint32_t)4U * (uint32_t)1U];
@@ -645,8 +652,7 @@ blake2b_update_block(
     Lib_IntVector_Intrinsics_vec256 v04 = r3[0U];
     Lib_IntVector_Intrinsics_vec256
     v14 = Lib_IntVector_Intrinsics_vec256_rotate_right_lanes64(v04, (uint32_t)1U);
-    r3[0U] = v14;
-  }
+    r3[0U] = v14;);
   Lib_IntVector_Intrinsics_vec256 *s0 = hash + (uint32_t)0U * (uint32_t)1U;
   Lib_IntVector_Intrinsics_vec256 *s1 = hash + (uint32_t)1U * (uint32_t)1U;
   Lib_IntVector_Intrinsics_vec256 *r0 = wv + (uint32_t)0U * (uint32_t)1U;

--- a/dist/gcc-compatible/Hacl_Hash_Blake2s_128.c
+++ b/dist/gcc-compatible/Hacl_Hash_Blake2s_128.c
@@ -33,15 +33,16 @@ update_blake2s_128(Lib_IntVector_Intrinsics_vec128 *s, uint64_t totlen, uint8_t 
   Lib_IntVector_Intrinsics_vec128 wv[4U] = { 0U };
   uint64_t totlen1 = totlen + (uint64_t)(uint32_t)64U;
   uint32_t m_w[16U] = { 0U };
-  for (uint32_t i = (uint32_t)0U; i < (uint32_t)16U; i++)
-  {
+  KRML_MAYBE_FOR16(i,
+    (uint32_t)0U,
+    (uint32_t)16U,
+    (uint32_t)1U,
     uint32_t *os = m_w;
     uint8_t *bj = block + i * (uint32_t)4U;
     uint32_t u = load32_le(bj);
     uint32_t r = u;
     uint32_t x = r;
-    os[i] = x;
-  }
+    os[i] = x;);
   Lib_IntVector_Intrinsics_vec128 mask = Lib_IntVector_Intrinsics_vec128_zero;
   uint32_t wv_14 = (uint32_t)0U;
   uint32_t wv_15 = (uint32_t)0U;
@@ -53,8 +54,10 @@ update_blake2s_128(Lib_IntVector_Intrinsics_vec128 *s, uint64_t totlen, uint8_t 
   memcpy(wv, s, (uint32_t)4U * (uint32_t)1U * sizeof (Lib_IntVector_Intrinsics_vec128));
   Lib_IntVector_Intrinsics_vec128 *wv3 = wv + (uint32_t)3U * (uint32_t)1U;
   wv3[0U] = Lib_IntVector_Intrinsics_vec128_xor(wv3[0U], mask);
-  for (uint32_t i = (uint32_t)0U; i < (uint32_t)10U; i++)
-  {
+  KRML_MAYBE_FOR10(i,
+    (uint32_t)0U,
+    (uint32_t)10U,
+    (uint32_t)1U,
     uint32_t start_idx = i % (uint32_t)10U * (uint32_t)16U;
     KRML_CHECK_SIZE(sizeof (Lib_IntVector_Intrinsics_vec128), (uint32_t)4U * (uint32_t)1U);
     Lib_IntVector_Intrinsics_vec128 m_st[(uint32_t)4U * (uint32_t)1U];
@@ -185,8 +188,7 @@ update_blake2s_128(Lib_IntVector_Intrinsics_vec128 *s, uint64_t totlen, uint8_t 
     Lib_IntVector_Intrinsics_vec128 v04 = r3[0U];
     Lib_IntVector_Intrinsics_vec128
     v14 = Lib_IntVector_Intrinsics_vec128_rotate_right_lanes32(v04, (uint32_t)1U);
-    r3[0U] = v14;
-  }
+    r3[0U] = v14;);
   Lib_IntVector_Intrinsics_vec128 *s0 = s + (uint32_t)0U * (uint32_t)1U;
   Lib_IntVector_Intrinsics_vec128 *s1 = s + (uint32_t)1U * (uint32_t)1U;
   Lib_IntVector_Intrinsics_vec128 *r0 = wv + (uint32_t)0U * (uint32_t)1U;
@@ -287,15 +289,16 @@ Hacl_Hash_Blake2s_128_update_last_blake2s_128(
   memcpy(tmp_rest, rest, rest_len * sizeof (uint8_t));
   uint64_t totlen = ev_ + (uint64_t)rest_len;
   uint32_t m_w[16U] = { 0U };
-  for (uint32_t i = (uint32_t)0U; i < (uint32_t)16U; i++)
-  {
+  KRML_MAYBE_FOR16(i,
+    (uint32_t)0U,
+    (uint32_t)16U,
+    (uint32_t)1U,
     uint32_t *os = m_w;
     uint8_t *bj = tmp + i * (uint32_t)4U;
     uint32_t u = load32_le(bj);
     uint32_t r = u;
     uint32_t x = r;
-    os[i] = x;
-  }
+    os[i] = x;);
   Lib_IntVector_Intrinsics_vec128 mask = Lib_IntVector_Intrinsics_vec128_zero;
   uint32_t wv_14 = (uint32_t)0xFFFFFFFFU;
   uint32_t wv_15 = (uint32_t)0U;
@@ -307,8 +310,10 @@ Hacl_Hash_Blake2s_128_update_last_blake2s_128(
   memcpy(wv, s, (uint32_t)4U * (uint32_t)1U * sizeof (Lib_IntVector_Intrinsics_vec128));
   Lib_IntVector_Intrinsics_vec128 *wv3 = wv + (uint32_t)3U * (uint32_t)1U;
   wv3[0U] = Lib_IntVector_Intrinsics_vec128_xor(wv3[0U], mask);
-  for (uint32_t i = (uint32_t)0U; i < (uint32_t)10U; i++)
-  {
+  KRML_MAYBE_FOR10(i,
+    (uint32_t)0U,
+    (uint32_t)10U,
+    (uint32_t)1U,
     uint32_t start_idx = i % (uint32_t)10U * (uint32_t)16U;
     KRML_CHECK_SIZE(sizeof (Lib_IntVector_Intrinsics_vec128), (uint32_t)4U * (uint32_t)1U);
     Lib_IntVector_Intrinsics_vec128 m_st[(uint32_t)4U * (uint32_t)1U];
@@ -439,8 +444,7 @@ Hacl_Hash_Blake2s_128_update_last_blake2s_128(
     Lib_IntVector_Intrinsics_vec128 v04 = r3[0U];
     Lib_IntVector_Intrinsics_vec128
     v14 = Lib_IntVector_Intrinsics_vec128_rotate_right_lanes32(v04, (uint32_t)1U);
-    r3[0U] = v14;
-  }
+    r3[0U] = v14;);
   Lib_IntVector_Intrinsics_vec128 *s0 = s + (uint32_t)0U * (uint32_t)1U;
   Lib_IntVector_Intrinsics_vec128 *s1 = s + (uint32_t)1U * (uint32_t)1U;
   Lib_IntVector_Intrinsics_vec128 *r0 = wv + (uint32_t)0U * (uint32_t)1U;
@@ -469,15 +473,16 @@ blake2s_update_block(
 )
 {
   uint32_t m_w[16U] = { 0U };
-  for (uint32_t i = (uint32_t)0U; i < (uint32_t)16U; i++)
-  {
+  KRML_MAYBE_FOR16(i,
+    (uint32_t)0U,
+    (uint32_t)16U,
+    (uint32_t)1U,
     uint32_t *os = m_w;
     uint8_t *bj = d + i * (uint32_t)4U;
     uint32_t u = load32_le(bj);
     uint32_t r = u;
     uint32_t x = r;
-    os[i] = x;
-  }
+    os[i] = x;);
   Lib_IntVector_Intrinsics_vec128 mask = Lib_IntVector_Intrinsics_vec128_zero;
   uint32_t wv_14;
   if (flag)
@@ -497,8 +502,10 @@ blake2s_update_block(
   memcpy(wv, hash, (uint32_t)4U * (uint32_t)1U * sizeof (Lib_IntVector_Intrinsics_vec128));
   Lib_IntVector_Intrinsics_vec128 *wv3 = wv + (uint32_t)3U * (uint32_t)1U;
   wv3[0U] = Lib_IntVector_Intrinsics_vec128_xor(wv3[0U], mask);
-  for (uint32_t i = (uint32_t)0U; i < (uint32_t)10U; i++)
-  {
+  KRML_MAYBE_FOR10(i,
+    (uint32_t)0U,
+    (uint32_t)10U,
+    (uint32_t)1U,
     uint32_t start_idx = i % (uint32_t)10U * (uint32_t)16U;
     KRML_CHECK_SIZE(sizeof (Lib_IntVector_Intrinsics_vec128), (uint32_t)4U * (uint32_t)1U);
     Lib_IntVector_Intrinsics_vec128 m_st[(uint32_t)4U * (uint32_t)1U];
@@ -629,8 +636,7 @@ blake2s_update_block(
     Lib_IntVector_Intrinsics_vec128 v04 = r3[0U];
     Lib_IntVector_Intrinsics_vec128
     v14 = Lib_IntVector_Intrinsics_vec128_rotate_right_lanes32(v04, (uint32_t)1U);
-    r3[0U] = v14;
-  }
+    r3[0U] = v14;);
   Lib_IntVector_Intrinsics_vec128 *s0 = hash + (uint32_t)0U * (uint32_t)1U;
   Lib_IntVector_Intrinsics_vec128 *s1 = hash + (uint32_t)1U * (uint32_t)1U;
   Lib_IntVector_Intrinsics_vec128 *r0 = wv + (uint32_t)0U * (uint32_t)1U;

--- a/dist/gcc-compatible/Hacl_Hash_MD5.c
+++ b/dist/gcc-compatible/Hacl_Hash_MD5.c
@@ -53,10 +53,7 @@ _t[64U] =
 
 void Hacl_Hash_Core_MD5_legacy_init(uint32_t *s)
 {
-  for (uint32_t i = (uint32_t)0U; i < (uint32_t)4U; i++)
-  {
-    s[i] = _h0[i];
-  }
+  KRML_MAYBE_FOR4(i, (uint32_t)0U, (uint32_t)4U, (uint32_t)1U, s[i] = _h0[i];);
 }
 
 void Hacl_Hash_Core_MD5_legacy_update(uint32_t *abcd, uint8_t *x)
@@ -1126,10 +1123,11 @@ static void legacy_pad(uint64_t len, uint8_t *dst)
 
 void Hacl_Hash_Core_MD5_legacy_finish(uint32_t *s, uint8_t *dst)
 {
-  for (uint32_t i = (uint32_t)0U; i < (uint32_t)4U; i++)
-  {
-    store32_le(dst + i * (uint32_t)4U, s[i]);
-  }
+  KRML_MAYBE_FOR4(i,
+    (uint32_t)0U,
+    (uint32_t)4U,
+    (uint32_t)1U,
+    store32_le(dst + i * (uint32_t)4U, s[i]););
 }
 
 void Hacl_Hash_MD5_legacy_update_multi(uint32_t *s, uint8_t *blocks, uint32_t n_blocks)

--- a/dist/gcc-compatible/Hacl_Hash_SHA1.c
+++ b/dist/gcc-compatible/Hacl_Hash_SHA1.c
@@ -35,10 +35,7 @@ _h0[5U] =
 
 void Hacl_Hash_Core_SHA1_legacy_init(uint32_t *s)
 {
-  for (uint32_t i = (uint32_t)0U; i < (uint32_t)5U; i++)
-  {
-    s[i] = _h0[i];
-  }
+  KRML_MAYBE_FOR5(i, (uint32_t)0U, (uint32_t)5U, (uint32_t)1U, s[i] = _h0[i];);
 }
 
 void Hacl_Hash_Core_SHA1_legacy_update(uint32_t *h, uint8_t *l)
@@ -159,10 +156,11 @@ static void legacy_pad(uint64_t len, uint8_t *dst)
 
 void Hacl_Hash_Core_SHA1_legacy_finish(uint32_t *s, uint8_t *dst)
 {
-  for (uint32_t i = (uint32_t)0U; i < (uint32_t)5U; i++)
-  {
-    store32_be(dst + i * (uint32_t)4U, s[i]);
-  }
+  KRML_MAYBE_FOR5(i,
+    (uint32_t)0U,
+    (uint32_t)5U,
+    (uint32_t)1U,
+    store32_be(dst + i * (uint32_t)4U, s[i]););
 }
 
 void Hacl_Hash_SHA1_legacy_update_multi(uint32_t *s, uint8_t *blocks, uint32_t n_blocks)

--- a/dist/gcc-compatible/Hacl_Hash_SHA2.c
+++ b/dist/gcc-compatible/Hacl_Hash_SHA2.c
@@ -111,34 +111,22 @@ k384_512[80U] =
 
 void Hacl_Hash_Core_SHA2_init_224(uint32_t *s)
 {
-  for (uint32_t i = (uint32_t)0U; i < (uint32_t)8U; i++)
-  {
-    s[i] = h224[i];
-  }
+  KRML_MAYBE_FOR8(i, (uint32_t)0U, (uint32_t)8U, (uint32_t)1U, s[i] = h224[i];);
 }
 
 void Hacl_Hash_Core_SHA2_init_256(uint32_t *s)
 {
-  for (uint32_t i = (uint32_t)0U; i < (uint32_t)8U; i++)
-  {
-    s[i] = h256[i];
-  }
+  KRML_MAYBE_FOR8(i, (uint32_t)0U, (uint32_t)8U, (uint32_t)1U, s[i] = h256[i];);
 }
 
 void Hacl_Hash_Core_SHA2_init_384(uint64_t *s)
 {
-  for (uint32_t i = (uint32_t)0U; i < (uint32_t)8U; i++)
-  {
-    s[i] = h384[i];
-  }
+  KRML_MAYBE_FOR8(i, (uint32_t)0U, (uint32_t)8U, (uint32_t)1U, s[i] = h384[i];);
 }
 
 void Hacl_Hash_Core_SHA2_init_512(uint64_t *s)
 {
-  for (uint32_t i = (uint32_t)0U; i < (uint32_t)8U; i++)
-  {
-    s[i] = h512[i];
-  }
+  KRML_MAYBE_FOR8(i, (uint32_t)0U, (uint32_t)8U, (uint32_t)1U, s[i] = h512[i];);
 }
 
 static void update_224(uint32_t *hash, uint8_t *block)
@@ -206,12 +194,13 @@ static void update_224(uint32_t *hash, uint8_t *block)
     hash1[6U] = f0;
     hash1[7U] = g0;
   }
-  for (uint32_t i = (uint32_t)0U; i < (uint32_t)8U; i++)
-  {
+  KRML_MAYBE_FOR8(i,
+    (uint32_t)0U,
+    (uint32_t)8U,
+    (uint32_t)1U,
     uint32_t xi = hash[i];
     uint32_t yi = hash1[i];
-    hash[i] = xi + yi;
-  }
+    hash[i] = xi + yi;);
 }
 
 static void update_256(uint32_t *hash, uint8_t *block)
@@ -279,12 +268,13 @@ static void update_256(uint32_t *hash, uint8_t *block)
     hash1[6U] = f0;
     hash1[7U] = g0;
   }
-  for (uint32_t i = (uint32_t)0U; i < (uint32_t)8U; i++)
-  {
+  KRML_MAYBE_FOR8(i,
+    (uint32_t)0U,
+    (uint32_t)8U,
+    (uint32_t)1U,
     uint32_t xi = hash[i];
     uint32_t yi = hash1[i];
-    hash[i] = xi + yi;
-  }
+    hash[i] = xi + yi;);
 }
 
 void Hacl_Hash_Core_SHA2_update_384(uint64_t *hash, uint8_t *block)
@@ -354,12 +344,13 @@ void Hacl_Hash_Core_SHA2_update_384(uint64_t *hash, uint8_t *block)
     hash1[6U] = f0;
     hash1[7U] = g0;
   }
-  for (uint32_t i = (uint32_t)0U; i < (uint32_t)8U; i++)
-  {
+  KRML_MAYBE_FOR8(i,
+    (uint32_t)0U,
+    (uint32_t)8U,
+    (uint32_t)1U,
     uint64_t xi = hash[i];
     uint64_t yi = hash1[i];
-    hash[i] = xi + yi;
-  }
+    hash[i] = xi + yi;);
 }
 
 void Hacl_Hash_Core_SHA2_update_512(uint64_t *hash, uint8_t *block)
@@ -429,12 +420,13 @@ void Hacl_Hash_Core_SHA2_update_512(uint64_t *hash, uint8_t *block)
     hash1[6U] = f0;
     hash1[7U] = g0;
   }
-  for (uint32_t i = (uint32_t)0U; i < (uint32_t)8U; i++)
-  {
+  KRML_MAYBE_FOR8(i,
+    (uint32_t)0U,
+    (uint32_t)8U,
+    (uint32_t)1U,
     uint64_t xi = hash[i];
     uint64_t yi = hash1[i];
-    hash[i] = xi + yi;
-  }
+    hash[i] = xi + yi;);
 }
 
 static void pad_224(uint64_t len, uint8_t *dst)
@@ -557,34 +549,38 @@ static void pad_512(FStar_UInt128_uint128 len, uint8_t *dst)
 
 void Hacl_Hash_Core_SHA2_finish_224(uint32_t *s, uint8_t *dst)
 {
-  for (uint32_t i = (uint32_t)0U; i < (uint32_t)7U; i++)
-  {
-    store32_be(dst + i * (uint32_t)4U, s[i]);
-  }
+  KRML_MAYBE_FOR7(i,
+    (uint32_t)0U,
+    (uint32_t)7U,
+    (uint32_t)1U,
+    store32_be(dst + i * (uint32_t)4U, s[i]););
 }
 
 void Hacl_Hash_Core_SHA2_finish_256(uint32_t *s, uint8_t *dst)
 {
-  for (uint32_t i = (uint32_t)0U; i < (uint32_t)8U; i++)
-  {
-    store32_be(dst + i * (uint32_t)4U, s[i]);
-  }
+  KRML_MAYBE_FOR8(i,
+    (uint32_t)0U,
+    (uint32_t)8U,
+    (uint32_t)1U,
+    store32_be(dst + i * (uint32_t)4U, s[i]););
 }
 
 void Hacl_Hash_Core_SHA2_finish_384(uint64_t *s, uint8_t *dst)
 {
-  for (uint32_t i = (uint32_t)0U; i < (uint32_t)6U; i++)
-  {
-    store64_be(dst + i * (uint32_t)8U, s[i]);
-  }
+  KRML_MAYBE_FOR6(i,
+    (uint32_t)0U,
+    (uint32_t)6U,
+    (uint32_t)1U,
+    store64_be(dst + i * (uint32_t)8U, s[i]););
 }
 
 void Hacl_Hash_Core_SHA2_finish_512(uint64_t *s, uint8_t *dst)
 {
-  for (uint32_t i = (uint32_t)0U; i < (uint32_t)8U; i++)
-  {
-    store64_be(dst + i * (uint32_t)8U, s[i]);
-  }
+  KRML_MAYBE_FOR8(i,
+    (uint32_t)0U,
+    (uint32_t)8U,
+    (uint32_t)1U,
+    store64_be(dst + i * (uint32_t)8U, s[i]););
 }
 
 void Hacl_Hash_SHA2_update_multi_224(uint32_t *s, uint8_t *blocks, uint32_t n_blocks)

--- a/dist/gcc-compatible/Hacl_K256_ECDSA.c
+++ b/dist/gcc-compatible/Hacl_K256_ECDSA.c
@@ -96,8 +96,10 @@ bn_add(uint32_t aLen, uint64_t *a, uint32_t bLen, uint64_t *b, uint64_t *res)
 static uint64_t add4(uint64_t *a, uint64_t *b, uint64_t *res)
 {
   uint64_t c = (uint64_t)0U;
-  for (uint32_t i = (uint32_t)0U; i < (uint32_t)1U; i++)
-  {
+  KRML_MAYBE_FOR1(i,
+    (uint32_t)0U,
+    (uint32_t)1U,
+    (uint32_t)1U,
     uint64_t t1 = a[(uint32_t)4U * i];
     uint64_t t20 = b[(uint32_t)4U * i];
     uint64_t *res_i0 = res + (uint32_t)4U * i;
@@ -113,23 +115,25 @@ static uint64_t add4(uint64_t *a, uint64_t *b, uint64_t *res)
     uint64_t t12 = a[(uint32_t)4U * i + (uint32_t)3U];
     uint64_t t2 = b[(uint32_t)4U * i + (uint32_t)3U];
     uint64_t *res_i = res + (uint32_t)4U * i + (uint32_t)3U;
-    c = Lib_IntTypes_Intrinsics_add_carry_u64(c, t12, t2, res_i);
-  }
-  for (uint32_t i = (uint32_t)4U; i < (uint32_t)4U; i++)
-  {
+    c = Lib_IntTypes_Intrinsics_add_carry_u64(c, t12, t2, res_i););
+  KRML_MAYBE_FOR0(i,
+    (uint32_t)4U,
+    (uint32_t)4U,
+    (uint32_t)1U,
     uint64_t t1 = a[i];
     uint64_t t2 = b[i];
     uint64_t *res_i = res + i;
-    c = Lib_IntTypes_Intrinsics_add_carry_u64(c, t1, t2, res_i);
-  }
+    c = Lib_IntTypes_Intrinsics_add_carry_u64(c, t1, t2, res_i););
   return c;
 }
 
 static void add_mod4(uint64_t *n, uint64_t *a, uint64_t *b, uint64_t *res)
 {
   uint64_t c0 = (uint64_t)0U;
-  for (uint32_t i = (uint32_t)0U; i < (uint32_t)1U; i++)
-  {
+  KRML_MAYBE_FOR1(i,
+    (uint32_t)0U,
+    (uint32_t)1U,
+    (uint32_t)1U,
     uint64_t t1 = a[(uint32_t)4U * i];
     uint64_t t20 = b[(uint32_t)4U * i];
     uint64_t *res_i0 = res + (uint32_t)4U * i;
@@ -145,20 +149,22 @@ static void add_mod4(uint64_t *n, uint64_t *a, uint64_t *b, uint64_t *res)
     uint64_t t12 = a[(uint32_t)4U * i + (uint32_t)3U];
     uint64_t t2 = b[(uint32_t)4U * i + (uint32_t)3U];
     uint64_t *res_i = res + (uint32_t)4U * i + (uint32_t)3U;
-    c0 = Lib_IntTypes_Intrinsics_add_carry_u64(c0, t12, t2, res_i);
-  }
-  for (uint32_t i = (uint32_t)4U; i < (uint32_t)4U; i++)
-  {
+    c0 = Lib_IntTypes_Intrinsics_add_carry_u64(c0, t12, t2, res_i););
+  KRML_MAYBE_FOR0(i,
+    (uint32_t)4U,
+    (uint32_t)4U,
+    (uint32_t)1U,
     uint64_t t1 = a[i];
     uint64_t t2 = b[i];
     uint64_t *res_i = res + i;
-    c0 = Lib_IntTypes_Intrinsics_add_carry_u64(c0, t1, t2, res_i);
-  }
+    c0 = Lib_IntTypes_Intrinsics_add_carry_u64(c0, t1, t2, res_i););
   uint64_t c00 = c0;
   uint64_t tmp[4U] = { 0U };
   uint64_t c = (uint64_t)0U;
-  for (uint32_t i = (uint32_t)0U; i < (uint32_t)1U; i++)
-  {
+  KRML_MAYBE_FOR1(i,
+    (uint32_t)0U,
+    (uint32_t)1U,
+    (uint32_t)1U,
     uint64_t t1 = res[(uint32_t)4U * i];
     uint64_t t20 = n[(uint32_t)4U * i];
     uint64_t *res_i0 = tmp + (uint32_t)4U * i;
@@ -174,30 +180,33 @@ static void add_mod4(uint64_t *n, uint64_t *a, uint64_t *b, uint64_t *res)
     uint64_t t12 = res[(uint32_t)4U * i + (uint32_t)3U];
     uint64_t t2 = n[(uint32_t)4U * i + (uint32_t)3U];
     uint64_t *res_i = tmp + (uint32_t)4U * i + (uint32_t)3U;
-    c = Lib_IntTypes_Intrinsics_sub_borrow_u64(c, t12, t2, res_i);
-  }
-  for (uint32_t i = (uint32_t)4U; i < (uint32_t)4U; i++)
-  {
+    c = Lib_IntTypes_Intrinsics_sub_borrow_u64(c, t12, t2, res_i););
+  KRML_MAYBE_FOR0(i,
+    (uint32_t)4U,
+    (uint32_t)4U,
+    (uint32_t)1U,
     uint64_t t1 = res[i];
     uint64_t t2 = n[i];
     uint64_t *res_i = tmp + i;
-    c = Lib_IntTypes_Intrinsics_sub_borrow_u64(c, t1, t2, res_i);
-  }
+    c = Lib_IntTypes_Intrinsics_sub_borrow_u64(c, t1, t2, res_i););
   uint64_t c1 = c;
   uint64_t c2 = c00 - c1;
-  for (uint32_t i = (uint32_t)0U; i < (uint32_t)4U; i++)
-  {
+  KRML_MAYBE_FOR4(i,
+    (uint32_t)0U,
+    (uint32_t)4U,
+    (uint32_t)1U,
     uint64_t *os = res;
     uint64_t x = (c2 & res[i]) | (~c2 & tmp[i]);
-    os[i] = x;
-  }
+    os[i] = x;);
 }
 
 static void sub_mod4(uint64_t *n, uint64_t *a, uint64_t *b, uint64_t *res)
 {
   uint64_t c0 = (uint64_t)0U;
-  for (uint32_t i = (uint32_t)0U; i < (uint32_t)1U; i++)
-  {
+  KRML_MAYBE_FOR1(i,
+    (uint32_t)0U,
+    (uint32_t)1U,
+    (uint32_t)1U,
     uint64_t t1 = a[(uint32_t)4U * i];
     uint64_t t20 = b[(uint32_t)4U * i];
     uint64_t *res_i0 = res + (uint32_t)4U * i;
@@ -213,20 +222,22 @@ static void sub_mod4(uint64_t *n, uint64_t *a, uint64_t *b, uint64_t *res)
     uint64_t t12 = a[(uint32_t)4U * i + (uint32_t)3U];
     uint64_t t2 = b[(uint32_t)4U * i + (uint32_t)3U];
     uint64_t *res_i = res + (uint32_t)4U * i + (uint32_t)3U;
-    c0 = Lib_IntTypes_Intrinsics_sub_borrow_u64(c0, t12, t2, res_i);
-  }
-  for (uint32_t i = (uint32_t)4U; i < (uint32_t)4U; i++)
-  {
+    c0 = Lib_IntTypes_Intrinsics_sub_borrow_u64(c0, t12, t2, res_i););
+  KRML_MAYBE_FOR0(i,
+    (uint32_t)4U,
+    (uint32_t)4U,
+    (uint32_t)1U,
     uint64_t t1 = a[i];
     uint64_t t2 = b[i];
     uint64_t *res_i = res + i;
-    c0 = Lib_IntTypes_Intrinsics_sub_borrow_u64(c0, t1, t2, res_i);
-  }
+    c0 = Lib_IntTypes_Intrinsics_sub_borrow_u64(c0, t1, t2, res_i););
   uint64_t c00 = c0;
   uint64_t tmp[4U] = { 0U };
   uint64_t c = (uint64_t)0U;
-  for (uint32_t i = (uint32_t)0U; i < (uint32_t)1U; i++)
-  {
+  KRML_MAYBE_FOR1(i,
+    (uint32_t)0U,
+    (uint32_t)1U,
+    (uint32_t)1U,
     uint64_t t1 = res[(uint32_t)4U * i];
     uint64_t t20 = n[(uint32_t)4U * i];
     uint64_t *res_i0 = tmp + (uint32_t)4U * i;
@@ -242,35 +253,40 @@ static void sub_mod4(uint64_t *n, uint64_t *a, uint64_t *b, uint64_t *res)
     uint64_t t12 = res[(uint32_t)4U * i + (uint32_t)3U];
     uint64_t t2 = n[(uint32_t)4U * i + (uint32_t)3U];
     uint64_t *res_i = tmp + (uint32_t)4U * i + (uint32_t)3U;
-    c = Lib_IntTypes_Intrinsics_add_carry_u64(c, t12, t2, res_i);
-  }
-  for (uint32_t i = (uint32_t)4U; i < (uint32_t)4U; i++)
-  {
+    c = Lib_IntTypes_Intrinsics_add_carry_u64(c, t12, t2, res_i););
+  KRML_MAYBE_FOR0(i,
+    (uint32_t)4U,
+    (uint32_t)4U,
+    (uint32_t)1U,
     uint64_t t1 = res[i];
     uint64_t t2 = n[i];
     uint64_t *res_i = tmp + i;
-    c = Lib_IntTypes_Intrinsics_add_carry_u64(c, t1, t2, res_i);
-  }
+    c = Lib_IntTypes_Intrinsics_add_carry_u64(c, t1, t2, res_i););
   uint64_t c1 = c;
   uint64_t c2 = (uint64_t)0U - c00;
-  for (uint32_t i = (uint32_t)0U; i < (uint32_t)4U; i++)
-  {
+  KRML_MAYBE_FOR4(i,
+    (uint32_t)0U,
+    (uint32_t)4U,
+    (uint32_t)1U,
     uint64_t *os = res;
     uint64_t x = (c2 & tmp[i]) | (~c2 & res[i]);
-    os[i] = x;
-  }
+    os[i] = x;);
 }
 
 static void mul4(uint64_t *a, uint64_t *b, uint64_t *res)
 {
   memset(res, 0U, (uint32_t)8U * sizeof (uint64_t));
-  for (uint32_t i0 = (uint32_t)0U; i0 < (uint32_t)4U; i0++)
-  {
+  KRML_MAYBE_FOR4(i0,
+    (uint32_t)0U,
+    (uint32_t)4U,
+    (uint32_t)1U,
     uint64_t bj = b[i0];
     uint64_t *res_j = res + i0;
     uint64_t c = (uint64_t)0U;
-    for (uint32_t i = (uint32_t)0U; i < (uint32_t)1U; i++)
-    {
+    KRML_MAYBE_FOR1(i,
+      (uint32_t)0U,
+      (uint32_t)1U,
+      (uint32_t)1U,
       uint64_t a_i = a[(uint32_t)4U * i];
       uint64_t *res_i0 = res_j + (uint32_t)4U * i;
       c = Hacl_Bignum_Base_mul_wide_add2_u64(a_i, bj, c, res_i0);
@@ -282,24 +298,25 @@ static void mul4(uint64_t *a, uint64_t *b, uint64_t *res)
       c = Hacl_Bignum_Base_mul_wide_add2_u64(a_i1, bj, c, res_i2);
       uint64_t a_i2 = a[(uint32_t)4U * i + (uint32_t)3U];
       uint64_t *res_i = res_j + (uint32_t)4U * i + (uint32_t)3U;
-      c = Hacl_Bignum_Base_mul_wide_add2_u64(a_i2, bj, c, res_i);
-    }
-    for (uint32_t i = (uint32_t)4U; i < (uint32_t)4U; i++)
-    {
+      c = Hacl_Bignum_Base_mul_wide_add2_u64(a_i2, bj, c, res_i););
+    KRML_MAYBE_FOR0(i,
+      (uint32_t)4U,
+      (uint32_t)4U,
+      (uint32_t)1U,
       uint64_t a_i = a[i];
       uint64_t *res_i = res_j + i;
-      c = Hacl_Bignum_Base_mul_wide_add2_u64(a_i, bj, c, res_i);
-    }
+      c = Hacl_Bignum_Base_mul_wide_add2_u64(a_i, bj, c, res_i););
     uint64_t r = c;
-    res[(uint32_t)4U + i0] = r;
-  }
+    res[(uint32_t)4U + i0] = r;);
 }
 
 static void sqr4(uint64_t *a, uint64_t *res)
 {
   memset(res, 0U, (uint32_t)8U * sizeof (uint64_t));
-  for (uint32_t i0 = (uint32_t)0U; i0 < (uint32_t)4U; i0++)
-  {
+  KRML_MAYBE_FOR4(i0,
+    (uint32_t)0U,
+    (uint32_t)4U,
+    (uint32_t)1U,
     uint64_t *ab = a;
     uint64_t a_j = a[i0];
     uint64_t *res_j = res + i0;
@@ -326,18 +343,18 @@ static void sqr4(uint64_t *a, uint64_t *res)
       c = Hacl_Bignum_Base_mul_wide_add2_u64(a_i, a_j, c, res_i);
     }
     uint64_t r = c;
-    res[i0 + i0] = r;
-  }
+    res[i0 + i0] = r;);
   uint64_t c0 = Hacl_Bignum_Addition_bn_add_eq_len_u64((uint32_t)8U, res, res, res);
   uint64_t tmp[8U] = { 0U };
-  for (uint32_t i = (uint32_t)0U; i < (uint32_t)4U; i++)
-  {
+  KRML_MAYBE_FOR4(i,
+    (uint32_t)0U,
+    (uint32_t)4U,
+    (uint32_t)1U,
     FStar_UInt128_uint128 res1 = FStar_UInt128_mul_wide(a[i], a[i]);
     uint64_t hi = FStar_UInt128_uint128_to_uint64(FStar_UInt128_shift_right(res1, (uint32_t)64U));
     uint64_t lo = FStar_UInt128_uint128_to_uint64(res1);
     tmp[(uint32_t)2U * i] = lo;
-    tmp[(uint32_t)2U * i + (uint32_t)1U] = hi;
-  }
+    tmp[(uint32_t)2U * i + (uint32_t)1U] = hi;);
   uint64_t c1 = Hacl_Bignum_Addition_bn_add_eq_len_u64((uint32_t)8U, res, tmp, res);
 }
 
@@ -345,11 +362,12 @@ static inline uint64_t is_qelem_zero(uint64_t *f)
 {
   uint64_t bn_zero[4U] = { 0U };
   uint64_t mask = (uint64_t)0xFFFFFFFFFFFFFFFFU;
-  for (uint32_t i = (uint32_t)0U; i < (uint32_t)4U; i++)
-  {
+  KRML_MAYBE_FOR4(i,
+    (uint32_t)0U,
+    (uint32_t)4U,
+    (uint32_t)1U,
     uint64_t uu____0 = FStar_UInt64_eq_mask(f[i], bn_zero[i]);
-    mask = uu____0 & mask;
-  }
+    mask = uu____0 & mask;);
   uint64_t mask1 = mask;
   uint64_t res = mask1;
   return res;
@@ -374,12 +392,13 @@ static inline uint64_t load_qelem_check(uint64_t *f, uint8_t *b)
   Hacl_Bignum_Convert_bn_from_bytes_be_uint64((uint32_t)32U, b, f);
   uint64_t is_zero = is_qelem_zero(f);
   uint64_t acc = (uint64_t)0U;
-  for (uint32_t i = (uint32_t)0U; i < (uint32_t)4U; i++)
-  {
+  KRML_MAYBE_FOR4(i,
+    (uint32_t)0U,
+    (uint32_t)4U,
+    (uint32_t)1U,
     uint64_t beq = FStar_UInt64_eq_mask(f[i], n[i]);
     uint64_t blt = ~FStar_UInt64_gte_mask(f[i], n[i]);
-    acc = (beq & acc) | (~beq & ((blt & (uint64_t)0xFFFFFFFFFFFFFFFFU) | (~blt & (uint64_t)0U)));
-  }
+    acc = (beq & acc) | (~beq & ((blt & (uint64_t)0xFFFFFFFFFFFFFFFFU) | (~blt & (uint64_t)0U))););
   uint64_t is_lt_q = acc;
   return ~is_zero & is_lt_q;
 }
@@ -429,12 +448,13 @@ static inline void modq_short(uint64_t *out, uint64_t *a)
   tmp[3U] = (uint64_t)0x0U;
   uint64_t c = add4(a, tmp, out);
   uint64_t mask = (uint64_t)0U - c;
-  for (uint32_t i = (uint32_t)0U; i < (uint32_t)4U; i++)
-  {
+  KRML_MAYBE_FOR4(i,
+    (uint32_t)0U,
+    (uint32_t)4U,
+    (uint32_t)1U,
     uint64_t *os = out;
     uint64_t x = (mask & out[i]) | (~mask & a[i]);
-    os[i] = x;
-  }
+    os[i] = x;);
 }
 
 static inline void load_qelem_modq(uint64_t *f, uint8_t *b)
@@ -474,8 +494,10 @@ mul_pow2_256_minus_q_add(
   uint64_t tmp[len + (uint32_t)2U];
   memset(tmp, 0U, (len + (uint32_t)2U) * sizeof (uint64_t));
   memset(tmp, 0U, (len + (uint32_t)2U) * sizeof (uint64_t));
-  for (uint32_t i0 = (uint32_t)0U; i0 < (uint32_t)2U; i0++)
-  {
+  KRML_MAYBE_FOR2(i0,
+    (uint32_t)0U,
+    (uint32_t)2U,
+    (uint32_t)1U,
     uint64_t bj = t01[i0];
     uint64_t *res_j = tmp + i0;
     uint64_t c = (uint64_t)0U;
@@ -501,8 +523,7 @@ mul_pow2_256_minus_q_add(
       c = Hacl_Bignum_Base_mul_wide_add2_u64(a_i, bj, c, res_i);
     }
     uint64_t r = c;
-    tmp[len + i0] = r;
-  }
+    tmp[len + i0] = r;);
   memcpy(res + (uint32_t)2U, a, len * sizeof (uint64_t));
   uint64_t uu____0 = bn_add(resLen, res, len + (uint32_t)2U, tmp, res);
   uint64_t c = bn_add(resLen, res, (uint32_t)4U, e, res);
@@ -529,12 +550,13 @@ static inline void modq(uint64_t *out, uint64_t *a)
   uint64_t c00 = c2;
   uint64_t c1 = add4(r, tmp, out);
   uint64_t mask = (uint64_t)0U - (c00 + c1);
-  for (uint32_t i = (uint32_t)0U; i < (uint32_t)4U; i++)
-  {
+  KRML_MAYBE_FOR4(i,
+    (uint32_t)0U,
+    (uint32_t)4U,
+    (uint32_t)1U,
     uint64_t *os = out;
     uint64_t x = (mask & out[i]) | (~mask & r[i]);
-    os[i] = x;
-  }
+    os[i] = x;);
 }
 
 static inline void qmul(uint64_t *out, uint64_t *f1, uint64_t *f2)
@@ -939,18 +961,20 @@ void Hacl_Impl_K256_PointMul_point_mul(uint64_t *out, uint64_t *scalar, uint64_t
   memcpy(table, out, (uint32_t)15U * sizeof (uint64_t));
   uint64_t *t1 = table + (uint32_t)15U;
   memcpy(t1, q, (uint32_t)15U * sizeof (uint64_t));
-  for (uint32_t i = (uint32_t)0U; i < (uint32_t)15U; i++)
-  {
+  KRML_MAYBE_FOR15(i,
+    (uint32_t)0U,
+    (uint32_t)15U,
+    (uint32_t)1U,
     uint64_t *t11 = table + i * (uint32_t)15U;
     uint64_t *t2 = table + i * (uint32_t)15U + (uint32_t)15U;
-    Hacl_Impl_K256_PointAdd_point_add(t2, q, t11);
-  }
+    Hacl_Impl_K256_PointAdd_point_add(t2, q, t11););
   for (uint32_t i0 = (uint32_t)0U; i0 < (uint32_t)64U; i0++)
   {
-    for (uint32_t i = (uint32_t)0U; i < (uint32_t)4U; i++)
-    {
-      Hacl_Impl_K256_PointDouble_point_double(out, out);
-    }
+    KRML_MAYBE_FOR4(i,
+      (uint32_t)0U,
+      (uint32_t)4U,
+      (uint32_t)1U,
+      Hacl_Impl_K256_PointDouble_point_double(out, out););
     uint32_t bk = (uint32_t)256U;
     uint64_t mask_l = (uint64_t)16U - (uint64_t)1U;
     uint32_t i1 = (bk - (uint32_t)4U * i0 - (uint32_t)4U) / (uint32_t)64U;
@@ -968,17 +992,19 @@ void Hacl_Impl_K256_PointMul_point_mul(uint64_t *out, uint64_t *scalar, uint64_t
     uint64_t bits_l = ite & mask_l;
     uint64_t a_bits_l[15U] = { 0U };
     memcpy(a_bits_l, table, (uint32_t)15U * sizeof (uint64_t));
-    for (uint32_t i2 = (uint32_t)0U; i2 < (uint32_t)15U; i2++)
-    {
+    KRML_MAYBE_FOR15(i2,
+      (uint32_t)0U,
+      (uint32_t)15U,
+      (uint32_t)1U,
       uint64_t c = FStar_UInt64_eq_mask(bits_l, (uint64_t)(i2 + (uint32_t)1U));
       uint64_t *res_j = table + (i2 + (uint32_t)1U) * (uint32_t)15U;
-      for (uint32_t i = (uint32_t)0U; i < (uint32_t)15U; i++)
-      {
+      KRML_MAYBE_FOR15(i,
+        (uint32_t)0U,
+        (uint32_t)15U,
+        (uint32_t)1U,
         uint64_t *os = a_bits_l;
         uint64_t x = (c & res_j[i]) | (~c & a_bits_l[i]);
-        os[i] = x;
-      }
-    }
+        os[i] = x;););
     Hacl_Impl_K256_PointAdd_point_add(out, out, a_bits_l);
   }
 }
@@ -1003,28 +1029,31 @@ point_mul_double_vartime(
   memcpy(table1, out, (uint32_t)15U * sizeof (uint64_t));
   uint64_t *t10 = table1 + (uint32_t)15U;
   memcpy(t10, q1, (uint32_t)15U * sizeof (uint64_t));
-  for (uint32_t i = (uint32_t)0U; i < (uint32_t)15U; i++)
-  {
+  KRML_MAYBE_FOR15(i,
+    (uint32_t)0U,
+    (uint32_t)15U,
+    (uint32_t)1U,
     uint64_t *t11 = table1 + i * (uint32_t)15U;
     uint64_t *t2 = table1 + i * (uint32_t)15U + (uint32_t)15U;
-    Hacl_Impl_K256_PointAdd_point_add(t2, q1, t11);
-  }
+    Hacl_Impl_K256_PointAdd_point_add(t2, q1, t11););
   uint64_t table2[240U] = { 0U };
   memcpy(table2, out, (uint32_t)15U * sizeof (uint64_t));
   uint64_t *t1 = table2 + (uint32_t)15U;
   memcpy(t1, q2, (uint32_t)15U * sizeof (uint64_t));
-  for (uint32_t i = (uint32_t)0U; i < (uint32_t)15U; i++)
-  {
+  KRML_MAYBE_FOR15(i,
+    (uint32_t)0U,
+    (uint32_t)15U,
+    (uint32_t)1U,
     uint64_t *t11 = table2 + i * (uint32_t)15U;
     uint64_t *t2 = table2 + i * (uint32_t)15U + (uint32_t)15U;
-    Hacl_Impl_K256_PointAdd_point_add(t2, q2, t11);
-  }
+    Hacl_Impl_K256_PointAdd_point_add(t2, q2, t11););
   for (uint32_t i = (uint32_t)0U; i < (uint32_t)64U; i++)
   {
-    for (uint32_t i0 = (uint32_t)0U; i0 < (uint32_t)4U; i0++)
-    {
-      Hacl_Impl_K256_PointDouble_point_double(out, out);
-    }
+    KRML_MAYBE_FOR4(i0,
+      (uint32_t)0U,
+      (uint32_t)4U,
+      (uint32_t)1U,
+      Hacl_Impl_K256_PointDouble_point_double(out, out););
     uint32_t bk = (uint32_t)256U;
     uint64_t mask_l0 = (uint64_t)16U - (uint64_t)1U;
     uint32_t i10 = (bk - (uint32_t)4U * i - (uint32_t)4U) / (uint32_t)64U;

--- a/dist/gcc-compatible/Hacl_K256_ECDSA.c
+++ b/dist/gcc-compatible/Hacl_K256_ECDSA.c
@@ -96,99 +96,69 @@ bn_add(uint32_t aLen, uint64_t *a, uint32_t bLen, uint64_t *b, uint64_t *res)
 static uint64_t add4(uint64_t *a, uint64_t *b, uint64_t *res)
 {
   uint64_t c = (uint64_t)0U;
-  KRML_MAYBE_FOR1(i,
-    (uint32_t)0U,
-    (uint32_t)1U,
-    (uint32_t)1U,
-    uint64_t t1 = a[(uint32_t)4U * i];
-    uint64_t t20 = b[(uint32_t)4U * i];
-    uint64_t *res_i0 = res + (uint32_t)4U * i;
+  {
+    uint64_t t1 = a[(uint32_t)4U * (uint32_t)0U];
+    uint64_t t20 = b[(uint32_t)4U * (uint32_t)0U];
+    uint64_t *res_i0 = res + (uint32_t)4U * (uint32_t)0U;
     c = Lib_IntTypes_Intrinsics_add_carry_u64(c, t1, t20, res_i0);
-    uint64_t t10 = a[(uint32_t)4U * i + (uint32_t)1U];
-    uint64_t t21 = b[(uint32_t)4U * i + (uint32_t)1U];
-    uint64_t *res_i1 = res + (uint32_t)4U * i + (uint32_t)1U;
+    uint64_t t10 = a[(uint32_t)4U * (uint32_t)0U + (uint32_t)1U];
+    uint64_t t21 = b[(uint32_t)4U * (uint32_t)0U + (uint32_t)1U];
+    uint64_t *res_i1 = res + (uint32_t)4U * (uint32_t)0U + (uint32_t)1U;
     c = Lib_IntTypes_Intrinsics_add_carry_u64(c, t10, t21, res_i1);
-    uint64_t t11 = a[(uint32_t)4U * i + (uint32_t)2U];
-    uint64_t t22 = b[(uint32_t)4U * i + (uint32_t)2U];
-    uint64_t *res_i2 = res + (uint32_t)4U * i + (uint32_t)2U;
+    uint64_t t11 = a[(uint32_t)4U * (uint32_t)0U + (uint32_t)2U];
+    uint64_t t22 = b[(uint32_t)4U * (uint32_t)0U + (uint32_t)2U];
+    uint64_t *res_i2 = res + (uint32_t)4U * (uint32_t)0U + (uint32_t)2U;
     c = Lib_IntTypes_Intrinsics_add_carry_u64(c, t11, t22, res_i2);
-    uint64_t t12 = a[(uint32_t)4U * i + (uint32_t)3U];
-    uint64_t t2 = b[(uint32_t)4U * i + (uint32_t)3U];
-    uint64_t *res_i = res + (uint32_t)4U * i + (uint32_t)3U;
-    c = Lib_IntTypes_Intrinsics_add_carry_u64(c, t12, t2, res_i););
-  KRML_MAYBE_FOR0(i,
-    (uint32_t)4U,
-    (uint32_t)4U,
-    (uint32_t)1U,
-    uint64_t t1 = a[i];
-    uint64_t t2 = b[i];
-    uint64_t *res_i = res + i;
-    c = Lib_IntTypes_Intrinsics_add_carry_u64(c, t1, t2, res_i););
+    uint64_t t12 = a[(uint32_t)4U * (uint32_t)0U + (uint32_t)3U];
+    uint64_t t2 = b[(uint32_t)4U * (uint32_t)0U + (uint32_t)3U];
+    uint64_t *res_i = res + (uint32_t)4U * (uint32_t)0U + (uint32_t)3U;
+    c = Lib_IntTypes_Intrinsics_add_carry_u64(c, t12, t2, res_i);
+  }
   return c;
 }
 
 static void add_mod4(uint64_t *n, uint64_t *a, uint64_t *b, uint64_t *res)
 {
   uint64_t c0 = (uint64_t)0U;
-  KRML_MAYBE_FOR1(i,
-    (uint32_t)0U,
-    (uint32_t)1U,
-    (uint32_t)1U,
-    uint64_t t1 = a[(uint32_t)4U * i];
-    uint64_t t20 = b[(uint32_t)4U * i];
-    uint64_t *res_i0 = res + (uint32_t)4U * i;
+  {
+    uint64_t t1 = a[(uint32_t)4U * (uint32_t)0U];
+    uint64_t t20 = b[(uint32_t)4U * (uint32_t)0U];
+    uint64_t *res_i0 = res + (uint32_t)4U * (uint32_t)0U;
     c0 = Lib_IntTypes_Intrinsics_add_carry_u64(c0, t1, t20, res_i0);
-    uint64_t t10 = a[(uint32_t)4U * i + (uint32_t)1U];
-    uint64_t t21 = b[(uint32_t)4U * i + (uint32_t)1U];
-    uint64_t *res_i1 = res + (uint32_t)4U * i + (uint32_t)1U;
+    uint64_t t10 = a[(uint32_t)4U * (uint32_t)0U + (uint32_t)1U];
+    uint64_t t21 = b[(uint32_t)4U * (uint32_t)0U + (uint32_t)1U];
+    uint64_t *res_i1 = res + (uint32_t)4U * (uint32_t)0U + (uint32_t)1U;
     c0 = Lib_IntTypes_Intrinsics_add_carry_u64(c0, t10, t21, res_i1);
-    uint64_t t11 = a[(uint32_t)4U * i + (uint32_t)2U];
-    uint64_t t22 = b[(uint32_t)4U * i + (uint32_t)2U];
-    uint64_t *res_i2 = res + (uint32_t)4U * i + (uint32_t)2U;
+    uint64_t t11 = a[(uint32_t)4U * (uint32_t)0U + (uint32_t)2U];
+    uint64_t t22 = b[(uint32_t)4U * (uint32_t)0U + (uint32_t)2U];
+    uint64_t *res_i2 = res + (uint32_t)4U * (uint32_t)0U + (uint32_t)2U;
     c0 = Lib_IntTypes_Intrinsics_add_carry_u64(c0, t11, t22, res_i2);
-    uint64_t t12 = a[(uint32_t)4U * i + (uint32_t)3U];
-    uint64_t t2 = b[(uint32_t)4U * i + (uint32_t)3U];
-    uint64_t *res_i = res + (uint32_t)4U * i + (uint32_t)3U;
-    c0 = Lib_IntTypes_Intrinsics_add_carry_u64(c0, t12, t2, res_i););
-  KRML_MAYBE_FOR0(i,
-    (uint32_t)4U,
-    (uint32_t)4U,
-    (uint32_t)1U,
-    uint64_t t1 = a[i];
-    uint64_t t2 = b[i];
-    uint64_t *res_i = res + i;
-    c0 = Lib_IntTypes_Intrinsics_add_carry_u64(c0, t1, t2, res_i););
+    uint64_t t12 = a[(uint32_t)4U * (uint32_t)0U + (uint32_t)3U];
+    uint64_t t2 = b[(uint32_t)4U * (uint32_t)0U + (uint32_t)3U];
+    uint64_t *res_i = res + (uint32_t)4U * (uint32_t)0U + (uint32_t)3U;
+    c0 = Lib_IntTypes_Intrinsics_add_carry_u64(c0, t12, t2, res_i);
+  }
   uint64_t c00 = c0;
   uint64_t tmp[4U] = { 0U };
   uint64_t c = (uint64_t)0U;
-  KRML_MAYBE_FOR1(i,
-    (uint32_t)0U,
-    (uint32_t)1U,
-    (uint32_t)1U,
-    uint64_t t1 = res[(uint32_t)4U * i];
-    uint64_t t20 = n[(uint32_t)4U * i];
-    uint64_t *res_i0 = tmp + (uint32_t)4U * i;
+  {
+    uint64_t t1 = res[(uint32_t)4U * (uint32_t)0U];
+    uint64_t t20 = n[(uint32_t)4U * (uint32_t)0U];
+    uint64_t *res_i0 = tmp + (uint32_t)4U * (uint32_t)0U;
     c = Lib_IntTypes_Intrinsics_sub_borrow_u64(c, t1, t20, res_i0);
-    uint64_t t10 = res[(uint32_t)4U * i + (uint32_t)1U];
-    uint64_t t21 = n[(uint32_t)4U * i + (uint32_t)1U];
-    uint64_t *res_i1 = tmp + (uint32_t)4U * i + (uint32_t)1U;
+    uint64_t t10 = res[(uint32_t)4U * (uint32_t)0U + (uint32_t)1U];
+    uint64_t t21 = n[(uint32_t)4U * (uint32_t)0U + (uint32_t)1U];
+    uint64_t *res_i1 = tmp + (uint32_t)4U * (uint32_t)0U + (uint32_t)1U;
     c = Lib_IntTypes_Intrinsics_sub_borrow_u64(c, t10, t21, res_i1);
-    uint64_t t11 = res[(uint32_t)4U * i + (uint32_t)2U];
-    uint64_t t22 = n[(uint32_t)4U * i + (uint32_t)2U];
-    uint64_t *res_i2 = tmp + (uint32_t)4U * i + (uint32_t)2U;
+    uint64_t t11 = res[(uint32_t)4U * (uint32_t)0U + (uint32_t)2U];
+    uint64_t t22 = n[(uint32_t)4U * (uint32_t)0U + (uint32_t)2U];
+    uint64_t *res_i2 = tmp + (uint32_t)4U * (uint32_t)0U + (uint32_t)2U;
     c = Lib_IntTypes_Intrinsics_sub_borrow_u64(c, t11, t22, res_i2);
-    uint64_t t12 = res[(uint32_t)4U * i + (uint32_t)3U];
-    uint64_t t2 = n[(uint32_t)4U * i + (uint32_t)3U];
-    uint64_t *res_i = tmp + (uint32_t)4U * i + (uint32_t)3U;
-    c = Lib_IntTypes_Intrinsics_sub_borrow_u64(c, t12, t2, res_i););
-  KRML_MAYBE_FOR0(i,
-    (uint32_t)4U,
-    (uint32_t)4U,
-    (uint32_t)1U,
-    uint64_t t1 = res[i];
-    uint64_t t2 = n[i];
-    uint64_t *res_i = tmp + i;
-    c = Lib_IntTypes_Intrinsics_sub_borrow_u64(c, t1, t2, res_i););
+    uint64_t t12 = res[(uint32_t)4U * (uint32_t)0U + (uint32_t)3U];
+    uint64_t t2 = n[(uint32_t)4U * (uint32_t)0U + (uint32_t)3U];
+    uint64_t *res_i = tmp + (uint32_t)4U * (uint32_t)0U + (uint32_t)3U;
+    c = Lib_IntTypes_Intrinsics_sub_borrow_u64(c, t12, t2, res_i);
+  }
   uint64_t c1 = c;
   uint64_t c2 = c00 - c1;
   KRML_MAYBE_FOR4(i,
@@ -203,65 +173,45 @@ static void add_mod4(uint64_t *n, uint64_t *a, uint64_t *b, uint64_t *res)
 static void sub_mod4(uint64_t *n, uint64_t *a, uint64_t *b, uint64_t *res)
 {
   uint64_t c0 = (uint64_t)0U;
-  KRML_MAYBE_FOR1(i,
-    (uint32_t)0U,
-    (uint32_t)1U,
-    (uint32_t)1U,
-    uint64_t t1 = a[(uint32_t)4U * i];
-    uint64_t t20 = b[(uint32_t)4U * i];
-    uint64_t *res_i0 = res + (uint32_t)4U * i;
+  {
+    uint64_t t1 = a[(uint32_t)4U * (uint32_t)0U];
+    uint64_t t20 = b[(uint32_t)4U * (uint32_t)0U];
+    uint64_t *res_i0 = res + (uint32_t)4U * (uint32_t)0U;
     c0 = Lib_IntTypes_Intrinsics_sub_borrow_u64(c0, t1, t20, res_i0);
-    uint64_t t10 = a[(uint32_t)4U * i + (uint32_t)1U];
-    uint64_t t21 = b[(uint32_t)4U * i + (uint32_t)1U];
-    uint64_t *res_i1 = res + (uint32_t)4U * i + (uint32_t)1U;
+    uint64_t t10 = a[(uint32_t)4U * (uint32_t)0U + (uint32_t)1U];
+    uint64_t t21 = b[(uint32_t)4U * (uint32_t)0U + (uint32_t)1U];
+    uint64_t *res_i1 = res + (uint32_t)4U * (uint32_t)0U + (uint32_t)1U;
     c0 = Lib_IntTypes_Intrinsics_sub_borrow_u64(c0, t10, t21, res_i1);
-    uint64_t t11 = a[(uint32_t)4U * i + (uint32_t)2U];
-    uint64_t t22 = b[(uint32_t)4U * i + (uint32_t)2U];
-    uint64_t *res_i2 = res + (uint32_t)4U * i + (uint32_t)2U;
+    uint64_t t11 = a[(uint32_t)4U * (uint32_t)0U + (uint32_t)2U];
+    uint64_t t22 = b[(uint32_t)4U * (uint32_t)0U + (uint32_t)2U];
+    uint64_t *res_i2 = res + (uint32_t)4U * (uint32_t)0U + (uint32_t)2U;
     c0 = Lib_IntTypes_Intrinsics_sub_borrow_u64(c0, t11, t22, res_i2);
-    uint64_t t12 = a[(uint32_t)4U * i + (uint32_t)3U];
-    uint64_t t2 = b[(uint32_t)4U * i + (uint32_t)3U];
-    uint64_t *res_i = res + (uint32_t)4U * i + (uint32_t)3U;
-    c0 = Lib_IntTypes_Intrinsics_sub_borrow_u64(c0, t12, t2, res_i););
-  KRML_MAYBE_FOR0(i,
-    (uint32_t)4U,
-    (uint32_t)4U,
-    (uint32_t)1U,
-    uint64_t t1 = a[i];
-    uint64_t t2 = b[i];
-    uint64_t *res_i = res + i;
-    c0 = Lib_IntTypes_Intrinsics_sub_borrow_u64(c0, t1, t2, res_i););
+    uint64_t t12 = a[(uint32_t)4U * (uint32_t)0U + (uint32_t)3U];
+    uint64_t t2 = b[(uint32_t)4U * (uint32_t)0U + (uint32_t)3U];
+    uint64_t *res_i = res + (uint32_t)4U * (uint32_t)0U + (uint32_t)3U;
+    c0 = Lib_IntTypes_Intrinsics_sub_borrow_u64(c0, t12, t2, res_i);
+  }
   uint64_t c00 = c0;
   uint64_t tmp[4U] = { 0U };
   uint64_t c = (uint64_t)0U;
-  KRML_MAYBE_FOR1(i,
-    (uint32_t)0U,
-    (uint32_t)1U,
-    (uint32_t)1U,
-    uint64_t t1 = res[(uint32_t)4U * i];
-    uint64_t t20 = n[(uint32_t)4U * i];
-    uint64_t *res_i0 = tmp + (uint32_t)4U * i;
+  {
+    uint64_t t1 = res[(uint32_t)4U * (uint32_t)0U];
+    uint64_t t20 = n[(uint32_t)4U * (uint32_t)0U];
+    uint64_t *res_i0 = tmp + (uint32_t)4U * (uint32_t)0U;
     c = Lib_IntTypes_Intrinsics_add_carry_u64(c, t1, t20, res_i0);
-    uint64_t t10 = res[(uint32_t)4U * i + (uint32_t)1U];
-    uint64_t t21 = n[(uint32_t)4U * i + (uint32_t)1U];
-    uint64_t *res_i1 = tmp + (uint32_t)4U * i + (uint32_t)1U;
+    uint64_t t10 = res[(uint32_t)4U * (uint32_t)0U + (uint32_t)1U];
+    uint64_t t21 = n[(uint32_t)4U * (uint32_t)0U + (uint32_t)1U];
+    uint64_t *res_i1 = tmp + (uint32_t)4U * (uint32_t)0U + (uint32_t)1U;
     c = Lib_IntTypes_Intrinsics_add_carry_u64(c, t10, t21, res_i1);
-    uint64_t t11 = res[(uint32_t)4U * i + (uint32_t)2U];
-    uint64_t t22 = n[(uint32_t)4U * i + (uint32_t)2U];
-    uint64_t *res_i2 = tmp + (uint32_t)4U * i + (uint32_t)2U;
+    uint64_t t11 = res[(uint32_t)4U * (uint32_t)0U + (uint32_t)2U];
+    uint64_t t22 = n[(uint32_t)4U * (uint32_t)0U + (uint32_t)2U];
+    uint64_t *res_i2 = tmp + (uint32_t)4U * (uint32_t)0U + (uint32_t)2U;
     c = Lib_IntTypes_Intrinsics_add_carry_u64(c, t11, t22, res_i2);
-    uint64_t t12 = res[(uint32_t)4U * i + (uint32_t)3U];
-    uint64_t t2 = n[(uint32_t)4U * i + (uint32_t)3U];
-    uint64_t *res_i = tmp + (uint32_t)4U * i + (uint32_t)3U;
-    c = Lib_IntTypes_Intrinsics_add_carry_u64(c, t12, t2, res_i););
-  KRML_MAYBE_FOR0(i,
-    (uint32_t)4U,
-    (uint32_t)4U,
-    (uint32_t)1U,
-    uint64_t t1 = res[i];
-    uint64_t t2 = n[i];
-    uint64_t *res_i = tmp + i;
-    c = Lib_IntTypes_Intrinsics_add_carry_u64(c, t1, t2, res_i););
+    uint64_t t12 = res[(uint32_t)4U * (uint32_t)0U + (uint32_t)3U];
+    uint64_t t2 = n[(uint32_t)4U * (uint32_t)0U + (uint32_t)3U];
+    uint64_t *res_i = tmp + (uint32_t)4U * (uint32_t)0U + (uint32_t)3U;
+    c = Lib_IntTypes_Intrinsics_add_carry_u64(c, t12, t2, res_i);
+  }
   uint64_t c1 = c;
   uint64_t c2 = (uint64_t)0U - c00;
   KRML_MAYBE_FOR4(i,
@@ -283,29 +233,20 @@ static void mul4(uint64_t *a, uint64_t *b, uint64_t *res)
     uint64_t bj = b[i0];
     uint64_t *res_j = res + i0;
     uint64_t c = (uint64_t)0U;
-    KRML_MAYBE_FOR1(i,
-      (uint32_t)0U,
-      (uint32_t)1U,
-      (uint32_t)1U,
-      uint64_t a_i = a[(uint32_t)4U * i];
-      uint64_t *res_i0 = res_j + (uint32_t)4U * i;
+    {
+      uint64_t a_i = a[(uint32_t)4U * (uint32_t)0U];
+      uint64_t *res_i0 = res_j + (uint32_t)4U * (uint32_t)0U;
       c = Hacl_Bignum_Base_mul_wide_add2_u64(a_i, bj, c, res_i0);
-      uint64_t a_i0 = a[(uint32_t)4U * i + (uint32_t)1U];
-      uint64_t *res_i1 = res_j + (uint32_t)4U * i + (uint32_t)1U;
+      uint64_t a_i0 = a[(uint32_t)4U * (uint32_t)0U + (uint32_t)1U];
+      uint64_t *res_i1 = res_j + (uint32_t)4U * (uint32_t)0U + (uint32_t)1U;
       c = Hacl_Bignum_Base_mul_wide_add2_u64(a_i0, bj, c, res_i1);
-      uint64_t a_i1 = a[(uint32_t)4U * i + (uint32_t)2U];
-      uint64_t *res_i2 = res_j + (uint32_t)4U * i + (uint32_t)2U;
+      uint64_t a_i1 = a[(uint32_t)4U * (uint32_t)0U + (uint32_t)2U];
+      uint64_t *res_i2 = res_j + (uint32_t)4U * (uint32_t)0U + (uint32_t)2U;
       c = Hacl_Bignum_Base_mul_wide_add2_u64(a_i1, bj, c, res_i2);
-      uint64_t a_i2 = a[(uint32_t)4U * i + (uint32_t)3U];
-      uint64_t *res_i = res_j + (uint32_t)4U * i + (uint32_t)3U;
-      c = Hacl_Bignum_Base_mul_wide_add2_u64(a_i2, bj, c, res_i););
-    KRML_MAYBE_FOR0(i,
-      (uint32_t)4U,
-      (uint32_t)4U,
-      (uint32_t)1U,
-      uint64_t a_i = a[i];
-      uint64_t *res_i = res_j + i;
-      c = Hacl_Bignum_Base_mul_wide_add2_u64(a_i, bj, c, res_i););
+      uint64_t a_i2 = a[(uint32_t)4U * (uint32_t)0U + (uint32_t)3U];
+      uint64_t *res_i = res_j + (uint32_t)4U * (uint32_t)0U + (uint32_t)3U;
+      c = Hacl_Bignum_Base_mul_wide_add2_u64(a_i2, bj, c, res_i);
+    }
     uint64_t r = c;
     res[(uint32_t)4U + i0] = r;);
 }

--- a/dist/gcc-compatible/Hacl_NaCl.c
+++ b/dist/gcc-compatible/Hacl_NaCl.c
@@ -88,11 +88,12 @@ secretbox_open_detached(
   uint8_t tag_[16U] = { 0U };
   Hacl_Poly1305_32_poly1305_mac(tag_, mlen, c, mkey);
   uint8_t res = (uint8_t)255U;
-  for (uint32_t i = (uint32_t)0U; i < (uint32_t)16U; i++)
-  {
+  KRML_MAYBE_FOR16(i,
+    (uint32_t)0U,
+    (uint32_t)16U,
+    (uint32_t)1U,
     uint8_t uu____0 = FStar_UInt8_eq_mask(tag[i], tag_[i]);
-    res = uu____0 & res;
-  }
+    res = uu____0 & res;);
   uint8_t z = res;
   if (z == (uint8_t)255U)
   {

--- a/dist/gcc-compatible/Hacl_P256.c
+++ b/dist/gcc-compatible/Hacl_P256.c
@@ -363,10 +363,11 @@ static void uploadOneImpl(uint64_t *f)
 
 void Hacl_Impl_P256_LowLevel_toUint8(uint64_t *i, uint8_t *o)
 {
-  for (uint32_t i0 = (uint32_t)0U; i0 < (uint32_t)4U; i0++)
-  {
-    store64_be(o + i0 * (uint32_t)8U, i[i0]);
-  }
+  KRML_MAYBE_FOR4(i0,
+    (uint32_t)0U,
+    (uint32_t)4U,
+    (uint32_t)1U,
+    store64_be(o + i0 * (uint32_t)8U, i[i0]););
 }
 
 void Hacl_Impl_P256_LowLevel_changeEndian(uint64_t *i)
@@ -383,15 +384,16 @@ void Hacl_Impl_P256_LowLevel_changeEndian(uint64_t *i)
 
 void Hacl_Impl_P256_LowLevel_toUint64ChangeEndian(uint8_t *i, uint64_t *o)
 {
-  for (uint32_t i0 = (uint32_t)0U; i0 < (uint32_t)4U; i0++)
-  {
+  KRML_MAYBE_FOR4(i0,
+    (uint32_t)0U,
+    (uint32_t)4U,
+    (uint32_t)1U,
     uint64_t *os = o;
     uint8_t *bj = i + i0 * (uint32_t)8U;
     uint64_t u = load64_be(bj);
     uint64_t r = u;
     uint64_t x = r;
-    os[i0] = x;
-  }
+    os[i0] = x;);
   Hacl_Impl_P256_LowLevel_changeEndian(o);
 }
 
@@ -1420,12 +1422,13 @@ uint64_t Hacl_Impl_P256_Core_isPointAtInfinityPrivate(uint64_t *p)
 static inline void cswap(uint64_t bit, uint64_t *p1, uint64_t *p2)
 {
   uint64_t mask = (uint64_t)0U - bit;
-  for (uint32_t i = (uint32_t)0U; i < (uint32_t)12U; i++)
-  {
+  KRML_MAYBE_FOR12(i,
+    (uint32_t)0U,
+    (uint32_t)12U,
+    (uint32_t)1U,
     uint64_t dummy = mask & (p1[i] ^ p2[i]);
     p1[i] = p1[i] ^ dummy;
-    p2[i] = p2[i] ^ dummy;
-  }
+    p2[i] = p2[i] ^ dummy;);
 }
 
 static void norm(uint64_t *p, uint64_t *resultPoint, uint64_t *tempBuffer)
@@ -1978,12 +1981,13 @@ uint64_t Hacl_Impl_P256_DH__ecp256dh_r(uint64_t *result, uint64_t *pubKey, uint8
 static inline void cswap0(uint64_t bit, uint64_t *p1, uint64_t *p2)
 {
   uint64_t mask = (uint64_t)0U - bit;
-  for (uint32_t i = (uint32_t)0U; i < (uint32_t)4U; i++)
-  {
+  KRML_MAYBE_FOR4(i,
+    (uint32_t)0U,
+    (uint32_t)4U,
+    (uint32_t)1U,
     uint64_t dummy = mask & (p1[i] ^ p2[i]);
     p1[i] = p1[i] ^ dummy;
-    p2[i] = p2[i] ^ dummy;
-  }
+    p2[i] = p2[i] ^ dummy;);
 }
 
 static void montgomery_ladder_exponent(uint64_t *r)
@@ -2413,12 +2417,13 @@ ecdsa_signature_core(
 static inline void cswap1(uint64_t bit, uint64_t *p1, uint64_t *p2)
 {
   uint64_t mask = (uint64_t)0U - bit;
-  for (uint32_t i = (uint32_t)0U; i < (uint32_t)4U; i++)
-  {
+  KRML_MAYBE_FOR4(i,
+    (uint32_t)0U,
+    (uint32_t)4U,
+    (uint32_t)1U,
     uint64_t dummy = mask & (p1[i] ^ p2[i]);
     p1[i] = p1[i] ^ dummy;
-    p2[i] = p2[i] ^ dummy;
-  }
+    p2[i] = p2[i] ^ dummy;);
 }
 
 static void montgomery_ladder_power(uint64_t *a, const uint8_t *scalar, uint64_t *result)

--- a/dist/gcc-compatible/Hacl_SHA2_Scalar32.c
+++ b/dist/gcc-compatible/Hacl_SHA2_Scalar32.c
@@ -64,10 +64,14 @@ static inline void sha224_update1(uint8_t *block, uint32_t *hash)
   ws[14U] = u13;
   uint32_t u14 = load32_be(b + (uint32_t)60U);
   ws[15U] = u14;
-  for (uint32_t i0 = (uint32_t)0U; i0 < (uint32_t)4U; i0++)
-  {
-    for (uint32_t i = (uint32_t)0U; i < (uint32_t)16U; i++)
-    {
+  KRML_MAYBE_FOR4(i0,
+    (uint32_t)0U,
+    (uint32_t)4U,
+    (uint32_t)1U,
+    KRML_MAYBE_FOR16(i,
+      (uint32_t)0U,
+      (uint32_t)16U,
+      (uint32_t)1U,
       uint32_t k_t = Hacl_Impl_SHA2_Generic_k224_256[(uint32_t)16U * i0 + i];
       uint32_t ws_t = ws[i];
       uint32_t a0 = hash[0U];
@@ -112,12 +116,13 @@ static inline void sha224_update1(uint8_t *block, uint32_t *hash)
       hash[4U] = e1;
       hash[5U] = f1;
       hash[6U] = g1;
-      hash[7U] = h12;
-    }
+      hash[7U] = h12;);
     if (i0 < (uint32_t)4U - (uint32_t)1U)
     {
-      for (uint32_t i = (uint32_t)0U; i < (uint32_t)16U; i++)
-      {
+      KRML_MAYBE_FOR16(i,
+        (uint32_t)0U,
+        (uint32_t)16U,
+        (uint32_t)1U,
         uint32_t t16 = ws[i];
         uint32_t t15 = ws[(i + (uint32_t)1U) % (uint32_t)16U];
         uint32_t t7 = ws[(i + (uint32_t)9U) % (uint32_t)16U];
@@ -130,16 +135,15 @@ static inline void sha224_update1(uint8_t *block, uint32_t *hash)
         s0 =
           (t15 << ((uint32_t)32U - (uint32_t)7U) | t15 >> (uint32_t)7U)
           ^ ((t15 << ((uint32_t)32U - (uint32_t)18U) | t15 >> (uint32_t)18U) ^ t15 >> (uint32_t)3U);
-        ws[i] = s1 + t7 + s0 + t16;
-      }
-    }
-  }
-  for (uint32_t i = (uint32_t)0U; i < (uint32_t)8U; i++)
-  {
+        ws[i] = s1 + t7 + s0 + t16;);
+    });
+  KRML_MAYBE_FOR8(i,
+    (uint32_t)0U,
+    (uint32_t)8U,
+    (uint32_t)1U,
     uint32_t *os = hash;
     uint32_t x = hash[i] + hash_old[i];
-    os[i] = x;
-  }
+    os[i] = x;);
 }
 
 void Hacl_SHA2_Scalar32_sha224(uint8_t *dst, uint32_t input_len, uint8_t *input)
@@ -147,12 +151,13 @@ void Hacl_SHA2_Scalar32_sha224(uint8_t *dst, uint32_t input_len, uint8_t *input)
   uint8_t *ib = input;
   uint8_t *rb = dst;
   uint32_t st[8U] = { 0U };
-  for (uint32_t i = (uint32_t)0U; i < (uint32_t)8U; i++)
-  {
+  KRML_MAYBE_FOR8(i,
+    (uint32_t)0U,
+    (uint32_t)8U,
+    (uint32_t)1U,
     uint32_t *os = st;
     uint32_t x = Hacl_Impl_SHA2_Generic_h224[i];
-    os[i] = x;
-  }
+    os[i] = x;);
   uint32_t rem = input_len % (uint32_t)64U;
   uint64_t len_ = (uint64_t)input_len;
   uint32_t blocks0 = input_len / (uint32_t)64U;
@@ -201,10 +206,11 @@ void Hacl_SHA2_Scalar32_sha224(uint8_t *dst, uint32_t input_len, uint8_t *input)
   KRML_CHECK_SIZE(sizeof (uint8_t), (uint32_t)1U * (uint32_t)8U * (uint32_t)4U);
   uint8_t hbuf[(uint32_t)1U * (uint32_t)8U * (uint32_t)4U];
   memset(hbuf, 0U, (uint32_t)1U * (uint32_t)8U * (uint32_t)4U * sizeof (uint8_t));
-  for (uint32_t i = (uint32_t)0U; i < (uint32_t)8U; i++)
-  {
-    store32_be(hbuf + i * (uint32_t)4U, st[i]);
-  }
+  KRML_MAYBE_FOR8(i,
+    (uint32_t)0U,
+    (uint32_t)8U,
+    (uint32_t)1U,
+    store32_be(hbuf + i * (uint32_t)4U, st[i]););
   memcpy(rb, hbuf, (uint32_t)28U * sizeof (uint8_t));
 }
 
@@ -246,10 +252,14 @@ static inline void sha256_update1(uint8_t *block, uint32_t *hash)
   ws[14U] = u13;
   uint32_t u14 = load32_be(b + (uint32_t)60U);
   ws[15U] = u14;
-  for (uint32_t i0 = (uint32_t)0U; i0 < (uint32_t)4U; i0++)
-  {
-    for (uint32_t i = (uint32_t)0U; i < (uint32_t)16U; i++)
-    {
+  KRML_MAYBE_FOR4(i0,
+    (uint32_t)0U,
+    (uint32_t)4U,
+    (uint32_t)1U,
+    KRML_MAYBE_FOR16(i,
+      (uint32_t)0U,
+      (uint32_t)16U,
+      (uint32_t)1U,
       uint32_t k_t = Hacl_Impl_SHA2_Generic_k224_256[(uint32_t)16U * i0 + i];
       uint32_t ws_t = ws[i];
       uint32_t a0 = hash[0U];
@@ -294,12 +304,13 @@ static inline void sha256_update1(uint8_t *block, uint32_t *hash)
       hash[4U] = e1;
       hash[5U] = f1;
       hash[6U] = g1;
-      hash[7U] = h12;
-    }
+      hash[7U] = h12;);
     if (i0 < (uint32_t)4U - (uint32_t)1U)
     {
-      for (uint32_t i = (uint32_t)0U; i < (uint32_t)16U; i++)
-      {
+      KRML_MAYBE_FOR16(i,
+        (uint32_t)0U,
+        (uint32_t)16U,
+        (uint32_t)1U,
         uint32_t t16 = ws[i];
         uint32_t t15 = ws[(i + (uint32_t)1U) % (uint32_t)16U];
         uint32_t t7 = ws[(i + (uint32_t)9U) % (uint32_t)16U];
@@ -312,16 +323,15 @@ static inline void sha256_update1(uint8_t *block, uint32_t *hash)
         s0 =
           (t15 << ((uint32_t)32U - (uint32_t)7U) | t15 >> (uint32_t)7U)
           ^ ((t15 << ((uint32_t)32U - (uint32_t)18U) | t15 >> (uint32_t)18U) ^ t15 >> (uint32_t)3U);
-        ws[i] = s1 + t7 + s0 + t16;
-      }
-    }
-  }
-  for (uint32_t i = (uint32_t)0U; i < (uint32_t)8U; i++)
-  {
+        ws[i] = s1 + t7 + s0 + t16;);
+    });
+  KRML_MAYBE_FOR8(i,
+    (uint32_t)0U,
+    (uint32_t)8U,
+    (uint32_t)1U,
     uint32_t *os = hash;
     uint32_t x = hash[i] + hash_old[i];
-    os[i] = x;
-  }
+    os[i] = x;);
 }
 
 void Hacl_SHA2_Scalar32_sha256(uint8_t *dst, uint32_t input_len, uint8_t *input)
@@ -329,12 +339,13 @@ void Hacl_SHA2_Scalar32_sha256(uint8_t *dst, uint32_t input_len, uint8_t *input)
   uint8_t *ib = input;
   uint8_t *rb = dst;
   uint32_t st[8U] = { 0U };
-  for (uint32_t i = (uint32_t)0U; i < (uint32_t)8U; i++)
-  {
+  KRML_MAYBE_FOR8(i,
+    (uint32_t)0U,
+    (uint32_t)8U,
+    (uint32_t)1U,
     uint32_t *os = st;
     uint32_t x = Hacl_Impl_SHA2_Generic_h256[i];
-    os[i] = x;
-  }
+    os[i] = x;);
   uint32_t rem = input_len % (uint32_t)64U;
   uint64_t len_ = (uint64_t)input_len;
   uint32_t blocks0 = input_len / (uint32_t)64U;
@@ -383,10 +394,11 @@ void Hacl_SHA2_Scalar32_sha256(uint8_t *dst, uint32_t input_len, uint8_t *input)
   KRML_CHECK_SIZE(sizeof (uint8_t), (uint32_t)1U * (uint32_t)8U * (uint32_t)4U);
   uint8_t hbuf[(uint32_t)1U * (uint32_t)8U * (uint32_t)4U];
   memset(hbuf, 0U, (uint32_t)1U * (uint32_t)8U * (uint32_t)4U * sizeof (uint8_t));
-  for (uint32_t i = (uint32_t)0U; i < (uint32_t)8U; i++)
-  {
-    store32_be(hbuf + i * (uint32_t)4U, st[i]);
-  }
+  KRML_MAYBE_FOR8(i,
+    (uint32_t)0U,
+    (uint32_t)8U,
+    (uint32_t)1U,
+    store32_be(hbuf + i * (uint32_t)4U, st[i]););
   memcpy(rb, hbuf, (uint32_t)32U * sizeof (uint8_t));
 }
 
@@ -428,10 +440,14 @@ static inline void sha384_update1(uint8_t *block, uint64_t *hash)
   ws[14U] = u13;
   uint64_t u14 = load64_be(b + (uint32_t)120U);
   ws[15U] = u14;
-  for (uint32_t i0 = (uint32_t)0U; i0 < (uint32_t)5U; i0++)
-  {
-    for (uint32_t i = (uint32_t)0U; i < (uint32_t)16U; i++)
-    {
+  KRML_MAYBE_FOR5(i0,
+    (uint32_t)0U,
+    (uint32_t)5U,
+    (uint32_t)1U,
+    KRML_MAYBE_FOR16(i,
+      (uint32_t)0U,
+      (uint32_t)16U,
+      (uint32_t)1U,
       uint64_t k_t = Hacl_Impl_SHA2_Generic_k384_512[(uint32_t)16U * i0 + i];
       uint64_t ws_t = ws[i];
       uint64_t a0 = hash[0U];
@@ -476,12 +492,13 @@ static inline void sha384_update1(uint8_t *block, uint64_t *hash)
       hash[4U] = e1;
       hash[5U] = f1;
       hash[6U] = g1;
-      hash[7U] = h12;
-    }
+      hash[7U] = h12;);
     if (i0 < (uint32_t)5U - (uint32_t)1U)
     {
-      for (uint32_t i = (uint32_t)0U; i < (uint32_t)16U; i++)
-      {
+      KRML_MAYBE_FOR16(i,
+        (uint32_t)0U,
+        (uint32_t)16U,
+        (uint32_t)1U,
         uint64_t t16 = ws[i];
         uint64_t t15 = ws[(i + (uint32_t)1U) % (uint32_t)16U];
         uint64_t t7 = ws[(i + (uint32_t)9U) % (uint32_t)16U];
@@ -494,16 +511,15 @@ static inline void sha384_update1(uint8_t *block, uint64_t *hash)
         s0 =
           (t15 << ((uint32_t)64U - (uint32_t)1U) | t15 >> (uint32_t)1U)
           ^ ((t15 << ((uint32_t)64U - (uint32_t)8U) | t15 >> (uint32_t)8U) ^ t15 >> (uint32_t)7U);
-        ws[i] = s1 + t7 + s0 + t16;
-      }
-    }
-  }
-  for (uint32_t i = (uint32_t)0U; i < (uint32_t)8U; i++)
-  {
+        ws[i] = s1 + t7 + s0 + t16;);
+    });
+  KRML_MAYBE_FOR8(i,
+    (uint32_t)0U,
+    (uint32_t)8U,
+    (uint32_t)1U,
     uint64_t *os = hash;
     uint64_t x = hash[i] + hash_old[i];
-    os[i] = x;
-  }
+    os[i] = x;);
 }
 
 void Hacl_SHA2_Scalar32_sha384(uint8_t *dst, uint32_t input_len, uint8_t *input)
@@ -511,12 +527,13 @@ void Hacl_SHA2_Scalar32_sha384(uint8_t *dst, uint32_t input_len, uint8_t *input)
   uint8_t *ib = input;
   uint8_t *rb = dst;
   uint64_t st[8U] = { 0U };
-  for (uint32_t i = (uint32_t)0U; i < (uint32_t)8U; i++)
-  {
+  KRML_MAYBE_FOR8(i,
+    (uint32_t)0U,
+    (uint32_t)8U,
+    (uint32_t)1U,
     uint64_t *os = st;
     uint64_t x = Hacl_Impl_SHA2_Generic_h384[i];
-    os[i] = x;
-  }
+    os[i] = x;);
   uint32_t rem = input_len % (uint32_t)128U;
   FStar_UInt128_uint128 len_ = FStar_UInt128_uint64_to_uint128((uint64_t)input_len);
   uint32_t blocks0 = input_len / (uint32_t)128U;
@@ -565,10 +582,11 @@ void Hacl_SHA2_Scalar32_sha384(uint8_t *dst, uint32_t input_len, uint8_t *input)
   KRML_CHECK_SIZE(sizeof (uint8_t), (uint32_t)1U * (uint32_t)8U * (uint32_t)8U);
   uint8_t hbuf[(uint32_t)1U * (uint32_t)8U * (uint32_t)8U];
   memset(hbuf, 0U, (uint32_t)1U * (uint32_t)8U * (uint32_t)8U * sizeof (uint8_t));
-  for (uint32_t i = (uint32_t)0U; i < (uint32_t)8U; i++)
-  {
-    store64_be(hbuf + i * (uint32_t)8U, st[i]);
-  }
+  KRML_MAYBE_FOR8(i,
+    (uint32_t)0U,
+    (uint32_t)8U,
+    (uint32_t)1U,
+    store64_be(hbuf + i * (uint32_t)8U, st[i]););
   memcpy(rb, hbuf, (uint32_t)48U * sizeof (uint8_t));
 }
 
@@ -610,10 +628,14 @@ static inline void sha512_update1(uint8_t *block, uint64_t *hash)
   ws[14U] = u13;
   uint64_t u14 = load64_be(b + (uint32_t)120U);
   ws[15U] = u14;
-  for (uint32_t i0 = (uint32_t)0U; i0 < (uint32_t)5U; i0++)
-  {
-    for (uint32_t i = (uint32_t)0U; i < (uint32_t)16U; i++)
-    {
+  KRML_MAYBE_FOR5(i0,
+    (uint32_t)0U,
+    (uint32_t)5U,
+    (uint32_t)1U,
+    KRML_MAYBE_FOR16(i,
+      (uint32_t)0U,
+      (uint32_t)16U,
+      (uint32_t)1U,
       uint64_t k_t = Hacl_Impl_SHA2_Generic_k384_512[(uint32_t)16U * i0 + i];
       uint64_t ws_t = ws[i];
       uint64_t a0 = hash[0U];
@@ -658,12 +680,13 @@ static inline void sha512_update1(uint8_t *block, uint64_t *hash)
       hash[4U] = e1;
       hash[5U] = f1;
       hash[6U] = g1;
-      hash[7U] = h12;
-    }
+      hash[7U] = h12;);
     if (i0 < (uint32_t)5U - (uint32_t)1U)
     {
-      for (uint32_t i = (uint32_t)0U; i < (uint32_t)16U; i++)
-      {
+      KRML_MAYBE_FOR16(i,
+        (uint32_t)0U,
+        (uint32_t)16U,
+        (uint32_t)1U,
         uint64_t t16 = ws[i];
         uint64_t t15 = ws[(i + (uint32_t)1U) % (uint32_t)16U];
         uint64_t t7 = ws[(i + (uint32_t)9U) % (uint32_t)16U];
@@ -676,16 +699,15 @@ static inline void sha512_update1(uint8_t *block, uint64_t *hash)
         s0 =
           (t15 << ((uint32_t)64U - (uint32_t)1U) | t15 >> (uint32_t)1U)
           ^ ((t15 << ((uint32_t)64U - (uint32_t)8U) | t15 >> (uint32_t)8U) ^ t15 >> (uint32_t)7U);
-        ws[i] = s1 + t7 + s0 + t16;
-      }
-    }
-  }
-  for (uint32_t i = (uint32_t)0U; i < (uint32_t)8U; i++)
-  {
+        ws[i] = s1 + t7 + s0 + t16;);
+    });
+  KRML_MAYBE_FOR8(i,
+    (uint32_t)0U,
+    (uint32_t)8U,
+    (uint32_t)1U,
     uint64_t *os = hash;
     uint64_t x = hash[i] + hash_old[i];
-    os[i] = x;
-  }
+    os[i] = x;);
 }
 
 void Hacl_SHA2_Scalar32_sha512(uint8_t *dst, uint32_t input_len, uint8_t *input)
@@ -693,12 +715,13 @@ void Hacl_SHA2_Scalar32_sha512(uint8_t *dst, uint32_t input_len, uint8_t *input)
   uint8_t *ib = input;
   uint8_t *rb = dst;
   uint64_t st[8U] = { 0U };
-  for (uint32_t i = (uint32_t)0U; i < (uint32_t)8U; i++)
-  {
+  KRML_MAYBE_FOR8(i,
+    (uint32_t)0U,
+    (uint32_t)8U,
+    (uint32_t)1U,
     uint64_t *os = st;
     uint64_t x = Hacl_Impl_SHA2_Generic_h512[i];
-    os[i] = x;
-  }
+    os[i] = x;);
   uint32_t rem = input_len % (uint32_t)128U;
   FStar_UInt128_uint128 len_ = FStar_UInt128_uint64_to_uint128((uint64_t)input_len);
   uint32_t blocks0 = input_len / (uint32_t)128U;
@@ -747,10 +770,11 @@ void Hacl_SHA2_Scalar32_sha512(uint8_t *dst, uint32_t input_len, uint8_t *input)
   KRML_CHECK_SIZE(sizeof (uint8_t), (uint32_t)1U * (uint32_t)8U * (uint32_t)8U);
   uint8_t hbuf[(uint32_t)1U * (uint32_t)8U * (uint32_t)8U];
   memset(hbuf, 0U, (uint32_t)1U * (uint32_t)8U * (uint32_t)8U * sizeof (uint8_t));
-  for (uint32_t i = (uint32_t)0U; i < (uint32_t)8U; i++)
-  {
-    store64_be(hbuf + i * (uint32_t)8U, st[i]);
-  }
+  KRML_MAYBE_FOR8(i,
+    (uint32_t)0U,
+    (uint32_t)8U,
+    (uint32_t)1U,
+    store64_be(hbuf + i * (uint32_t)8U, st[i]););
   memcpy(rb, hbuf, (uint32_t)64U * sizeof (uint8_t));
 }
 

--- a/dist/gcc-compatible/Hacl_SHA2_Vec128.c
+++ b/dist/gcc-compatible/Hacl_SHA2_Vec128.c
@@ -180,10 +180,14 @@ sha224_update4(Hacl_Impl_SHA2_Types_uint8_4p block, Lib_IntVector_Intrinsics_vec
   ws[13U] = ws13;
   ws[14U] = ws14;
   ws[15U] = ws15;
-  for (uint32_t i0 = (uint32_t)0U; i0 < (uint32_t)4U; i0++)
-  {
-    for (uint32_t i = (uint32_t)0U; i < (uint32_t)16U; i++)
-    {
+  KRML_MAYBE_FOR4(i0,
+    (uint32_t)0U,
+    (uint32_t)4U,
+    (uint32_t)1U,
+    KRML_MAYBE_FOR16(i,
+      (uint32_t)0U,
+      (uint32_t)16U,
+      (uint32_t)1U,
       uint32_t k_t = Hacl_Impl_SHA2_Generic_k224_256[(uint32_t)16U * i0 + i];
       Lib_IntVector_Intrinsics_vec128 ws_t = ws[i];
       Lib_IntVector_Intrinsics_vec128 a0 = hash[0U];
@@ -232,12 +236,13 @@ sha224_update4(Hacl_Impl_SHA2_Types_uint8_4p block, Lib_IntVector_Intrinsics_vec
       hash[4U] = e1;
       hash[5U] = f1;
       hash[6U] = g1;
-      hash[7U] = h12;
-    }
+      hash[7U] = h12;);
     if (i0 < (uint32_t)4U - (uint32_t)1U)
     {
-      for (uint32_t i = (uint32_t)0U; i < (uint32_t)16U; i++)
-      {
+      KRML_MAYBE_FOR16(i,
+        (uint32_t)0U,
+        (uint32_t)16U,
+        (uint32_t)1U,
         Lib_IntVector_Intrinsics_vec128 t16 = ws[i];
         Lib_IntVector_Intrinsics_vec128 t15 = ws[(i + (uint32_t)1U) % (uint32_t)16U];
         Lib_IntVector_Intrinsics_vec128 t7 = ws[(i + (uint32_t)9U) % (uint32_t)16U];
@@ -260,17 +265,16 @@ sha224_update4(Hacl_Impl_SHA2_Types_uint8_4p block, Lib_IntVector_Intrinsics_vec
           Lib_IntVector_Intrinsics_vec128_add32(Lib_IntVector_Intrinsics_vec128_add32(Lib_IntVector_Intrinsics_vec128_add32(s1,
                 t7),
               s0),
-            t16);
-      }
-    }
-  }
-  for (uint32_t i = (uint32_t)0U; i < (uint32_t)8U; i++)
-  {
+            t16););
+    });
+  KRML_MAYBE_FOR8(i,
+    (uint32_t)0U,
+    (uint32_t)8U,
+    (uint32_t)1U,
     Lib_IntVector_Intrinsics_vec128 *os = hash;
     Lib_IntVector_Intrinsics_vec128
     x = Lib_IntVector_Intrinsics_vec128_add32(hash[i], hash_old[i]);
-    os[i] = x;
-  }
+    os[i] = x;);
 }
 
 void
@@ -291,13 +295,14 @@ Hacl_SHA2_Vec128_sha224_4(
   Hacl_Impl_SHA2_Types_uint8_4p
   rb = { .fst = dst0, .snd = { .fst = dst1, .snd = { .fst = dst2, .snd = dst3 } } };
   Lib_IntVector_Intrinsics_vec128 st[8U] = { 0U };
-  for (uint32_t i = (uint32_t)0U; i < (uint32_t)8U; i++)
-  {
+  KRML_MAYBE_FOR8(i,
+    (uint32_t)0U,
+    (uint32_t)8U,
+    (uint32_t)1U,
     Lib_IntVector_Intrinsics_vec128 *os = st;
     uint32_t hi = Hacl_Impl_SHA2_Generic_h224[i];
     Lib_IntVector_Intrinsics_vec128 x = Lib_IntVector_Intrinsics_vec128_load32(hi);
-    os[i] = x;
-  }
+    os[i] = x;);
   uint32_t rem = input_len % (uint32_t)64U;
   uint64_t len_ = (uint64_t)input_len;
   uint32_t blocks0 = input_len / (uint32_t)64U;
@@ -459,10 +464,11 @@ Hacl_SHA2_Vec128_sha224_4(
   st[5U] = st6_;
   st[6U] = st3_;
   st[7U] = st7_;
-  for (uint32_t i = (uint32_t)0U; i < (uint32_t)8U; i++)
-  {
-    Lib_IntVector_Intrinsics_vec128_store32_be(hbuf + i * (uint32_t)16U, st[i]);
-  }
+  KRML_MAYBE_FOR8(i,
+    (uint32_t)0U,
+    (uint32_t)8U,
+    (uint32_t)1U,
+    Lib_IntVector_Intrinsics_vec128_store32_be(hbuf + i * (uint32_t)16U, st[i]););
   uint8_t *b31 = rb.snd.snd.snd;
   uint8_t *b2 = rb.snd.snd.fst;
   uint8_t *b1 = rb.snd.fst;
@@ -627,10 +633,14 @@ sha256_update4(Hacl_Impl_SHA2_Types_uint8_4p block, Lib_IntVector_Intrinsics_vec
   ws[13U] = ws13;
   ws[14U] = ws14;
   ws[15U] = ws15;
-  for (uint32_t i0 = (uint32_t)0U; i0 < (uint32_t)4U; i0++)
-  {
-    for (uint32_t i = (uint32_t)0U; i < (uint32_t)16U; i++)
-    {
+  KRML_MAYBE_FOR4(i0,
+    (uint32_t)0U,
+    (uint32_t)4U,
+    (uint32_t)1U,
+    KRML_MAYBE_FOR16(i,
+      (uint32_t)0U,
+      (uint32_t)16U,
+      (uint32_t)1U,
       uint32_t k_t = Hacl_Impl_SHA2_Generic_k224_256[(uint32_t)16U * i0 + i];
       Lib_IntVector_Intrinsics_vec128 ws_t = ws[i];
       Lib_IntVector_Intrinsics_vec128 a0 = hash[0U];
@@ -679,12 +689,13 @@ sha256_update4(Hacl_Impl_SHA2_Types_uint8_4p block, Lib_IntVector_Intrinsics_vec
       hash[4U] = e1;
       hash[5U] = f1;
       hash[6U] = g1;
-      hash[7U] = h12;
-    }
+      hash[7U] = h12;);
     if (i0 < (uint32_t)4U - (uint32_t)1U)
     {
-      for (uint32_t i = (uint32_t)0U; i < (uint32_t)16U; i++)
-      {
+      KRML_MAYBE_FOR16(i,
+        (uint32_t)0U,
+        (uint32_t)16U,
+        (uint32_t)1U,
         Lib_IntVector_Intrinsics_vec128 t16 = ws[i];
         Lib_IntVector_Intrinsics_vec128 t15 = ws[(i + (uint32_t)1U) % (uint32_t)16U];
         Lib_IntVector_Intrinsics_vec128 t7 = ws[(i + (uint32_t)9U) % (uint32_t)16U];
@@ -707,17 +718,16 @@ sha256_update4(Hacl_Impl_SHA2_Types_uint8_4p block, Lib_IntVector_Intrinsics_vec
           Lib_IntVector_Intrinsics_vec128_add32(Lib_IntVector_Intrinsics_vec128_add32(Lib_IntVector_Intrinsics_vec128_add32(s1,
                 t7),
               s0),
-            t16);
-      }
-    }
-  }
-  for (uint32_t i = (uint32_t)0U; i < (uint32_t)8U; i++)
-  {
+            t16););
+    });
+  KRML_MAYBE_FOR8(i,
+    (uint32_t)0U,
+    (uint32_t)8U,
+    (uint32_t)1U,
     Lib_IntVector_Intrinsics_vec128 *os = hash;
     Lib_IntVector_Intrinsics_vec128
     x = Lib_IntVector_Intrinsics_vec128_add32(hash[i], hash_old[i]);
-    os[i] = x;
-  }
+    os[i] = x;);
 }
 
 void
@@ -738,13 +748,14 @@ Hacl_SHA2_Vec128_sha256_4(
   Hacl_Impl_SHA2_Types_uint8_4p
   rb = { .fst = dst0, .snd = { .fst = dst1, .snd = { .fst = dst2, .snd = dst3 } } };
   Lib_IntVector_Intrinsics_vec128 st[8U] = { 0U };
-  for (uint32_t i = (uint32_t)0U; i < (uint32_t)8U; i++)
-  {
+  KRML_MAYBE_FOR8(i,
+    (uint32_t)0U,
+    (uint32_t)8U,
+    (uint32_t)1U,
     Lib_IntVector_Intrinsics_vec128 *os = st;
     uint32_t hi = Hacl_Impl_SHA2_Generic_h256[i];
     Lib_IntVector_Intrinsics_vec128 x = Lib_IntVector_Intrinsics_vec128_load32(hi);
-    os[i] = x;
-  }
+    os[i] = x;);
   uint32_t rem = input_len % (uint32_t)64U;
   uint64_t len_ = (uint64_t)input_len;
   uint32_t blocks0 = input_len / (uint32_t)64U;
@@ -906,10 +917,11 @@ Hacl_SHA2_Vec128_sha256_4(
   st[5U] = st6_;
   st[6U] = st3_;
   st[7U] = st7_;
-  for (uint32_t i = (uint32_t)0U; i < (uint32_t)8U; i++)
-  {
-    Lib_IntVector_Intrinsics_vec128_store32_be(hbuf + i * (uint32_t)16U, st[i]);
-  }
+  KRML_MAYBE_FOR8(i,
+    (uint32_t)0U,
+    (uint32_t)8U,
+    (uint32_t)1U,
+    Lib_IntVector_Intrinsics_vec128_store32_be(hbuf + i * (uint32_t)16U, st[i]););
   uint8_t *b31 = rb.snd.snd.snd;
   uint8_t *b2 = rb.snd.snd.fst;
   uint8_t *b1 = rb.snd.fst;

--- a/dist/gcc-compatible/Hacl_SHA2_Vec256.c
+++ b/dist/gcc-compatible/Hacl_SHA2_Vec256.c
@@ -264,10 +264,14 @@ sha224_update8(Hacl_Impl_SHA2_Types_uint8_8p block, Lib_IntVector_Intrinsics_vec
   ws[13U] = ws13;
   ws[14U] = ws14;
   ws[15U] = ws15;
-  for (uint32_t i0 = (uint32_t)0U; i0 < (uint32_t)4U; i0++)
-  {
-    for (uint32_t i = (uint32_t)0U; i < (uint32_t)16U; i++)
-    {
+  KRML_MAYBE_FOR4(i0,
+    (uint32_t)0U,
+    (uint32_t)4U,
+    (uint32_t)1U,
+    KRML_MAYBE_FOR16(i,
+      (uint32_t)0U,
+      (uint32_t)16U,
+      (uint32_t)1U,
       uint32_t k_t = Hacl_Impl_SHA2_Generic_k224_256[(uint32_t)16U * i0 + i];
       Lib_IntVector_Intrinsics_vec256 ws_t = ws[i];
       Lib_IntVector_Intrinsics_vec256 a0 = hash[0U];
@@ -316,12 +320,13 @@ sha224_update8(Hacl_Impl_SHA2_Types_uint8_8p block, Lib_IntVector_Intrinsics_vec
       hash[4U] = e1;
       hash[5U] = f1;
       hash[6U] = g1;
-      hash[7U] = h12;
-    }
+      hash[7U] = h12;);
     if (i0 < (uint32_t)4U - (uint32_t)1U)
     {
-      for (uint32_t i = (uint32_t)0U; i < (uint32_t)16U; i++)
-      {
+      KRML_MAYBE_FOR16(i,
+        (uint32_t)0U,
+        (uint32_t)16U,
+        (uint32_t)1U,
         Lib_IntVector_Intrinsics_vec256 t16 = ws[i];
         Lib_IntVector_Intrinsics_vec256 t15 = ws[(i + (uint32_t)1U) % (uint32_t)16U];
         Lib_IntVector_Intrinsics_vec256 t7 = ws[(i + (uint32_t)9U) % (uint32_t)16U];
@@ -344,17 +349,16 @@ sha224_update8(Hacl_Impl_SHA2_Types_uint8_8p block, Lib_IntVector_Intrinsics_vec
           Lib_IntVector_Intrinsics_vec256_add32(Lib_IntVector_Intrinsics_vec256_add32(Lib_IntVector_Intrinsics_vec256_add32(s1,
                 t7),
               s0),
-            t16);
-      }
-    }
-  }
-  for (uint32_t i = (uint32_t)0U; i < (uint32_t)8U; i++)
-  {
+            t16););
+    });
+  KRML_MAYBE_FOR8(i,
+    (uint32_t)0U,
+    (uint32_t)8U,
+    (uint32_t)1U,
     Lib_IntVector_Intrinsics_vec256 *os = hash;
     Lib_IntVector_Intrinsics_vec256
     x = Lib_IntVector_Intrinsics_vec256_add32(hash[i], hash_old[i]);
-    os[i] = x;
-  }
+    os[i] = x;);
 }
 
 void
@@ -412,13 +416,14 @@ Hacl_SHA2_Vec256_sha224_8(
       }
     };
   Lib_IntVector_Intrinsics_vec256 st[8U] = { 0U };
-  for (uint32_t i = (uint32_t)0U; i < (uint32_t)8U; i++)
-  {
+  KRML_MAYBE_FOR8(i,
+    (uint32_t)0U,
+    (uint32_t)8U,
+    (uint32_t)1U,
     Lib_IntVector_Intrinsics_vec256 *os = st;
     uint32_t hi = Hacl_Impl_SHA2_Generic_h224[i];
     Lib_IntVector_Intrinsics_vec256 x = Lib_IntVector_Intrinsics_vec256_load32(hi);
-    os[i] = x;
-  }
+    os[i] = x;);
   uint32_t rem = input_len % (uint32_t)64U;
   uint64_t len_ = (uint64_t)input_len;
   uint32_t blocks0 = input_len / (uint32_t)64U;
@@ -724,10 +729,11 @@ Hacl_SHA2_Vec256_sha224_8(
   st[5U] = st5_;
   st[6U] = st6_;
   st[7U] = st7_;
-  for (uint32_t i = (uint32_t)0U; i < (uint32_t)8U; i++)
-  {
-    Lib_IntVector_Intrinsics_vec256_store32_be(hbuf + i * (uint32_t)32U, st[i]);
-  }
+  KRML_MAYBE_FOR8(i,
+    (uint32_t)0U,
+    (uint32_t)8U,
+    (uint32_t)1U,
+    Lib_IntVector_Intrinsics_vec256_store32_be(hbuf + i * (uint32_t)32U, st[i]););
   uint8_t *b71 = rb.snd.snd.snd.snd.snd.snd.snd;
   uint8_t *b6 = rb.snd.snd.snd.snd.snd.snd.fst;
   uint8_t *b5 = rb.snd.snd.snd.snd.snd.fst;
@@ -984,10 +990,14 @@ sha256_update8(Hacl_Impl_SHA2_Types_uint8_8p block, Lib_IntVector_Intrinsics_vec
   ws[13U] = ws13;
   ws[14U] = ws14;
   ws[15U] = ws15;
-  for (uint32_t i0 = (uint32_t)0U; i0 < (uint32_t)4U; i0++)
-  {
-    for (uint32_t i = (uint32_t)0U; i < (uint32_t)16U; i++)
-    {
+  KRML_MAYBE_FOR4(i0,
+    (uint32_t)0U,
+    (uint32_t)4U,
+    (uint32_t)1U,
+    KRML_MAYBE_FOR16(i,
+      (uint32_t)0U,
+      (uint32_t)16U,
+      (uint32_t)1U,
       uint32_t k_t = Hacl_Impl_SHA2_Generic_k224_256[(uint32_t)16U * i0 + i];
       Lib_IntVector_Intrinsics_vec256 ws_t = ws[i];
       Lib_IntVector_Intrinsics_vec256 a0 = hash[0U];
@@ -1036,12 +1046,13 @@ sha256_update8(Hacl_Impl_SHA2_Types_uint8_8p block, Lib_IntVector_Intrinsics_vec
       hash[4U] = e1;
       hash[5U] = f1;
       hash[6U] = g1;
-      hash[7U] = h12;
-    }
+      hash[7U] = h12;);
     if (i0 < (uint32_t)4U - (uint32_t)1U)
     {
-      for (uint32_t i = (uint32_t)0U; i < (uint32_t)16U; i++)
-      {
+      KRML_MAYBE_FOR16(i,
+        (uint32_t)0U,
+        (uint32_t)16U,
+        (uint32_t)1U,
         Lib_IntVector_Intrinsics_vec256 t16 = ws[i];
         Lib_IntVector_Intrinsics_vec256 t15 = ws[(i + (uint32_t)1U) % (uint32_t)16U];
         Lib_IntVector_Intrinsics_vec256 t7 = ws[(i + (uint32_t)9U) % (uint32_t)16U];
@@ -1064,17 +1075,16 @@ sha256_update8(Hacl_Impl_SHA2_Types_uint8_8p block, Lib_IntVector_Intrinsics_vec
           Lib_IntVector_Intrinsics_vec256_add32(Lib_IntVector_Intrinsics_vec256_add32(Lib_IntVector_Intrinsics_vec256_add32(s1,
                 t7),
               s0),
-            t16);
-      }
-    }
-  }
-  for (uint32_t i = (uint32_t)0U; i < (uint32_t)8U; i++)
-  {
+            t16););
+    });
+  KRML_MAYBE_FOR8(i,
+    (uint32_t)0U,
+    (uint32_t)8U,
+    (uint32_t)1U,
     Lib_IntVector_Intrinsics_vec256 *os = hash;
     Lib_IntVector_Intrinsics_vec256
     x = Lib_IntVector_Intrinsics_vec256_add32(hash[i], hash_old[i]);
-    os[i] = x;
-  }
+    os[i] = x;);
 }
 
 void
@@ -1132,13 +1142,14 @@ Hacl_SHA2_Vec256_sha256_8(
       }
     };
   Lib_IntVector_Intrinsics_vec256 st[8U] = { 0U };
-  for (uint32_t i = (uint32_t)0U; i < (uint32_t)8U; i++)
-  {
+  KRML_MAYBE_FOR8(i,
+    (uint32_t)0U,
+    (uint32_t)8U,
+    (uint32_t)1U,
     Lib_IntVector_Intrinsics_vec256 *os = st;
     uint32_t hi = Hacl_Impl_SHA2_Generic_h256[i];
     Lib_IntVector_Intrinsics_vec256 x = Lib_IntVector_Intrinsics_vec256_load32(hi);
-    os[i] = x;
-  }
+    os[i] = x;);
   uint32_t rem = input_len % (uint32_t)64U;
   uint64_t len_ = (uint64_t)input_len;
   uint32_t blocks0 = input_len / (uint32_t)64U;
@@ -1444,10 +1455,11 @@ Hacl_SHA2_Vec256_sha256_8(
   st[5U] = st5_;
   st[6U] = st6_;
   st[7U] = st7_;
-  for (uint32_t i = (uint32_t)0U; i < (uint32_t)8U; i++)
-  {
-    Lib_IntVector_Intrinsics_vec256_store32_be(hbuf + i * (uint32_t)32U, st[i]);
-  }
+  KRML_MAYBE_FOR8(i,
+    (uint32_t)0U,
+    (uint32_t)8U,
+    (uint32_t)1U,
+    Lib_IntVector_Intrinsics_vec256_store32_be(hbuf + i * (uint32_t)32U, st[i]););
   uint8_t *b71 = rb.snd.snd.snd.snd.snd.snd.snd;
   uint8_t *b6 = rb.snd.snd.snd.snd.snd.snd.fst;
   uint8_t *b5 = rb.snd.snd.snd.snd.snd.fst;
@@ -1604,10 +1616,14 @@ sha384_update4(Hacl_Impl_SHA2_Types_uint8_4p block, Lib_IntVector_Intrinsics_vec
   ws[13U] = ws13;
   ws[14U] = ws14;
   ws[15U] = ws15;
-  for (uint32_t i0 = (uint32_t)0U; i0 < (uint32_t)5U; i0++)
-  {
-    for (uint32_t i = (uint32_t)0U; i < (uint32_t)16U; i++)
-    {
+  KRML_MAYBE_FOR5(i0,
+    (uint32_t)0U,
+    (uint32_t)5U,
+    (uint32_t)1U,
+    KRML_MAYBE_FOR16(i,
+      (uint32_t)0U,
+      (uint32_t)16U,
+      (uint32_t)1U,
       uint64_t k_t = Hacl_Impl_SHA2_Generic_k384_512[(uint32_t)16U * i0 + i];
       Lib_IntVector_Intrinsics_vec256 ws_t = ws[i];
       Lib_IntVector_Intrinsics_vec256 a0 = hash[0U];
@@ -1656,12 +1672,13 @@ sha384_update4(Hacl_Impl_SHA2_Types_uint8_4p block, Lib_IntVector_Intrinsics_vec
       hash[4U] = e1;
       hash[5U] = f1;
       hash[6U] = g1;
-      hash[7U] = h12;
-    }
+      hash[7U] = h12;);
     if (i0 < (uint32_t)5U - (uint32_t)1U)
     {
-      for (uint32_t i = (uint32_t)0U; i < (uint32_t)16U; i++)
-      {
+      KRML_MAYBE_FOR16(i,
+        (uint32_t)0U,
+        (uint32_t)16U,
+        (uint32_t)1U,
         Lib_IntVector_Intrinsics_vec256 t16 = ws[i];
         Lib_IntVector_Intrinsics_vec256 t15 = ws[(i + (uint32_t)1U) % (uint32_t)16U];
         Lib_IntVector_Intrinsics_vec256 t7 = ws[(i + (uint32_t)9U) % (uint32_t)16U];
@@ -1684,17 +1701,16 @@ sha384_update4(Hacl_Impl_SHA2_Types_uint8_4p block, Lib_IntVector_Intrinsics_vec
           Lib_IntVector_Intrinsics_vec256_add64(Lib_IntVector_Intrinsics_vec256_add64(Lib_IntVector_Intrinsics_vec256_add64(s1,
                 t7),
               s0),
-            t16);
-      }
-    }
-  }
-  for (uint32_t i = (uint32_t)0U; i < (uint32_t)8U; i++)
-  {
+            t16););
+    });
+  KRML_MAYBE_FOR8(i,
+    (uint32_t)0U,
+    (uint32_t)8U,
+    (uint32_t)1U,
     Lib_IntVector_Intrinsics_vec256 *os = hash;
     Lib_IntVector_Intrinsics_vec256
     x = Lib_IntVector_Intrinsics_vec256_add64(hash[i], hash_old[i]);
-    os[i] = x;
-  }
+    os[i] = x;);
 }
 
 void
@@ -1715,13 +1731,14 @@ Hacl_SHA2_Vec256_sha384_4(
   Hacl_Impl_SHA2_Types_uint8_4p
   rb = { .fst = dst0, .snd = { .fst = dst1, .snd = { .fst = dst2, .snd = dst3 } } };
   Lib_IntVector_Intrinsics_vec256 st[8U] = { 0U };
-  for (uint32_t i = (uint32_t)0U; i < (uint32_t)8U; i++)
-  {
+  KRML_MAYBE_FOR8(i,
+    (uint32_t)0U,
+    (uint32_t)8U,
+    (uint32_t)1U,
     Lib_IntVector_Intrinsics_vec256 *os = st;
     uint64_t hi = Hacl_Impl_SHA2_Generic_h384[i];
     Lib_IntVector_Intrinsics_vec256 x = Lib_IntVector_Intrinsics_vec256_load64(hi);
-    os[i] = x;
-  }
+    os[i] = x;);
   uint32_t rem = input_len % (uint32_t)128U;
   FStar_UInt128_uint128 len_ = FStar_UInt128_uint64_to_uint128((uint64_t)input_len);
   uint32_t blocks0 = input_len / (uint32_t)128U;
@@ -1875,10 +1892,11 @@ Hacl_SHA2_Vec256_sha384_4(
   st[5U] = st6_;
   st[6U] = st3_;
   st[7U] = st7_;
-  for (uint32_t i = (uint32_t)0U; i < (uint32_t)8U; i++)
-  {
-    Lib_IntVector_Intrinsics_vec256_store64_be(hbuf + i * (uint32_t)32U, st[i]);
-  }
+  KRML_MAYBE_FOR8(i,
+    (uint32_t)0U,
+    (uint32_t)8U,
+    (uint32_t)1U,
+    Lib_IntVector_Intrinsics_vec256_store64_be(hbuf + i * (uint32_t)32U, st[i]););
   uint8_t *b31 = rb.snd.snd.snd;
   uint8_t *b2 = rb.snd.snd.fst;
   uint8_t *b1 = rb.snd.fst;
@@ -2027,10 +2045,14 @@ sha512_update4(Hacl_Impl_SHA2_Types_uint8_4p block, Lib_IntVector_Intrinsics_vec
   ws[13U] = ws13;
   ws[14U] = ws14;
   ws[15U] = ws15;
-  for (uint32_t i0 = (uint32_t)0U; i0 < (uint32_t)5U; i0++)
-  {
-    for (uint32_t i = (uint32_t)0U; i < (uint32_t)16U; i++)
-    {
+  KRML_MAYBE_FOR5(i0,
+    (uint32_t)0U,
+    (uint32_t)5U,
+    (uint32_t)1U,
+    KRML_MAYBE_FOR16(i,
+      (uint32_t)0U,
+      (uint32_t)16U,
+      (uint32_t)1U,
       uint64_t k_t = Hacl_Impl_SHA2_Generic_k384_512[(uint32_t)16U * i0 + i];
       Lib_IntVector_Intrinsics_vec256 ws_t = ws[i];
       Lib_IntVector_Intrinsics_vec256 a0 = hash[0U];
@@ -2079,12 +2101,13 @@ sha512_update4(Hacl_Impl_SHA2_Types_uint8_4p block, Lib_IntVector_Intrinsics_vec
       hash[4U] = e1;
       hash[5U] = f1;
       hash[6U] = g1;
-      hash[7U] = h12;
-    }
+      hash[7U] = h12;);
     if (i0 < (uint32_t)5U - (uint32_t)1U)
     {
-      for (uint32_t i = (uint32_t)0U; i < (uint32_t)16U; i++)
-      {
+      KRML_MAYBE_FOR16(i,
+        (uint32_t)0U,
+        (uint32_t)16U,
+        (uint32_t)1U,
         Lib_IntVector_Intrinsics_vec256 t16 = ws[i];
         Lib_IntVector_Intrinsics_vec256 t15 = ws[(i + (uint32_t)1U) % (uint32_t)16U];
         Lib_IntVector_Intrinsics_vec256 t7 = ws[(i + (uint32_t)9U) % (uint32_t)16U];
@@ -2107,17 +2130,16 @@ sha512_update4(Hacl_Impl_SHA2_Types_uint8_4p block, Lib_IntVector_Intrinsics_vec
           Lib_IntVector_Intrinsics_vec256_add64(Lib_IntVector_Intrinsics_vec256_add64(Lib_IntVector_Intrinsics_vec256_add64(s1,
                 t7),
               s0),
-            t16);
-      }
-    }
-  }
-  for (uint32_t i = (uint32_t)0U; i < (uint32_t)8U; i++)
-  {
+            t16););
+    });
+  KRML_MAYBE_FOR8(i,
+    (uint32_t)0U,
+    (uint32_t)8U,
+    (uint32_t)1U,
     Lib_IntVector_Intrinsics_vec256 *os = hash;
     Lib_IntVector_Intrinsics_vec256
     x = Lib_IntVector_Intrinsics_vec256_add64(hash[i], hash_old[i]);
-    os[i] = x;
-  }
+    os[i] = x;);
 }
 
 void
@@ -2138,13 +2160,14 @@ Hacl_SHA2_Vec256_sha512_4(
   Hacl_Impl_SHA2_Types_uint8_4p
   rb = { .fst = dst0, .snd = { .fst = dst1, .snd = { .fst = dst2, .snd = dst3 } } };
   Lib_IntVector_Intrinsics_vec256 st[8U] = { 0U };
-  for (uint32_t i = (uint32_t)0U; i < (uint32_t)8U; i++)
-  {
+  KRML_MAYBE_FOR8(i,
+    (uint32_t)0U,
+    (uint32_t)8U,
+    (uint32_t)1U,
     Lib_IntVector_Intrinsics_vec256 *os = st;
     uint64_t hi = Hacl_Impl_SHA2_Generic_h512[i];
     Lib_IntVector_Intrinsics_vec256 x = Lib_IntVector_Intrinsics_vec256_load64(hi);
-    os[i] = x;
-  }
+    os[i] = x;);
   uint32_t rem = input_len % (uint32_t)128U;
   FStar_UInt128_uint128 len_ = FStar_UInt128_uint64_to_uint128((uint64_t)input_len);
   uint32_t blocks0 = input_len / (uint32_t)128U;
@@ -2298,10 +2321,11 @@ Hacl_SHA2_Vec256_sha512_4(
   st[5U] = st6_;
   st[6U] = st3_;
   st[7U] = st7_;
-  for (uint32_t i = (uint32_t)0U; i < (uint32_t)8U; i++)
-  {
-    Lib_IntVector_Intrinsics_vec256_store64_be(hbuf + i * (uint32_t)32U, st[i]);
-  }
+  KRML_MAYBE_FOR8(i,
+    (uint32_t)0U,
+    (uint32_t)8U,
+    (uint32_t)1U,
+    Lib_IntVector_Intrinsics_vec256_store64_be(hbuf + i * (uint32_t)32U, st[i]););
   uint8_t *b31 = rb.snd.snd.snd;
   uint8_t *b2 = rb.snd.snd.fst;
   uint8_t *b1 = rb.snd.fst;

--- a/dist/gcc-compatible/Hacl_SHA3.c
+++ b/dist/gcc-compatible/Hacl_SHA3.c
@@ -70,26 +70,29 @@ void Hacl_Impl_SHA3_state_permute(uint64_t *s)
   for (uint32_t i0 = (uint32_t)0U; i0 < (uint32_t)24U; i0++)
   {
     uint64_t b[5U] = { 0U };
-    for (uint32_t i = (uint32_t)0U; i < (uint32_t)5U; i++)
-    {
+    KRML_MAYBE_FOR5(i,
+      (uint32_t)0U,
+      (uint32_t)5U,
+      (uint32_t)1U,
       b[i] =
         s[i
         + (uint32_t)0U]
         ^
           (s[i
           + (uint32_t)5U]
-          ^ (s[i + (uint32_t)10U] ^ (s[i + (uint32_t)15U] ^ s[i + (uint32_t)20U])));
-    }
-    for (uint32_t i1 = (uint32_t)0U; i1 < (uint32_t)5U; i1++)
-    {
+          ^ (s[i + (uint32_t)10U] ^ (s[i + (uint32_t)15U] ^ s[i + (uint32_t)20U]))););
+    KRML_MAYBE_FOR5(i1,
+      (uint32_t)0U,
+      (uint32_t)5U,
+      (uint32_t)1U,
       uint64_t uu____0 = b[(i1 + (uint32_t)4U) % (uint32_t)5U];
       uint64_t
       _D = uu____0 ^ Hacl_Impl_SHA3_rotl(b[(i1 + (uint32_t)1U) % (uint32_t)5U], (uint32_t)1U);
-      for (uint32_t i = (uint32_t)0U; i < (uint32_t)5U; i++)
-      {
-        s[i1 + (uint32_t)5U * i] = s[i1 + (uint32_t)5U * i] ^ _D;
-      }
-    }
+      KRML_MAYBE_FOR5(i,
+        (uint32_t)0U,
+        (uint32_t)5U,
+        (uint32_t)1U,
+        s[i1 + (uint32_t)5U * i] = s[i1 + (uint32_t)5U * i] ^ _D;););
     Lib_Memzero0_memzero(b, (uint32_t)5U * sizeof (b[0U]));
     uint64_t x = s[1U];
     uint64_t b0 = x;
@@ -104,10 +107,14 @@ void Hacl_Impl_SHA3_state_permute(uint64_t *s)
     Lib_Memzero0_memzero(&b0, (uint32_t)1U * sizeof ((&b0)[0U]));
     uint64_t b1[25U] = { 0U };
     memcpy(b1, s, (uint32_t)25U * sizeof (uint64_t));
-    for (uint32_t i1 = (uint32_t)0U; i1 < (uint32_t)5U; i1++)
-    {
-      for (uint32_t i = (uint32_t)0U; i < (uint32_t)5U; i++)
-      {
+    KRML_MAYBE_FOR5(i1,
+      (uint32_t)0U,
+      (uint32_t)5U,
+      (uint32_t)1U,
+      KRML_MAYBE_FOR5(i,
+        (uint32_t)0U,
+        (uint32_t)5U,
+        (uint32_t)1U,
         s[i + (uint32_t)5U * i1] =
           b1[i
           + (uint32_t)5U * i1]
@@ -115,9 +122,7 @@ void Hacl_Impl_SHA3_state_permute(uint64_t *s)
             (~b1[(i + (uint32_t)1U)
             % (uint32_t)5U
             + (uint32_t)5U * i1]
-            & b1[(i + (uint32_t)2U) % (uint32_t)5U + (uint32_t)5U * i1]);
-      }
-    }
+            & b1[(i + (uint32_t)2U) % (uint32_t)5U + (uint32_t)5U * i1]);););
     Lib_Memzero0_memzero(b1, (uint32_t)25U * sizeof (b1[0U]));
     uint64_t c = Hacl_Impl_SHA3_keccak_rndc[i0];
     s[0U] = s[0U] ^ c;

--- a/dist/gcc-compatible/Hacl_Salsa20.c
+++ b/dist/gcc-compatible/Hacl_Salsa20.c
@@ -82,12 +82,13 @@ static inline void salsa20_core(uint32_t *k, uint32_t *ctx, uint32_t ctr)
   uint32_t ctr_u32 = ctr;
   k[8U] = k[8U] + ctr_u32;
   rounds(k);
-  for (uint32_t i = (uint32_t)0U; i < (uint32_t)16U; i++)
-  {
+  KRML_MAYBE_FOR16(i,
+    (uint32_t)0U,
+    (uint32_t)16U,
+    (uint32_t)1U,
     uint32_t *os = k;
     uint32_t x = k[i] + ctx[i];
-    os[i] = x;
-  }
+    os[i] = x;);
   k[8U] = k[8U] + ctr_u32;
 }
 
@@ -97,24 +98,26 @@ static inline void salsa20_key_block0(uint8_t *out, uint8_t *key, uint8_t *n)
   uint32_t k[16U] = { 0U };
   uint32_t k32[8U] = { 0U };
   uint32_t n32[2U] = { 0U };
-  for (uint32_t i = (uint32_t)0U; i < (uint32_t)8U; i++)
-  {
+  KRML_MAYBE_FOR8(i,
+    (uint32_t)0U,
+    (uint32_t)8U,
+    (uint32_t)1U,
     uint32_t *os = k32;
     uint8_t *bj = key + i * (uint32_t)4U;
     uint32_t u = load32_le(bj);
     uint32_t r = u;
     uint32_t x = r;
-    os[i] = x;
-  }
-  for (uint32_t i = (uint32_t)0U; i < (uint32_t)2U; i++)
-  {
+    os[i] = x;);
+  KRML_MAYBE_FOR2(i,
+    (uint32_t)0U,
+    (uint32_t)2U,
+    (uint32_t)1U,
     uint32_t *os = n32;
     uint8_t *bj = n + i * (uint32_t)4U;
     uint32_t u = load32_le(bj);
     uint32_t r = u;
     uint32_t x = r;
-    os[i] = x;
-  }
+    os[i] = x;);
   ctx[0U] = (uint32_t)0x61707865U;
   uint32_t *k0 = k32;
   uint32_t *k1 = k32 + (uint32_t)4U;
@@ -127,10 +130,11 @@ static inline void salsa20_key_block0(uint8_t *out, uint8_t *key, uint8_t *n)
   memcpy(ctx + (uint32_t)11U, k1, (uint32_t)4U * sizeof (uint32_t));
   ctx[15U] = (uint32_t)0x6b206574U;
   salsa20_core(k, ctx, (uint32_t)0U);
-  for (uint32_t i = (uint32_t)0U; i < (uint32_t)16U; i++)
-  {
-    store32_le(out + i * (uint32_t)4U, k[i]);
-  }
+  KRML_MAYBE_FOR16(i,
+    (uint32_t)0U,
+    (uint32_t)16U,
+    (uint32_t)1U,
+    store32_le(out + i * (uint32_t)4U, k[i]););
 }
 
 static inline void
@@ -146,24 +150,26 @@ salsa20_encrypt(
   uint32_t ctx[16U] = { 0U };
   uint32_t k32[8U] = { 0U };
   uint32_t n32[2U] = { 0U };
-  for (uint32_t i = (uint32_t)0U; i < (uint32_t)8U; i++)
-  {
+  KRML_MAYBE_FOR8(i,
+    (uint32_t)0U,
+    (uint32_t)8U,
+    (uint32_t)1U,
     uint32_t *os = k32;
     uint8_t *bj = key + i * (uint32_t)4U;
     uint32_t u = load32_le(bj);
     uint32_t r = u;
     uint32_t x = r;
-    os[i] = x;
-  }
-  for (uint32_t i = (uint32_t)0U; i < (uint32_t)2U; i++)
-  {
+    os[i] = x;);
+  KRML_MAYBE_FOR2(i,
+    (uint32_t)0U,
+    (uint32_t)2U,
+    (uint32_t)1U,
     uint32_t *os = n32;
     uint8_t *bj = n + i * (uint32_t)4U;
     uint32_t u = load32_le(bj);
     uint32_t r = u;
     uint32_t x = r;
-    os[i] = x;
-  }
+    os[i] = x;);
   ctx[0U] = (uint32_t)0x61707865U;
   uint32_t *k0 = k32;
   uint32_t *k10 = k32 + (uint32_t)4U;
@@ -186,25 +192,28 @@ salsa20_encrypt(
     uint32_t k1[16U] = { 0U };
     salsa20_core(k1, ctx, i0);
     uint32_t bl[16U] = { 0U };
-    for (uint32_t i = (uint32_t)0U; i < (uint32_t)16U; i++)
-    {
+    KRML_MAYBE_FOR16(i,
+      (uint32_t)0U,
+      (uint32_t)16U,
+      (uint32_t)1U,
       uint32_t *os = bl;
       uint8_t *bj = uu____1 + i * (uint32_t)4U;
       uint32_t u = load32_le(bj);
       uint32_t r = u;
       uint32_t x = r;
-      os[i] = x;
-    }
-    for (uint32_t i = (uint32_t)0U; i < (uint32_t)16U; i++)
-    {
+      os[i] = x;);
+    KRML_MAYBE_FOR16(i,
+      (uint32_t)0U,
+      (uint32_t)16U,
+      (uint32_t)1U,
       uint32_t *os = bl;
       uint32_t x = bl[i] ^ k1[i];
-      os[i] = x;
-    }
-    for (uint32_t i = (uint32_t)0U; i < (uint32_t)16U; i++)
-    {
-      store32_le(uu____0 + i * (uint32_t)4U, bl[i]);
-    }
+      os[i] = x;);
+    KRML_MAYBE_FOR16(i,
+      (uint32_t)0U,
+      (uint32_t)16U,
+      (uint32_t)1U,
+      store32_le(uu____0 + i * (uint32_t)4U, bl[i]););
   }
   if (rem1 > (uint32_t)0U)
   {
@@ -215,25 +224,28 @@ salsa20_encrypt(
     uint32_t k1[16U] = { 0U };
     salsa20_core(k1, ctx, nb);
     uint32_t bl[16U] = { 0U };
-    for (uint32_t i = (uint32_t)0U; i < (uint32_t)16U; i++)
-    {
+    KRML_MAYBE_FOR16(i,
+      (uint32_t)0U,
+      (uint32_t)16U,
+      (uint32_t)1U,
       uint32_t *os = bl;
       uint8_t *bj = plain + i * (uint32_t)4U;
       uint32_t u = load32_le(bj);
       uint32_t r = u;
       uint32_t x = r;
-      os[i] = x;
-    }
-    for (uint32_t i = (uint32_t)0U; i < (uint32_t)16U; i++)
-    {
+      os[i] = x;);
+    KRML_MAYBE_FOR16(i,
+      (uint32_t)0U,
+      (uint32_t)16U,
+      (uint32_t)1U,
       uint32_t *os = bl;
       uint32_t x = bl[i] ^ k1[i];
-      os[i] = x;
-    }
-    for (uint32_t i = (uint32_t)0U; i < (uint32_t)16U; i++)
-    {
-      store32_le(plain + i * (uint32_t)4U, bl[i]);
-    }
+      os[i] = x;);
+    KRML_MAYBE_FOR16(i,
+      (uint32_t)0U,
+      (uint32_t)16U,
+      (uint32_t)1U,
+      store32_le(plain + i * (uint32_t)4U, bl[i]););
     memcpy(uu____2, plain, rem * sizeof (uint8_t));
   }
 }
@@ -251,24 +263,26 @@ salsa20_decrypt(
   uint32_t ctx[16U] = { 0U };
   uint32_t k32[8U] = { 0U };
   uint32_t n32[2U] = { 0U };
-  for (uint32_t i = (uint32_t)0U; i < (uint32_t)8U; i++)
-  {
+  KRML_MAYBE_FOR8(i,
+    (uint32_t)0U,
+    (uint32_t)8U,
+    (uint32_t)1U,
     uint32_t *os = k32;
     uint8_t *bj = key + i * (uint32_t)4U;
     uint32_t u = load32_le(bj);
     uint32_t r = u;
     uint32_t x = r;
-    os[i] = x;
-  }
-  for (uint32_t i = (uint32_t)0U; i < (uint32_t)2U; i++)
-  {
+    os[i] = x;);
+  KRML_MAYBE_FOR2(i,
+    (uint32_t)0U,
+    (uint32_t)2U,
+    (uint32_t)1U,
     uint32_t *os = n32;
     uint8_t *bj = n + i * (uint32_t)4U;
     uint32_t u = load32_le(bj);
     uint32_t r = u;
     uint32_t x = r;
-    os[i] = x;
-  }
+    os[i] = x;);
   ctx[0U] = (uint32_t)0x61707865U;
   uint32_t *k0 = k32;
   uint32_t *k10 = k32 + (uint32_t)4U;
@@ -291,25 +305,28 @@ salsa20_decrypt(
     uint32_t k1[16U] = { 0U };
     salsa20_core(k1, ctx, i0);
     uint32_t bl[16U] = { 0U };
-    for (uint32_t i = (uint32_t)0U; i < (uint32_t)16U; i++)
-    {
+    KRML_MAYBE_FOR16(i,
+      (uint32_t)0U,
+      (uint32_t)16U,
+      (uint32_t)1U,
       uint32_t *os = bl;
       uint8_t *bj = uu____1 + i * (uint32_t)4U;
       uint32_t u = load32_le(bj);
       uint32_t r = u;
       uint32_t x = r;
-      os[i] = x;
-    }
-    for (uint32_t i = (uint32_t)0U; i < (uint32_t)16U; i++)
-    {
+      os[i] = x;);
+    KRML_MAYBE_FOR16(i,
+      (uint32_t)0U,
+      (uint32_t)16U,
+      (uint32_t)1U,
       uint32_t *os = bl;
       uint32_t x = bl[i] ^ k1[i];
-      os[i] = x;
-    }
-    for (uint32_t i = (uint32_t)0U; i < (uint32_t)16U; i++)
-    {
-      store32_le(uu____0 + i * (uint32_t)4U, bl[i]);
-    }
+      os[i] = x;);
+    KRML_MAYBE_FOR16(i,
+      (uint32_t)0U,
+      (uint32_t)16U,
+      (uint32_t)1U,
+      store32_le(uu____0 + i * (uint32_t)4U, bl[i]););
   }
   if (rem1 > (uint32_t)0U)
   {
@@ -320,25 +337,28 @@ salsa20_decrypt(
     uint32_t k1[16U] = { 0U };
     salsa20_core(k1, ctx, nb);
     uint32_t bl[16U] = { 0U };
-    for (uint32_t i = (uint32_t)0U; i < (uint32_t)16U; i++)
-    {
+    KRML_MAYBE_FOR16(i,
+      (uint32_t)0U,
+      (uint32_t)16U,
+      (uint32_t)1U,
       uint32_t *os = bl;
       uint8_t *bj = plain + i * (uint32_t)4U;
       uint32_t u = load32_le(bj);
       uint32_t r = u;
       uint32_t x = r;
-      os[i] = x;
-    }
-    for (uint32_t i = (uint32_t)0U; i < (uint32_t)16U; i++)
-    {
+      os[i] = x;);
+    KRML_MAYBE_FOR16(i,
+      (uint32_t)0U,
+      (uint32_t)16U,
+      (uint32_t)1U,
       uint32_t *os = bl;
       uint32_t x = bl[i] ^ k1[i];
-      os[i] = x;
-    }
-    for (uint32_t i = (uint32_t)0U; i < (uint32_t)16U; i++)
-    {
-      store32_le(plain + i * (uint32_t)4U, bl[i]);
-    }
+      os[i] = x;);
+    KRML_MAYBE_FOR16(i,
+      (uint32_t)0U,
+      (uint32_t)16U,
+      (uint32_t)1U,
+      store32_le(plain + i * (uint32_t)4U, bl[i]););
     memcpy(uu____2, plain, rem * sizeof (uint8_t));
   }
 }
@@ -348,24 +368,26 @@ static inline void hsalsa20(uint8_t *out, uint8_t *key, uint8_t *n)
   uint32_t ctx[16U] = { 0U };
   uint32_t k32[8U] = { 0U };
   uint32_t n32[4U] = { 0U };
-  for (uint32_t i = (uint32_t)0U; i < (uint32_t)8U; i++)
-  {
+  KRML_MAYBE_FOR8(i,
+    (uint32_t)0U,
+    (uint32_t)8U,
+    (uint32_t)1U,
     uint32_t *os = k32;
     uint8_t *bj = key + i * (uint32_t)4U;
     uint32_t u = load32_le(bj);
     uint32_t r = u;
     uint32_t x = r;
-    os[i] = x;
-  }
-  for (uint32_t i = (uint32_t)0U; i < (uint32_t)4U; i++)
-  {
+    os[i] = x;);
+  KRML_MAYBE_FOR4(i,
+    (uint32_t)0U,
+    (uint32_t)4U,
+    (uint32_t)1U,
     uint32_t *os = n32;
     uint8_t *bj = n + i * (uint32_t)4U;
     uint32_t u = load32_le(bj);
     uint32_t r = u;
     uint32_t x = r;
-    os[i] = x;
-  }
+    os[i] = x;);
   uint32_t *k0 = k32;
   uint32_t *k1 = k32 + (uint32_t)4U;
   ctx[0U] = (uint32_t)0x61707865U;
@@ -385,10 +407,11 @@ static inline void hsalsa20(uint8_t *out, uint8_t *key, uint8_t *n)
   uint32_t r6 = ctx[8U];
   uint32_t r7 = ctx[9U];
   uint32_t res[8U] = { r0, r1, r2, r3, r4, r5, r6, r7 };
-  for (uint32_t i = (uint32_t)0U; i < (uint32_t)8U; i++)
-  {
-    store32_le(out + i * (uint32_t)4U, res[i]);
-  }
+  KRML_MAYBE_FOR8(i,
+    (uint32_t)0U,
+    (uint32_t)8U,
+    (uint32_t)1U,
+    store32_le(out + i * (uint32_t)4U, res[i]););
 }
 
 void

--- a/dist/gcc-compatible/INFO.txt
+++ b/dist/gcc-compatible/INFO.txt
@@ -1,4 +1,4 @@
 This code was generated with the following toolchain.
 F* version: c803362efccbc67f166138a12f90809f9e22f022
-KaRaMeL version: 4507656e7bc801ebe09e0c8a3cd04a2e8b4a7ef7
+KaRaMeL version: d7750574d07db9222d552b18d0c189794dd68c23
 Vale version: 0.3.19

--- a/dist/gcc-compatible/INFO.txt
+++ b/dist/gcc-compatible/INFO.txt
@@ -1,4 +1,4 @@
 This code was generated with the following toolchain.
 F* version: c803362efccbc67f166138a12f90809f9e22f022
-KaRaMeL version: d7750574d07db9222d552b18d0c189794dd68c23
+KaRaMeL version: 011a3ee203ac8dcec2d75aa90987d8524d242c82
 Vale version: 0.3.19

--- a/dist/karamel/include/krml/internal/target.h
+++ b/dist/karamel/include/krml/internal/target.h
@@ -110,4 +110,188 @@ inline static int32_t krml_time() {
 #  define KRML_DEPRECATED(x) __declspec(deprecated(x))
 #endif
 
+/* Macros for prettier unrolling of loops */
+#define KRML_LOOP1(i, n, x) { \
+  x \
+  i += n; \
+}
+
+#define KRML_LOOP2(i, n, x) \
+  KRML_LOOP1(i, n, x) \
+  KRML_LOOP1(i, n, x)
+
+#define KRML_LOOP3(i, n, x) \
+  KRML_LOOP2(i, n, x) \
+  KRML_LOOP1(i, n, x)
+
+#define KRML_LOOP4(i, n, x) \
+  KRML_LOOP2(i, n, x) \
+  KRML_LOOP2(i, n, x)
+
+#define KRML_LOOP5(i, n, x) \
+  KRML_LOOP4(i, n, x) \
+  KRML_LOOP1(i, n, x)
+
+#define KRML_LOOP6(i, n, x) \
+  KRML_LOOP4(i, n, x) \
+  KRML_LOOP2(i, n, x)
+
+#define KRML_LOOP7(i, n, x) \
+  KRML_LOOP4(i, n, x) \
+  KRML_LOOP3(i, n, x)
+
+#define KRML_LOOP8(i, n, x) \
+  KRML_LOOP4(i, n, x) \
+  KRML_LOOP4(i, n, x)
+
+#define KRML_LOOP9(i, n, x) \
+  KRML_LOOP8(i, n, x) \
+  KRML_LOOP1(i, n, x)
+
+#define KRML_LOOP10(i, n, x) \
+  KRML_LOOP8(i, n, x) \
+  KRML_LOOP2(i, n, x)
+
+#define KRML_LOOP11(i, n, x) \
+  KRML_LOOP8(i, n, x) \
+  KRML_LOOP3(i, n, x)
+
+#define KRML_LOOP12(i, n, x) \
+  KRML_LOOP8(i, n, x) \
+  KRML_LOOP4(i, n, x)
+
+#define KRML_LOOP13(i, n, x) \
+  KRML_LOOP8(i, n, x) \
+  KRML_LOOP5(i, n, x)
+
+#define KRML_LOOP14(i, n, x) \
+  KRML_LOOP8(i, n, x) \
+  KRML_LOOP6(i, n, x)
+
+#define KRML_LOOP15(i, n, x) \
+  KRML_LOOP8(i, n, x) \
+  KRML_LOOP7(i, n, x)
+
+#define KRML_LOOP16(i, n, x) \
+  KRML_LOOP8(i, n, x) \
+  KRML_LOOP8(i, n, x)
+
+#define KRML_UNROLL_FOR(i, z, n, k, x) do { \
+  uint32_t i = z; \
+  KRML_LOOP##n(i, k, x) \
+} while (0)
+
+#define KRML_ACTUAL_FOR(i, z, n, k, x) \
+  do { \
+    for (uint32_t i = z; i < n; i += k) { \
+      x \
+    } \
+  while (0);
+
+#ifndef KRML_UNROLL_MAX
+#define KRML_UNROLL_MAX 16
+#endif
+
+/* 1 is the number of loop iterations, i.e. (n - z)/k as evaluated by krml */
+#if 0 <= KRML_UNROLL_MAX
+#define KRML_MAYBE_FOR0(i, z, n, k, x)
+#else
+#define KRML_MAYBE_FOR0(i, z, n, k, x) KRML_ACTUAL_FOR(i, z, n, k, x)
+#endif
+
+#if 1 <= KRML_UNROLL_MAX
+#define KRML_MAYBE_FOR1(i, z, n, k, x) KRML_UNROLL_FOR(i, z, 1, k, x)
+#else
+#define KRML_MAYBE_FOR1(i, z, n, k, x) KRML_ACTUAL_FOR(i, z, n, k, x)
+#endif
+
+#if 2 <= KRML_UNROLL_MAX
+#define KRML_MAYBE_FOR2(i, z, n, k, x) KRML_UNROLL_FOR(i, z, 2, k, x)
+#else
+#define KRML_MAYBE_FOR2(i, z, n, k, x) KRML_ACTUAL_FOR(i, z, n, k, x)
+#endif
+
+#if 3 <= KRML_UNROLL_MAX
+#define KRML_MAYBE_FOR3(i, z, n, k, x) KRML_UNROLL_FOR(i, z, 3, k, x)
+#else
+#define KRML_MAYBE_FOR3(i, z, n, k, x) KRML_ACTUAL_FOR(i, z, n, k, x)
+#endif
+
+#if 4 <= KRML_UNROLL_MAX
+#define KRML_MAYBE_FOR4(i, z, n, k, x) KRML_UNROLL_FOR(i, z, 4, k, x)
+#else
+#define KRML_MAYBE_FOR4(i, z, n, k, x) KRML_ACTUAL_FOR(i, z, n, k, x)
+#endif
+
+#if 5 <= KRML_UNROLL_MAX
+#define KRML_MAYBE_FOR5(i, z, n, k, x) KRML_UNROLL_FOR(i, z, 5, k, x)
+#else
+#define KRML_MAYBE_FOR5(i, z, n, k, x) KRML_ACTUAL_FOR(i, z, n, k, x)
+#endif
+
+#if 6 <= KRML_UNROLL_MAX
+#define KRML_MAYBE_FOR6(i, z, n, k, x) KRML_UNROLL_FOR(i, z, 6, k, x)
+#else
+#define KRML_MAYBE_FOR6(i, z, n, k, x) KRML_ACTUAL_FOR(i, z, n, k, x)
+#endif
+
+#if 7 <= KRML_UNROLL_MAX
+#define KRML_MAYBE_FOR7(i, z, n, k, x) KRML_UNROLL_FOR(i, z, 7, k, x)
+#else
+#define KRML_MAYBE_FOR7(i, z, n, k, x) KRML_ACTUAL_FOR(i, z, n, k, x)
+#endif
+
+#if 8 <= KRML_UNROLL_MAX
+#define KRML_MAYBE_FOR8(i, z, n, k, x) KRML_UNROLL_FOR(i, z, 8, k, x)
+#else
+#define KRML_MAYBE_FOR8(i, z, n, k, x) KRML_ACTUAL_FOR(i, z, n, k, x)
+#endif
+
+#if 9 <= KRML_UNROLL_MAX
+#define KRML_MAYBE_FOR9(i, z, n, k, x) KRML_UNROLL_FOR(i, z, 9, k, x)
+#else
+#define KRML_MAYBE_FOR9(i, z, n, k, x) KRML_ACTUAL_FOR(i, z, n, k, x)
+#endif
+
+#if 10 <= KRML_UNROLL_MAX
+#define KRML_MAYBE_FOR10(i, z, n, k, x) KRML_UNROLL_FOR(i, z, 10, k, x)
+#else
+#define KRML_MAYBE_FOR10(i, z, n, k, x) KRML_ACTUAL_FOR(i, z, n, k, x)
+#endif
+
+#if 11 <= KRML_UNROLL_MAX
+#define KRML_MAYBE_FOR11(i, z, n, k, x) KRML_UNROLL_FOR(i, z, 11, k, x)
+#else
+#define KRML_MAYBE_FOR11(i, z, n, k, x) KRML_ACTUAL_FOR(i, z, n, k, x)
+#endif
+
+#if 12 <= KRML_UNROLL_MAX
+#define KRML_MAYBE_FOR12(i, z, n, k, x) KRML_UNROLL_FOR(i, z, 12, k, x)
+#else
+#define KRML_MAYBE_FOR12(i, z, n, k, x) KRML_ACTUAL_FOR(i, z, n, k, x)
+#endif
+
+#if 13 <= KRML_UNROLL_MAX
+#define KRML_MAYBE_FOR13(i, z, n, k, x) KRML_UNROLL_FOR(i, z, 13, k, x)
+#else
+#define KRML_MAYBE_FOR13(i, z, n, k, x) KRML_ACTUAL_FOR(i, z, n, k, x)
+#endif
+
+#if 14 <= KRML_UNROLL_MAX
+#define KRML_MAYBE_FOR14(i, z, n, k, x) KRML_UNROLL_FOR(i, z, 14, k, x)
+#else
+#define KRML_MAYBE_FOR14(i, z, n, k, x) KRML_ACTUAL_FOR(i, z, n, k, x)
+#endif
+
+#if 15 <= KRML_UNROLL_MAX
+#define KRML_MAYBE_FOR15(i, z, n, k, x) KRML_UNROLL_FOR(i, z, 15, k, x)
+#else
+#define KRML_MAYBE_FOR15(i, z, n, k, x) KRML_ACTUAL_FOR(i, z, n, k, x)
+#endif
+
+#if 16 <= KRML_UNROLL_MAX
+#define KRML_MAYBE_FOR16(i, z, n, k, x) KRML_UNROLL_FOR(i, z, 16, k, x)
+#else
+#define KRML_MAYBE_FOR16(i, z, n, k, x) KRML_ACTUAL_FOR(i, z, n, k, x)
+#endif
 #endif


### PR DESCRIPTION
Right now, krml has an option `-funroll-loops` that replaces for-loops whose bounds are statically known by a series of C blocks for each possible value of the index.

Following many discussions, it turns out that this isn't great:
- generated C code is ugly
- prevents different degrees of unrolling depending on target
- unrolling loops in F* isn't great either because this is not always the right thing to do.

This PR demonstrates the effect of https://github.com/FStarLang/karamel/pull/280, a krml change that relies on macros to perform loop unrolling.

Basically, if krml is passed the option `-funroll-loops N`, and encounters a for loop of the form `for (int i = Z; i < M; i += K)` where Z, M and K are constants, and where `(M - Z + K - 1)/K <= N` (i.e. `ceil((M-Z)/K) <= N`), then instead of generating a for-loop, krml generates `KRML_MAYBE_FORT` where `T` is the number of iterations computed using the formula above.

Then, at compile-time, the user can pass `-DKRML_UNROLL_MAX=N'` where `N' <= N` -- any loops shorter than `N'` will be macro-expanded, and other loops will macro-expand to an actual for-loop.

Note that the argument to `-funroll-loops` is perhaps something we can dispense with; I was just thinking that it made no sense to generate `KRML_MAYBE_FOR256` when we very well know that we're not going to macro-expand such a big loop. But we could also hardcode 16 as the limit.

Also note that owing to limitations of the C preprocessor, I had to hardcode an upper limit to the number of possible unrolling levels. This is essentially due to the fact that a macro's expansion cannot contain `#if`.