### PR TITLE
.ci/script.sh: set krml env vars before trying to build dist

### DIFF
--- a/.ci/script.sh
+++ b/.ci/script.sh
@@ -59,7 +59,8 @@ make -C tests -j test
 # intrinsics for x86 in cpu cycle count routines in testlib.c
 pushd dist/test/c/
 git clone https://github.com/fstarlang/karamel --depth 10
-export KRML_HOME=$(pwd)/karamel
+export KRML_LIBDIR=$(pwd)/karamel/krmllib
+export KRML_INCLUDEDIR=$(pwd)/karamel/include
 make -C karamel/krmllib/dist/generic -f Makefile.basic -j
 make -j -k
 popd

--- a/dist/test/c/Makefile
+++ b/dist/test/c/Makefile
@@ -10,7 +10,7 @@ CFLAGS += -I../../karamel/krmllib/dist/minimal
 
 all: $(patsubst %.c,%.test,$(SOURCES))
 
-%.exe: %.o ../../gcc-compatible/libevercrypt.a $(KRML_HOME)/krmllib/dist/generic/libkrmllib.a
+%.exe: %.o ../../gcc-compatible/libevercrypt.a $(KRML_LIBDIR)/dist/generic/libkrmllib.a
 	$(CC) $^ -o $@
 
 .PHONY: .test


### PR DESCRIPTION
## Proposed changes

To build karamel dist one now needs to pass a different set of environment variables. Dist CI succeeded here: https://github.com/mtzguido/hacl-star/actions/runs/24195813098.

The Makefile should also probably be updated to not require KRML_HOME. I've started on that, but somehow F* is crashing on me even when I use an older "fstar1" version.

## Types of changes

What types of changes does your code introduce to HACL*?
_Put an `x` in the boxes that apply_

- [x] Build/CI
- [ ] Proof maintenance (non-breaking change which fixes a proof regression)
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New algorithm or feature (non-breaking change which adds functionality)
- [ ] Improved performance (fix or feature that would improve performance of some algorithm on some platform)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CODE_OF_CONDUCT.md](https://github.com/hacl-star/hacl-star/blob/main/CODE_OF_CONDUCT.md) doc
- [x] I have read and agree to submit my changes under the [LICENSE](https://github.com/hacl-star/hacl-star/blob/main/LICENSE)
- [ ] I have added necessary documentation (if appropriate)
- [ ] I have edited [CHANGES.md](https://github.com/hacl-star/hacl-star/blob/main/CHANGES.md) (if appropriate)