### PR TITLE
Fix AltiVec bool keyword conflict on PowerPC (GCC)

### DIFF
--- a/lib/c/libintvector.h
+++ b/lib/c/libintvector.h
@@ -802,6 +802,18 @@ vector128 Lib_IntVector_Intrinsics_vec128_xor(vector128 x0, vector128 x1) {
 #if defined(HACL_CAN_COMPILE_VEC128)
 
 #include <altivec.h>
+
+/* GCC's AltiVec extension hijacks 'bool' as '__vector __bool int'.
+   Restore C99/C11 scalar bool for HACL* code. */
+#if defined(__GNUC__) && !defined(__clang__)
+#undef bool
+#define bool _Bool
+#undef true
+#define true 1
+#undef false
+#define false 0
+#endif
+
 #include <string.h> // for memcpy
 #include <stdint.h>
 


### PR DESCRIPTION
Fixes #1067

GCC's AltiVec extension redefines `bool` as `__vector __bool int` when `altivec.h` is included. This breaks all scalar `bool` usage in HACL* SIMD128 code on PowerPC.

The fix adds a bool restoration shim in `libintvector.h`'s PowerPC section, right after the `altivec.h` include. Only active on GCC + PowerPC.

As discussed in #1067 with @protz — only `lib/c/` is modified. The `dist/` refresh will be handled by the maintainer.

Tested on bare-metal IBM POWER8 S824 (ppc64le, GCC 10.5).